### PR TITLE
support custom dubbo invoke retry times

### DIFF
--- a/pkg/client/dubbo/config.go
+++ b/pkg/client/dubbo/config.go
@@ -33,7 +33,7 @@ type DubboProxyConfig struct {
 	AutoResolve bool `yaml:"auto_resolve" json:"auto_resolve,omitempty"`
 	// Protoset path to load protoset files
 	Protoset []string `yaml:"protoset" json:"protoset,omitempty"`
-	// Load   load balance
+	// Load balance
 	LoadBalance string `yaml:"load_balance"  json:"load_balance,omitempty"`
 	// Retries number of retries
 	Retries string `yaml:"retries" json:"retries,omitempty"`

--- a/pkg/client/dubbo/config.go
+++ b/pkg/client/dubbo/config.go
@@ -33,6 +33,8 @@ type DubboProxyConfig struct {
 	AutoResolve bool `yaml:"auto_resolve" json:"auto_resolve,omitempty"`
 	// Protoset path to load protoset files
 	Protoset []string `yaml:"protoset" json:"protoset,omitempty"`
-	// Load
+	// Load   load balance
 	LoadBalance string `yaml:"load_balance"  json:"load_balance,omitempty"`
+	// Retries number of retries
+	Retries string `yaml:"retries" json:"retries,omitempty"`
 }

--- a/pkg/client/dubbo/dubbo.go
+++ b/pkg/client/dubbo/dubbo.go
@@ -319,12 +319,15 @@ func (dc *Client) create(key string, irequest fc.IntegrationRequest) *generic.Ge
 		Version:       irequest.DubboBackendConfig.Version,
 		Group:         irequest.Group,
 		Loadbalance:   dc.dubboProxyConfig.LoadBalance,
+		Retries:       dc.dubboProxyConfig.Retries,
 	}
 
-	if len(irequest.DubboBackendConfig.Retries) == 0 {
-		refConf.Retries = "3"
-	} else {
-		refConf.Retries = irequest.DubboBackendConfig.Retries
+	if refConf.Retries == "" {
+		if len(irequest.DubboBackendConfig.Retries) == 0 {
+			refConf.Retries = "3"
+		} else {
+			refConf.Retries = irequest.DubboBackendConfig.Retries
+		}
 	}
 
 	if dc.dubboProxyConfig.Timeout != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Now we can specify retry times on dubbo proxy like this:

                  - name: dgp.filter.http.dubboproxy
                    config:
                      dubboProxyConfig:
                        auto_resolve: true
                        retries: 3
                        registries:
                          "zookeeper":
                            protocol: "zookeeper"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```