### PR TITLE
go build -i is deprecated

### DIFF
--- a/igt/Makefile
+++ b/igt/Makefile
@@ -82,7 +82,7 @@ build: $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME) config
 .PHONY: $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME)
 $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME):
 	$(info   >  Buiding application binary: $(OUT_DIR)/$(PROJECT_NAME)$(EXT_NAME))
-	@CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -i -o $(OUT_DIR)/server/$(PROJECT_NAME)$(EXT_NAME) $(SOURCES)
+	@CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -o $(OUT_DIR)/server/$(PROJECT_NAME)$(EXT_NAME) $(SOURCES)
 
 
 ## config: Setup config files
@@ -141,7 +141,7 @@ run: buildPixiu
 ## buildPixiu: start pixiu
 .PHONY: buildPixiu
 buildPixiu:
-	@CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -i -o $(OUT_DIR)/dubbo-go-pixiu$(EXT_NAME) $(pixiuSources)
+	@CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -o $(OUT_DIR)/dubbo-go-pixiu$(EXT_NAME) $(pixiuSources)
 	@-$(OUT_DIR)/dubbo-go-pixiu$(EXT_NAME) gateway start -a $(API_CONFIG_PATH) -c $(CONFIG_PATH) & echo $$! > $(PIXIU_PID)
 	@cat $(PIXIU_PID) | sed "/^/s/^/  \> PIXIU_PID: /"
 
@@ -149,7 +149,7 @@ buildPixiu:
 ## startPixiu: start pixiu foreground
 .PHONY: startPixiu
 startPixiu:
-	@CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -i -o $(OUT_DIR)/dubbo-go-pixiu$(EXT_NAME) $(pixiuSources)
+	@CGO_ENABLED=$(CGO) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -o $(OUT_DIR)/dubbo-go-pixiu$(EXT_NAME) $(pixiuSources)
 	@-$(OUT_DIR)/dubbo-go-pixiu$(EXT_NAME) gateway start -a $(API_CONFIG_PATH) -c $(CONFIG_PATH)
 
 ## stop: Stop running the application (for server)


### PR DESCRIPTION
https://github.com/golang/go/issues/37962

<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
remove -i flag from go build in igt/Makefile
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
error when running samples: go build: -i flag is deprecated
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```