### PR TITLE
add metrics

### DIFF
--- a/pixiu/pkg/filter/metric/metric.go
+++ b/pixiu/pkg/filter/metric/metric.go
@@ -19,7 +19,7 @@ package metric
 
 import (
 	"fmt"
-	http2 "net/http"
+	stdhttp "net/http"
 	"time"
 )
 
@@ -141,12 +141,10 @@ func computeApproximateResponseSize(res *client.Response) (int, error) {
 	if res == nil {
 		return 0, errors.New("client.Response is null pointer ")
 	}
-	s := 0
-	s += len(res.Data)
-	return s, nil
+	return len(res.Data), nil
 }
 
-func computeApproximateRequestSize(r *http2.Request) (int, error) {
+func computeApproximateRequestSize(r *stdhttp.Request) (int, error) {
 	if r == nil {
 		return 0, errors.New("http.Request is null pointer ")
 	}

--- a/pixiu/pkg/prometheus/prometheus.go
+++ b/pixiu/pkg/prometheus/prometheus.go
@@ -386,7 +386,5 @@ func computeApproximateResponseSize(res *client.Response) (int, error) {
 	if res == nil {
 		return 0, errors.New("client.Response is null pointer ")
 	}
-	s := 0
-	s += len(res.Data)
-	return s, nil
+	return len(res.Data), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**: There are 2 metrics filter:  "dgp.filter.http.metric" and  "dgp.filter.http.prometheusmetric". Them do similar things. But dgp.filter.http.prometheusmetric support push mode only that is not recommend. This issue move some metric of prometheusmetric to "dgp.filter.http.metric" .

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```