### PR TITLE
feat - auto resolve metadata from request

### DIFF
--- a/cmd/pixiu/gateway.go
+++ b/cmd/pixiu/gateway.go
@@ -47,7 +47,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			err := initLog()
 			if err != nil {
-				logger.Warnf("[startGatewayCmd] failed to init logger, %s", err.Error())
+				logger.Infof("[startGatewayCmd] failed to init logger, %s", err.Error())
 			}
 
 			bootstrap, meta, err := initApiConfig()

--- a/configs/conf.yaml
+++ b/configs/conf.yaml
@@ -20,40 +20,35 @@
 static_resources:
   listeners:
     - name: "net/http"
+      protocol_type: "HTTP"
       address:
         socket_address:
-          protocol_type: "HTTP"
           address: "0.0.0.0"
           port: 8888
       filter_chains:
-        - filter_chain_match:
-          domains:
-            - api.dubbo.com
-            - api.pixiu.com
-          filters:
-            - name: dgp.filter.httpconnectionmanager
-              config:
-                route_config:
-                  routes:
-                    - match:
-                        prefix: "/user"
-                      route:
-                        cluster: "user"
-                        cluster_not_found_response_code: 505
-                http_filters:
-                  - name: dgp.filter.http.httpproxy
-                    config:
-                  - name: dgp.filter.http.cors
-                    config:
-                      allow_origin:
-                        - api.dubbo.com
-                      allow_methods: ""
-                      allow_headers: ""
-                      expose_headers: ""
-                      max_age: ""
-                      allow_credentials: false
-                  - name: dgp.filter.http.response
-                    config:
+        filters:
+          - name: dgp.filter.httpconnectionmanager
+            config:
+              route_config:
+                routes:
+                  - match:
+                      prefix: "/user"
+                    route:
+                      cluster: "user"
+                      cluster_not_found_response_code: 505
+              http_filters:
+                - name: dgp.filter.http.httpproxy
+                  config:
+                - name: dgp.filter.http.cors
+                  config:
+                    allow_origin:
+                      - api.dubbo.com
+                    allow_methods: ""
+                    allow_headers: ""
+                    expose_headers: ""
+                    max_age: ""
+                    allow_credentials: false
+
       config:
         idle_timeout: 5s
         read_timeout: 5s

--- a/pkg/client/dubbo/config.go
+++ b/pkg/client/dubbo/config.go
@@ -29,4 +29,6 @@ type DubboProxyConfig struct {
 	Timeout *model.TimeoutConfig `yaml:"timeout_config" json:"timeout_config"`
 	// IsDefaultMap whether to use DefaultMap role
 	IsDefaultMap bool
+	// AutoResolve whether to resolve api config from request
+	AutoResolve bool `yaml:"auto_resolve" json:"auto_resolve,omitempty"`
 }

--- a/pkg/filter/http/remote/call.go
+++ b/pkg/filter/http/remote/call.go
@@ -39,6 +39,7 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
 	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
+	"github.com/dubbogo/dubbo-go-pixiu-filter/pkg/router"
 )
 
 const (
@@ -49,6 +50,13 @@ const (
 
 const (
 	Kind = constant.HTTPDubboProxyFilter
+)
+
+const (
+	x_dubbo_http_dubbo_version = "x-dubbo-http1.1-dubbo-version"
+	x_dubbo_service_protocol   = "x-dubbo-service-protocol"
+	x_dubbo_service_version    = "x-dubbo-service-version"
+	x_dubbo_group              = "x-dubbo-service-group"
 )
 
 func init() {
@@ -114,6 +122,14 @@ func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, c
 }
 
 func (f *Filter) Decode(c *contexthttp.HttpContext) filter.FilterStatus {
+
+	if f.conf.Dpc.AutoResolve {
+		if err := f.resolve(c); err != nil {
+			c.SendLocalReply(http.StatusInternalServerError, []byte(fmt.Sprintf("auto resolve err: %s", err)))
+			return filter.Stop
+		}
+	}
+
 	api := c.GetAPI()
 
 	if (f.conf.Level == open && api.Mock) || (f.conf.Level == all) {
@@ -156,4 +172,88 @@ func matchClient(typ apiConf.RequestType) (client.Client, error) {
 	default:
 		return nil, errors.New("not support")
 	}
+}
+
+func NewDefaultAPI() router.API {
+	api := router.API{}
+	return api
+}
+
+func NewDefaultMethod() apiConf.Method {
+	method := apiConf.Method{}
+	method.Enable = true
+	method.Mock = false
+	method.HTTPVerb = http.MethodPost
+	return method
+}
+
+func (f *Filter) resolve(ctx *contexthttp.HttpContext) error {
+	// method must be post
+	req := ctx.Request
+	if req.Method != http.MethodPost {
+		return errors.New("http request method must be post when trying to auto resolve")
+	}
+	// header must has x-dubbo-http1.1-dubbo-version to declare using auto resolve rule
+	version := req.Header.Get(x_dubbo_http_dubbo_version)
+	if version == "" {
+		return errors.New("http request must has x-dubbo-http1.1-dubbo-version header when trying to auto resolve")
+	}
+
+	// http://host/{application}/{service}/{method} or https://host/{application}/{service}/{method}
+	rawPath := req.URL.Path
+	rawPath = strings.Trim(rawPath, "/")
+	splits := strings.Split(rawPath, "/")
+	if len(splits) != 3 {
+		return errors.New("http request path must meet {application}/{service}/{method} format when trying to auto resolve")
+	}
+
+	integrationRequest := apiConf.IntegrationRequest{}
+	resolve_protocol := req.Header.Get(x_dubbo_service_protocol)
+	if resolve_protocol == string(apiConf.HTTPRequest) {
+		integrationRequest.RequestType = apiConf.HTTPRequest
+	} else if resolve_protocol == string(apiConf.DubboRequest) {
+		integrationRequest.RequestType = apiConf.DubboRequest
+	} else if resolve_protocol == "triple" {
+		integrationRequest.RequestType = "triple"
+	} else {
+		return errors.New("http request has unknown protocol in x-dubbo-protocol when trying to auto resolve")
+	}
+
+	dubboBackendConfig := apiConf.DubboBackendConfig{}
+	dubboBackendConfig.Version = req.Header.Get(x_dubbo_service_version)
+	dubboBackendConfig.Group = req.Header.Get(x_dubbo_group)
+	integrationRequest.DubboBackendConfig = dubboBackendConfig
+
+	defaultMappingParams := []apiConf.MappingParam{
+		{
+			Name:  "requestBody.values",
+			MapTo: "opt.values",
+		}, {
+			Name:  "requestBody.types",
+			MapTo: "opt.types",
+		}, {
+			Name:  "uri.application",
+			MapTo: "opt.application",
+		}, {
+			Name:  "uri.interface",
+			MapTo: "opt.interface",
+		}, {
+			Name:  "uri.method",
+			MapTo: "opt.method",
+		},
+	}
+	integrationRequest.MappingParams = defaultMappingParams
+
+	method := NewDefaultMethod()
+	method.IntegrationRequest = integrationRequest
+
+	inboundRequest := apiConf.InboundRequest{}
+	inboundRequest.RequestType = apiConf.HTTPRequest
+	method.InboundRequest = inboundRequest
+
+	api := NewDefaultAPI()
+	api.URLPattern = "/:application/:interface/:method"
+	api.Method = method
+	ctx.API(api)
+	return nil
 }

--- a/pkg/filter/http/remote/call.go
+++ b/pkg/filter/http/remote/call.go
@@ -174,19 +174,6 @@ func matchClient(typ apiConf.RequestType) (client.Client, error) {
 	}
 }
 
-func NewDefaultAPI() router.API {
-	api := router.API{}
-	return api
-}
-
-func NewDefaultMethod() apiConf.Method {
-	method := apiConf.Method{}
-	method.Enable = true
-	method.Mock = false
-	method.HTTPVerb = http.MethodPost
-	return method
-}
-
 func (f *Filter) resolve(ctx *contexthttp.HttpContext) error {
 	// method must be post
 	req := ctx.Request
@@ -208,15 +195,15 @@ func (f *Filter) resolve(ctx *contexthttp.HttpContext) error {
 	}
 
 	integrationRequest := apiConf.IntegrationRequest{}
-	resolve_protocol := req.Header.Get(x_dubbo_service_protocol)
-	if resolve_protocol == string(apiConf.HTTPRequest) {
+	resolveProtocol := req.Header.Get(x_dubbo_service_protocol)
+	if resolveProtocol == string(apiConf.HTTPRequest) {
 		integrationRequest.RequestType = apiConf.HTTPRequest
-	} else if resolve_protocol == string(apiConf.DubboRequest) {
+	} else if resolveProtocol == string(apiConf.DubboRequest) {
 		integrationRequest.RequestType = apiConf.DubboRequest
-	} else if resolve_protocol == "triple" {
+	} else if resolveProtocol == "triple" {
 		integrationRequest.RequestType = "triple"
 	} else {
-		return errors.New("http request has unknown protocol in x-dubbo-protocol when trying to auto resolve")
+		return errors.New("http request has unknown protocol in x-dubbo-service-protocol when trying to auto resolve")
 	}
 
 	dubboBackendConfig := apiConf.DubboBackendConfig{}
@@ -244,16 +231,24 @@ func (f *Filter) resolve(ctx *contexthttp.HttpContext) error {
 	}
 	integrationRequest.MappingParams = defaultMappingParams
 
-	method := NewDefaultMethod()
+	method := newDefaultMethod()
 	method.IntegrationRequest = integrationRequest
 
 	inboundRequest := apiConf.InboundRequest{}
 	inboundRequest.RequestType = apiConf.HTTPRequest
 	method.InboundRequest = inboundRequest
 
-	api := NewDefaultAPI()
+	api := router.API{}
 	api.URLPattern = "/:application/:interface/:method"
 	api.Method = method
 	ctx.API(api)
 	return nil
+}
+
+func newDefaultMethod() apiConf.Method {
+	method := apiConf.Method{}
+	method.Enable = true
+	method.Mock = false
+	method.HTTPVerb = http.MethodPost
+	return method
 }

--- a/pkg/filter/http/remote/call.go
+++ b/pkg/filter/http/remote/call.go
@@ -28,6 +28,7 @@ import (
 
 import (
 	apiConf "github.com/dubbogo/dubbo-go-pixiu-filter/pkg/api/config"
+	"github.com/dubbogo/dubbo-go-pixiu-filter/pkg/router"
 )
 
 import (
@@ -39,7 +40,6 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
 	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
-	"github.com/dubbogo/dubbo-go-pixiu-filter/pkg/router"
 )
 
 const (

--- a/pkg/filter/http/remote/call.go
+++ b/pkg/filter/http/remote/call.go
@@ -231,7 +231,11 @@ func (f *Filter) resolve(ctx *contexthttp.HttpContext) error {
 	}
 	integrationRequest.MappingParams = defaultMappingParams
 
-	method := newDefaultMethod()
+	method := apiConf.Method{
+		Enable:   true,
+		Mock:     false,
+		HTTPVerb: http.MethodPost,
+	}
 	method.IntegrationRequest = integrationRequest
 
 	inboundRequest := apiConf.InboundRequest{}
@@ -243,12 +247,4 @@ func (f *Filter) resolve(ctx *contexthttp.HttpContext) error {
 	api.Method = method
 	ctx.API(api)
 	return nil
-}
-
-func newDefaultMethod() apiConf.Method {
-	method := apiConf.Method{}
-	method.Enable = true
-	method.Mock = false
-	method.HTTPVerb = http.MethodPost
-	return method
 }

--- a/samples/dubbogo/simple/resolve/docker/docker-compose.yml
+++ b/samples/dubbogo/simple/resolve/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version: '3'
+
+services:
+  zookeeper:
+    image: zookeeper
+    ports:
+      - 2181:2181
+    restart: on-failure

--- a/samples/dubbogo/simple/resolve/pixiu/conf.yaml
+++ b/samples/dubbogo/simple/resolve/pixiu/conf.yaml
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+static_resources:
+  listeners:
+    - name: "net/http"
+      protocol_type: "HTTP"
+      address:
+        socket_address:
+          address: "0.0.0.0"
+          port: 8883
+      filter_chains:
+          filters:
+            - name: dgp.filter.httpconnectionmanager
+              config:
+                route_config:
+                  routes:
+                    - match:
+                        prefix: "*"
+                http_filters:
+                  - name: dgp.filter.http.dubboproxy
+                    config:
+                      dubboProxyConfig:
+                        auto_resolve: true
+                        registries:
+                          "zookeeper":
+                            protocol: "zookeeper"
+                            timeout: "3s"
+                            address: "127.0.0.1:2181"
+                            username: ""
+                            password: ""
+                        timeout_config:
+                          connect_timeout: 5s
+                          request_timeout: 5s
+
+                server_name: "test_http_dubbo"
+                generate_request_id: false
+      config:
+        idle_timeout: 5s
+        read_timeout: 5s
+        write_timeout: 5s
+  shutdown_config:
+    timeout: "60s"
+    step_timeout: "10s"
+    reject_policy: "immediacy"

--- a/samples/dubbogo/simple/resolve/server/app/server.go
+++ b/samples/dubbogo/simple/resolve/server/app/server.go
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/logger"
+	"dubbo.apache.org/dubbo-go/v3/config"
+	_ "dubbo.apache.org/dubbo-go/v3/imports"
+)
+
+// Version dubbo version
+const Version = "2.7.5"
+
+var survivalTimeout = int(3e9)
+
+// they are necessary:
+// 		export CONF_PROVIDER_FILE_PATH="xxx"
+// 		export APP_LOG_CONF_FILE="xxx"
+func main() {
+	config.Load()
+	logger.Info("dubbo version is: %s", Version)
+	initSignal()
+}
+
+func initSignal() {
+	signals := make(chan os.Signal, 1)
+	// It is not possible to block SIGKILL or syscall.SIGSTOP
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	for {
+		sig := <-signals
+		logger.Infof("get signal %s", sig.String())
+		switch sig {
+		case syscall.SIGHUP:
+			// reload()
+		default:
+			time.AfterFunc(time.Duration(survivalTimeout), func() {
+				logger.Warnf("app exit now by force...")
+				os.Exit(1)
+			})
+
+			// The program exits normally or timeout forcibly exits.
+			fmt.Println("provider app exit now...")
+			return
+		}
+	}
+}

--- a/samples/dubbogo/simple/resolve/server/app/user.go
+++ b/samples/dubbogo/simple/resolve/server/app/user.go
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/config"
+	hessian "github.com/apache/dubbo-go-hessian2"
+)
+
+func init() {
+	config.SetProviderService(new(UserProvider))
+	// ------for hessian2------
+	hessian.RegisterPOJO(&User{})
+
+	cache = newUserDB()
+
+	t1, _ := time.Parse(
+		time.RFC3339,
+		"2021-08-01T10:08:41+00:00")
+
+	cache.Add(&User{ID: "0001", Code: 1, Name: "tc", Age: 18, Time: t1})
+	cache.Add(&User{ID: "0002", Code: 2, Name: "ic", Age: 88, Time: t1})
+}
+
+var cache *userDB
+
+// userDB cache user.
+type userDB struct {
+	// key is name, value is user obj
+	nameIndex map[string]*User
+	// key is code, value is user obj
+	codeIndex map[int64]*User
+	lock      sync.Mutex
+}
+
+// userDB create func
+func newUserDB() *userDB {
+	return &userDB{
+		nameIndex: make(map[string]*User, 16),
+		codeIndex: make(map[int64]*User, 16),
+		lock:      sync.Mutex{},
+	}
+}
+
+// nolint
+func (db *userDB) Add(u *User) bool {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if u.Name == "" || u.Code <= 0 {
+		return false
+	}
+
+	if !db.existName(u.Name) && !db.existCode(u.Code) {
+		return db.AddForName(u) && db.AddForCode(u)
+	}
+
+	return false
+}
+
+// nolint
+func (db *userDB) AddForName(u *User) bool {
+	if len(u.Name) == 0 {
+		return false
+	}
+
+	if _, ok := db.nameIndex[u.Name]; ok {
+		return false
+	}
+
+	db.nameIndex[u.Name] = u
+	return true
+}
+
+// nolint
+func (db *userDB) AddForCode(u *User) bool {
+	if u.Code <= 0 {
+		return false
+	}
+
+	if _, ok := db.codeIndex[u.Code]; ok {
+		return false
+	}
+
+	db.codeIndex[u.Code] = u
+	return true
+}
+
+// nolint
+func (db *userDB) GetByName(n string) (*User, bool) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	r, ok := db.nameIndex[n]
+	return r, ok
+}
+
+// nolint
+func (db *userDB) GetByCode(n int64) (*User, bool) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	r, ok := db.codeIndex[n]
+	return r, ok
+}
+
+func (db *userDB) existName(name string) bool {
+	if len(name) <= 0 {
+		return false
+	}
+
+	_, ok := db.nameIndex[name]
+	if ok {
+		return true
+	}
+
+	return false
+}
+
+func (db *userDB) existCode(code int64) bool {
+	if code <= 0 {
+		return false
+	}
+
+	_, ok := db.codeIndex[code]
+	if ok {
+		return true
+	}
+
+	return false
+}
+
+// User user obj.
+type User struct {
+	ID   string    `json:"id,omitempty"`
+	Code int64     `json:"code,omitempty"`
+	Name string    `json:"name,omitempty"`
+	Age  int32     `json:"age,omitempty"`
+	Time time.Time `json:"time,omitempty"`
+}
+
+// UserProvider the dubbo provider.
+// like: version: 1.0.0 group: test
+type UserProvider struct{}
+
+// CreateUser new user, PX config POST.
+func (u *UserProvider) CreateUser(ctx context.Context, user *User) (*User, error) {
+	outLn("Req CreateUser data:%#v", user)
+	if user == nil {
+		return nil, errors.New("not found")
+	}
+	_, ok := cache.GetByName(user.Name)
+	if ok {
+		return nil, errors.New("data is exist")
+	}
+
+	b := cache.Add(user)
+	if b {
+		return user, nil
+	}
+
+	return nil, errors.New("add error")
+}
+
+// GetUserByName query by name, single param, PX config GET.
+func (u *UserProvider) GetUserByName(ctx context.Context, name string) (*User, error) {
+	outLn("Req GetUserByName name:%#v", name)
+	r, ok := cache.GetByName(name)
+	if ok {
+		outLn("Req GetUserByName result:%#v", r)
+		return r, nil
+	}
+	return nil, nil
+}
+
+// GetUserByCode query by code, single param, PX config GET.
+func (u *UserProvider) GetUserByCode(ctx context.Context, code int64) (*User, error) {
+	outLn("Req GetUserByCode name:%#v", code)
+	r, ok := cache.GetByCode(code)
+	if ok {
+		outLn("Req GetUserByCode result:%#v", r)
+		return r, nil
+	}
+	return nil, nil
+}
+
+// GetUserTimeout query by name, will timeout for pixiu.
+func (u *UserProvider) GetUserTimeout(ctx context.Context, name string) (*User, error) {
+	outLn("Req GetUserByName name:%#v", name)
+	// sleep 10s, pixiu config less than 10s.
+	time.Sleep(10 * time.Second)
+	r, ok := cache.GetByName(name)
+	if ok {
+		outLn("Req GetUserByName result:%#v", r)
+		return r, nil
+	}
+	return nil, nil
+}
+
+// GetUserByNameAndAge query by name and age, two params, PX config GET.
+func (u *UserProvider) GetUserByNameAndAge(ctx context.Context, name string, age int32) (*User, error) {
+	outLn("Req GetUserByNameAndAge name:%s, age:%d", name, age)
+	r, ok := cache.GetByName(name)
+	if ok && r.Age == age {
+		outLn("Req GetUserByNameAndAge result:%#v", r)
+		return r, nil
+	}
+	return r, nil
+}
+
+// UpdateUser update by user struct, my be another struct, PX config POST or PUT.
+func (u *UserProvider) UpdateUser(ctx context.Context, user *User) (bool, error) {
+	outLn("Req UpdateUser data:%#v", user)
+	r, ok := cache.GetByName(user.Name)
+	if ok {
+		if user.ID != "" {
+			r.ID = user.ID
+		}
+		if user.Age >= 0 {
+			r.Age = user.Age
+		}
+		return true, nil
+	}
+	return false, errors.New("not found")
+}
+
+// UpdateUserByName update by user struct, my be another struct, PX config POST or PUT.
+func (u *UserProvider) UpdateUserByName(ctx context.Context, name string, user *User) (bool, error) {
+	outLn("Req UpdateUserByName data:%#v", user)
+	r, ok := cache.GetByName(name)
+	if ok {
+		if user.ID != "" {
+			r.ID = user.ID
+		}
+		if user.Age >= 0 {
+			r.Age = user.Age
+		}
+		return true, nil
+	}
+	return false, errors.New("not found")
+}
+
+// nolint
+func (u *UserProvider) Reference() string {
+	return "UserProvider"
+}
+
+// nolint
+func (u User) JavaClassName() string {
+	return "com.dubbogo.pixiu.User"
+}
+
+// nolint
+func outLn(format string, args ...interface{}) {
+	fmt.Printf("\033[32;40m"+format+"\033[0m\n", args...)
+}

--- a/samples/dubbogo/simple/resolve/server/profiles/dev/log.yml
+++ b/samples/dubbogo/simple/resolve/server/profiles/dev/log.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+level: "debug"
+development: true
+disableCaller: false
+disableStacktrace: false
+sampling:
+encoding: "console"
+
+# encoder
+encoderConfig:
+  messageKey: "message"
+  levelKey: "level"
+  timeKey: "time"
+  nameKey: "logger"
+  callerKey: "caller"
+  stacktraceKey: "stacktrace"
+  lineEnding: ""
+  levelEncoder: "capitalColor"
+  timeEncoder: "iso8601"
+  durationEncoder: "seconds"
+  callerEncoder: "short"
+  nameEncoder: ""
+
+outputPaths:
+  - "stderr"
+errorOutputPaths:
+  - "stderr"
+initialFields:

--- a/samples/dubbogo/simple/resolve/server/profiles/dev/server.yml
+++ b/samples/dubbogo/simple/resolve/server/profiles/dev/server.yml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# dubbo server yaml configure file
+# application config
+dubbo:
+  registries:
+    zk:
+      protocol: zookeeper
+      timeout: 3s
+      address: 127.0.0.1:2181
+  protocols:
+    dubbo:
+      name: dubbo
+      port: 20000
+  provider:
+    registry-ids: zk
+    services:
+      UserProvider:
+        group: test
+        version: 1.0.0
+        cluster: test_dubbo
+        serialization: hessian2
+        interface: com.dubbogo.pixiu.UserService

--- a/samples/dubbogo/simple/resolve/test/pixiu_test.go
+++ b/samples/dubbogo/simple/resolve/test/pixiu_test.go
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPost1(t *testing.T) {
+	url := "http://localhost:8883/UserService/com.dubbogo.pixiu.UserService/GetUserByName"
+	data := "{\"types\":\"string\",\"values\":\"tc\"}"
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("POST", url, strings.NewReader(data))
+	req.Header.Set("x-dubbo-http1.1-dubbo-version", "1.0.0")
+	req.Header.Set("x-dubbo-service-protocol", "dubbo")
+	req.Header.Set("x-dubbo-service-version", "1.0.0")
+	req.Header.Set("x-dubbo-service-group", "test")
+
+	assert.NoError(t, err)
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	s, _ := ioutil.ReadAll(resp.Body)
+	assert.True(t, strings.Contains(string(s), "0001"))
+}
+
+func TestPost2(t *testing.T) {
+	url := "http://localhost:8883/UserService/com.dubbogo.pixiu.UserService/UpdateUserByName"
+	data := "{\"types\":\"string,object\",\"values\":[\"tc\",{\"id\":\"0001\",\"code\":1,\"name\":\"tc\",\"age\":15}]}"
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("POST", url, strings.NewReader(data))
+	req.Header.Set("x-dubbo-http1.1-dubbo-version", "1.0.0")
+	req.Header.Set("x-dubbo-service-protocol", "dubbo")
+	req.Header.Set("x-dubbo-service-version", "1.0.0")
+	req.Header.Set("x-dubbo-service-group", "test")
+	assert.NoError(t, err)
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	s, _ := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, "true", string(s))
+}
+
+func TestPost3(t *testing.T) {
+	url := "http://localhost:8883/UserService/com.dubbogo.pixiu.UserService/GetUserByCode"
+	data := "{\"types\":\"int\",\"values\":1}"
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("POST", url, strings.NewReader(data))
+	req.Header.Set("x-dubbo-http1.1-dubbo-version", "1.0.0")
+	req.Header.Set("x-dubbo-service-protocol", "dubbo")
+	req.Header.Set("x-dubbo-service-version", "1.0.0")
+	req.Header.Set("x-dubbo-service-group", "test")
+	assert.NoError(t, err)
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	s, _ := ioutil.ReadAll(resp.Body)
+	assert.True(t, strings.Contains(string(s), "0001"))
+}

--- a/start_integrate_test.sh
+++ b/start_integrate_test.sh
@@ -19,6 +19,7 @@ array+=("samples/dubbogo/simple/mix")
 array+=("samples/dubbogo/simple/proxy")
 array+=("samples/dubbogo/simple/query")
 array+=("samples/dubbogo/simple/uri")
+array+=("samples/dubbogo/simple/resolve")
 array+=("samples/dubbogo/simple/registry")
 
 #


### PR DESCRIPTION
#### What this PR does:

Http to dubbo default transform strategy.

We can remove ap_config.yaml file and resolve http request to get api_config.

Related to #298

The strategy document  is https://www.yuque.com/docs/share/4f82b71e-fa2b-4e65-8007-ba3afe2a1740?#