### PR TITLE
upgrade hessian2 to v1.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Shopify/sarama v1.19.0
 	github.com/alibaba/sentinel-golang v1.0.2
 	github.com/apache/dubbo-getty v1.4.7-rc2
-	github.com/apache/dubbo-go-hessian2 v1.10.2
+	github.com/apache/dubbo-go-hessian2 v1.11.0
 	github.com/creasty/defaults v1.5.2
 	github.com/dubbogo/dubbo-go-pixiu-filter v0.1.4
 	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,9 @@ github.com/apache/dubbo-getty v1.4.7-rc2 h1:Q/vDRoT35kSa0iMdMJSTjBFFHjLryDWPitq3
 github.com/apache/dubbo-getty v1.4.7-rc2/go.mod h1:+6IHweEgfMCShEzGzQw2H7Wt33nYTJ/U9lNH9tHrzMM=
 github.com/apache/dubbo-go-hessian2 v1.9.1/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
 github.com/apache/dubbo-go-hessian2 v1.9.3/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
-github.com/apache/dubbo-go-hessian2 v1.10.2 h1:Wb27FKBmgutoZWcXHt1C/WM4e+sBVW0NdLQQZ5ITlrU=
 github.com/apache/dubbo-go-hessian2 v1.10.2/go.mod h1:7rEw9guWABQa6Aqb8HeZcsYPHsOS7XT1qtJvkmI6c5w=
+github.com/apache/dubbo-go-hessian2 v1.11.0 h1:VTdT6NStuEqNmyT3AdSN2DLDBqhXvAAyAAAoh9hLavk=
+github.com/apache/dubbo-go-hessian2 v1.11.0/go.mod h1:7rEw9guWABQa6Aqb8HeZcsYPHsOS7XT1qtJvkmI6c5w=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION

**What this PR does**:
upgrade hessian2 to v1.11.0, see https://github.com/apache/dubbo-go-hessian2/releases/tag/v1.11.0

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
- upgrade hessian2 to v1.11.0
```