### PR TITLE
FIX:markdown file shell command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ if prepare config file manually, notice:
 if run pixiu manually in pixiu project, use command as below.
 
 ```shell
- go run cmd/pixiu/*.go gateway start -c /[absolute-path]/dubbo-go-pixiu/samples/dubbogo/simple/direct/pixiu/conf.yaml
+ go run cmd/pixiu/*.go gateway start -c /[absolute-path]/dubbo-go-pixiu-samples/dubbogo/simple/direct/pixiu/conf.yaml
 ```
 
 if run pixiu manually in pixiu project and wasm feature, use command as below.
@@ -89,7 +89,7 @@ run pixiu app binary
 
 ```shell
 go build cmd/pixiu/*.go
-./pixiu gateway start -c /[absolute-path]/dubbo-go-pixiu/samples/dubbogo/simple/direct/pixiu/conf.yaml
+./pixiu gateway start -c /[absolute-path]/dubbo-go-pixiu-samples/dubbogo/simple/direct/pixiu/conf.yaml
 ```
 
 #### Try a request

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,7 +73,7 @@ cd dubbogo/simple
 使用下列命令来手动启动 pixiu
 
 ```shell
- go run cmd/pixiu/*.go gateway start -c /[absolute-path]/dubbo-go-pixiu/samples/dubbogo/simple/direct/pixiu/conf.yaml
+ go run cmd/pixiu/*.go gateway start -c /[absolute-path]/dubbo-go-pixiu-samples/dubbogo/simple/direct/pixiu/conf.yaml
 ```
 
 如果希望启用wasm ,使用下列命令来手动启动 pixiu
@@ -86,7 +86,7 @@ go build -tags wasm -o pixiu cmd/pixiu/*.go
 
 ```shell
 go build cmd/pixiu/*.go
-./pixiu gateway start -c /[absolute-path]/dubbo-go-pixiu/samples/dubbogo/simple/direct/pixiu/conf.yaml
+./pixiu gateway start -c /[absolute-path]/dubbo-go-pixiu-samples/dubbogo/simple/direct/pixiu/conf.yaml
 ```
 
 #### 尝试请求


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
fix markdown file errors, the configuration file path in the shell command is incorrect
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
fix the configuration file path in the shell command

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
YES
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```