### PR TITLE
fix ut fail by upgrade gomock to v1.5.5

### DIFF
--- a/pkg/config/xds/xds_test.go
+++ b/pkg/config/xds/xds_test.go
@@ -121,7 +121,8 @@ func TestAdapter_createApiManager(t *testing.T) {
 			store.EXPECT().Config().Return([]*model.Cluster{cluster})
 			return store, nil
 		})
-		clusterMg.EXPECT().HasCluster("cluster-2").Return(false)
+		// delete this stub by #https://github.com/golang/mock/issues/530
+		//clusterMg.EXPECT().HasCluster("cluster-2").Return(false)
 		apiclient.Init(clusterMg)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Just fix the ut for xds_test.go

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```