### PR TITLE
fix: Register sentinel ratelimit filter

### DIFF
--- a/pkg/pluginregistry/registry.go
+++ b/pkg/pluginregistry/registry.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/network/grpcconnectionmanager"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/network/httpconnectionmanager"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/prometheus"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/sentinel/ratelimit"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/tracing"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/traffic"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/listener/http"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

sentinel ratelimit filter was not registered before, which leads to user cannot use ```dgp.filter.http.ratelimit``` by name in conf file and ```https://github.com/apache/dubbo-go-pixiu-samples/tree/main/plugins/ratelimit``` in dubbo-go-pixiu-samples cannot be run successfully.


