### PR TITLE
All adaptors initialized at initAdapters(), so call it once is enough.

### DIFF
--- a/pkg/server/adapter_manager.go
+++ b/pkg/server/adapter_manager.go
@@ -31,10 +31,7 @@ type AdapterManager struct {
 
 func CreateDefaultAdapterManager(server *Server, bs *model.Bootstrap) *AdapterManager {
 	am := &AdapterManager{configs: bs.StaticResources.Adapters}
-	sr := bs.StaticResources
-	for _, ad := range sr.Adapters {
-		am.initAdapters(server, ad)
-	}
+	am.initAdapters()
 	return am
 }
 
@@ -50,7 +47,7 @@ func (am *AdapterManager) Stop() {
 	}
 }
 
-func (am *AdapterManager) initAdapters(server *Server, ad *model.Adapter) {
+func (am *AdapterManager) initAdapters() {
 
 	var ads []adapter.Adapter
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Optimize processing of CreateDefaultAdapterManager. remove unnecessary loop init.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```