### PR TITLE
feat: supports tcp/http/https for health check & fix: Fix ignoring the domains field #667

### DIFF
--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -19,6 +19,7 @@ package healthcheck
 
 import (
 	"runtime/debug"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -168,7 +169,8 @@ func (hc *HealthChecker) stopCheck(endpoint *model.Endpoint) {
 
 func newChecker(endpoint *model.Endpoint, hc *HealthChecker) *EndpointChecker {
 	var checker Checker
-	switch hc.protocol {
+	protocol := strings.ToLower(hc.protocol)
+	switch protocol {
 	case "tcp":
 		checker = &TCPChecker{
 			address: endpoint.Address.GetAddress(),

--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -52,14 +52,15 @@ type HealthChecker struct {
 	initialDelay       time.Duration
 	cluster            *model.ClusterConfig
 	unhealthyThreshold uint32
+	protocol           string
 }
 
 // EndpointChecker is a wrapper of types.HealthCheckSession for health check
 type EndpointChecker struct {
 	endpoint      *model.Endpoint
 	HealthChecker *HealthChecker
-	// TCP checker, can extend to http, grpc, dubbo or other protocol checker
-	tcpChecker    *TCPChecker
+	// checker, todo can extend to TCP, http, grpc, dubbo or other protocol checker
+	checker       Checker
 	resp          chan checkResponse
 	timeout       chan bool
 	checkID       uint64
@@ -71,6 +72,11 @@ type EndpointChecker struct {
 	threshold     uint32
 
 	once sync.Once
+}
+
+type Checker interface {
+	CheckHealth() bool
+	OnTimeout()
 }
 
 type checkResponse struct {
@@ -108,6 +114,7 @@ func CreateHealthCheck(cluster *model.ClusterConfig, cfg model.HealthCheckConfig
 	}
 
 	hc := &HealthChecker{
+		protocol:           cfg.Protocol,
 		sessionConfig:      cfg.SessionConfig,
 		cluster:            cluster,
 		timeout:            timeout,
@@ -162,8 +169,33 @@ func (hc *HealthChecker) stopCheck(endpoint *model.Endpoint) {
 }
 
 func newChecker(endpoint *model.Endpoint, hc *HealthChecker) *EndpointChecker {
+	var checker Checker
+	switch hc.protocol {
+	case "tcp":
+		checker = &TCPChecker{
+			address: endpoint.Address.GetAddress(),
+			timeout: hc.timeout,
+		}
+	case "http":
+		checker = &HTTPChecker{
+			address: endpoint.Address.GetAddress(),
+			timeout: hc.timeout,
+		}
+	case "https":
+		checker = &HTTPSChecker{
+			address: endpoint.Address.GetAddress(),
+			timeout: hc.timeout,
+		}
+	default:
+		logger.Warnf("[health check] %s health checker is not implemented, using tcp checker", hc.protocol)
+		checker = &TCPChecker{
+			address: endpoint.Address.GetAddress(),
+			timeout: hc.timeout,
+		}
+	}
+
 	c := &EndpointChecker{
-		tcpChecker:    newTcpChecker(endpoint, hc.timeout),
+		checker:       checker,
 		endpoint:      endpoint,
 		HealthChecker: hc,
 		resp:          make(chan checkResponse),
@@ -171,13 +203,6 @@ func newChecker(endpoint *model.Endpoint, hc *HealthChecker) *EndpointChecker {
 		stop:          make(chan struct{}),
 	}
 	return c
-}
-
-func newTcpChecker(endpoint *model.Endpoint, timeout time.Duration) *TCPChecker {
-	return &TCPChecker{
-		addr:    endpoint.Address.GetAddress(),
-		timeout: timeout,
-	}
 }
 
 func (hc *HealthChecker) getCheckInterval() time.Duration {
@@ -279,7 +304,7 @@ func (c *EndpointChecker) OnCheck() {
 	c.checkTimeout = gxtime.AfterFunc(c.HealthChecker.timeout, c.OnTimeout)
 	c.resp <- checkResponse{
 		ID:      id,
-		Healthy: c.tcpChecker.CheckHealth(),
+		Healthy: c.checker.CheckHealth(),
 	}
 }
 

--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -25,12 +25,10 @@ import (
 )
 
 import (
-	gxtime "github.com/dubbogo/gost/time"
-)
-
-import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
+
+	gxtime "github.com/dubbogo/gost/time"
 )
 
 const (

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package healthcheck
 
 import (

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -20,6 +20,7 @@ package healthcheck
 import (
 	"log"
 	"net"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -76,7 +77,7 @@ func TestTcpConn(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := TcpConn(tc.addr, tc.port, tc.timeout)
+			actual := TcpConn(tc.addr, strconv.Itoa(tc.port), tc.timeout)
 			if actual != tc.expected {
 				t.Fail()
 			}

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -73,7 +73,7 @@ func TestTcpConn(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := TcpConn(tc.addr, strconv.Itoa(tc.port), tc.timeout)
+			actual := CheckTcpConn(tc.addr, strconv.Itoa(tc.port), tc.timeout)
 			if actual != tc.expected {
 				t.Fail()
 			}

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"net"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 )
@@ -48,12 +47,11 @@ func TestTcpConn(t *testing.T) {
 	time.Sleep(100 * time.Millisecond) // Give the server some time to start
 
 	type TestCase struct {
-		name         string
-		addr         string
-		port         int
-		timeout      time.Duration
-		shouldListen bool
-		expected     bool
+		name     string
+		addr     string
+		port     int
+		timeout  time.Duration
+		expected bool
 	}
 
 	testCases := []TestCase{
@@ -73,8 +71,6 @@ func TestTcpConn(t *testing.T) {
 		},
 	}
 
-	var wg sync.WaitGroup
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := TcpConn(tc.addr, strconv.Itoa(tc.port), tc.timeout)
@@ -83,6 +79,4 @@ func TestTcpConn(t *testing.T) {
 			}
 		})
 	}
-
-	wg.Wait()
 }

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -18,65 +18,161 @@
 package healthcheck
 
 import (
-	"log"
 	"net"
-	"strconv"
 	"testing"
 	"time"
 )
 
-func TestTcpConn(t *testing.T) {
+func TestNormalizeAddress(t *testing.T) {
+	tests := []struct {
+		name        string
+		address     string
+		port        string
+		wantAddress string
+		wantErr     bool
+	}{
+		{
+			name:        "port is empty, address has port",
+			address:     "localhost:8080",
+			port:        "",
+			wantAddress: "localhost:8080",
+			wantErr:     false,
+		},
+		{
+			name:        "port is empty, address has no port",
+			address:     "localhost",
+			port:        "",
+			wantAddress: "",
+			wantErr:     true,
+		},
+		{
+			name:        "port is not empty, address has no port",
+			address:     "localhost",
+			port:        "80",
+			wantAddress: "localhost:80",
+			wantErr:     false,
+		},
+		{
+			name:        "port is not empty, address has same port",
+			address:     "localhost:80",
+			port:        "80",
+			wantAddress: "localhost:80",
+			wantErr:     false,
+		},
+		{
+			name:        "port is not empty, address has different port",
+			address:     "localhost:8080",
+			port:        "80",
+			wantAddress: "localhost:80",
+			wantErr:     false,
+		},
+		{
+			name:        "invalid address format for empty port",
+			address:     "[::1]", // IPv6 without port
+			port:        "",
+			wantAddress: "",
+			wantErr:     true,
+		},
+		{
+			name:        "valid IPv6 address with port",
+			address:     "[::1]:8080",
+			port:        "",
+			wantAddress: "[::1]:8080",
+			wantErr:     false,
+		},
+		{
+			name:        "port is not empty, valid IPv6 address without port",
+			address:     "[::1]",
+			port:        "80",
+			wantAddress: "[::1]:80",
+			wantErr:     false,
+		},
+		{
+			name:        "port is not empty, valid IPv6 address with different port",
+			address:     "[::1]:8080",
+			port:        "80",
+			wantAddress: "[::1]:80",
+			wantErr:     false,
+		},
+	}
 
-	go func() {
-		listener, err := net.Listen("tcp", ":12347")
-		if err != nil {
-			log.Fatalf("listen failed: %v", err)
-		}
-
-		for {
-			client, err := listener.Accept()
-			if err != nil {
-				log.Printf("accept new client failed: %v", err)
-				continue
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAddress, gotErr := normalizeAddress(tt.address, tt.port)
+			if (gotErr != nil) != tt.wantErr {
+				t.Errorf("normalizeAddress(%q, %q) error = %v, wantErr %v", tt.address, tt.port, gotErr, tt.wantErr)
+				return
 			}
-
-			client.Close()
-		}
-	}()
-
-	time.Sleep(100 * time.Millisecond) // Give the server some time to start
-
-	type TestCase struct {
-		name     string
-		addr     string
-		port     int
-		timeout  time.Duration
-		expected bool
-	}
-
-	testCases := []TestCase{
-		{
-			name:     "12347",
-			addr:     "127.0.0.1",
-			port:     12347,
-			timeout:  100 * time.Millisecond,
-			expected: true,
-		},
-		{
-			name:     "12348",
-			addr:     "127.0.0.1",
-			port:     12348,
-			timeout:  100 * time.Millisecond,
-			expected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := CheckTcpConn(tc.addr, strconv.Itoa(tc.port), tc.timeout)
-			if actual != tc.expected {
-				t.Fail()
+			if gotAddress != tt.wantAddress {
+				t.Errorf("normalizeAddress(%q, %q) gotAddress = %q, want %q", tt.address, tt.port, gotAddress, tt.wantAddress)
 			}
 		})
 	}
+}
+
+func TestCheckTcpConn(t *testing.T) {
+	// We need a way to simulate a successful and a failed TCP connection.
+	// We can achieve this by setting up a temporary listener for the success case
+	// and using an invalid address for the failure case.
+
+	// Success case: Set up a temporary listener
+	listener, err := net.Listen("tcp", "localhost:0") // Listen on a random available port
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+	defer listener.Close()
+	addr := listener.Addr().String()
+	host, portStr, _ := net.SplitHostPort(addr)
+
+	t.Run("successful connection", func(t *testing.T) {
+		go func() {
+			conn, _ := listener.Accept() // Accept the incoming connection
+			if conn != nil {
+				conn.Close()
+			}
+		}()
+		success := CheckTcpConn(host, portStr, 100*time.Millisecond)
+		if !success {
+			t.Errorf("CheckTcpConn(%q, %q, ...) should return true for a successful connection", host, portStr)
+		}
+	})
+
+	// Failure case 1: Invalid address format
+	t.Run("failed connection due to invalid address format", func(t *testing.T) {
+		success := CheckTcpConn("invalid address", "80", 100*time.Millisecond)
+		if success {
+			t.Errorf("CheckTcpConn(%q, %q, ...) should return false for an invalid address format", "invalid address", "80")
+		}
+	})
+
+	// Failure case 2: Connection timeout
+	t.Run("failed connection due to timeout", func(t *testing.T) {
+		// Use a non-routable local address to ensure a timeout
+		success := CheckTcpConn("10.255.255.1", "80", 100*time.Millisecond)
+		if success {
+			t.Errorf("CheckTcpConn(%q, %q, ...) should return false due to timeout", "10.255.255.1", "80")
+		}
+	})
+
+	// Test with empty port (should fail due to normalizeAddress)
+	t.Run("failed with empty port and no port in address", func(t *testing.T) {
+		success := CheckTcpConn("localhost", "", 100*time.Millisecond)
+		if success {
+			t.Errorf("CheckTcpConn(%q, %q, ...) should return false when port is empty and address has no port", "localhost", "")
+		}
+	})
+
+	// Test with empty port and address has port (should succeed)
+	t.Run("successful with empty port and port in address", func(t *testing.T) {
+		go func() {
+			conn, _ := listener.Accept()
+			if conn != nil {
+				conn.Close()
+			}
+		}()
+		success := CheckTcpConn(addr, "", 100*time.Millisecond)
+		if !success {
+			t.Errorf("CheckTcpConn(%q, %q, ...) should return true when port is empty and address has port", addr, "")
+		}
+	})
 }

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -148,9 +148,9 @@ func TestCheckTcpConn(t *testing.T) {
 	// Failure case 2: Connection timeout
 	t.Run("failed connection due to timeout", func(t *testing.T) {
 		// Use a non-routable local address to ensure a timeout
-		success := CheckTcpConn("10.255.255.1", "80", 100*time.Millisecond)
+		success := CheckTcpConn("127.0.0.1", "80", 100*time.Millisecond)
 		if success {
-			t.Errorf("CheckTcpConn(%q, %q, ...) should return false due to timeout", "10.255.255.1", "80")
+			t.Errorf("CheckTcpConn(%q, %q, ...) should return false due to timeout", "127.0.0.1", "80")
 		}
 	})
 

--- a/pkg/cluster/healthcheck/http.go
+++ b/pkg/cluster/healthcheck/http.go
@@ -28,7 +28,7 @@ type HTTPChecker struct {
 
 func (s *HTTPChecker) CheckHealth() bool {
 	tarAddr := s.address
-	return TcpConn(tarAddr, "80", s.timeout)
+	return CheckTcpConn(tarAddr, "80", s.timeout)
 }
 
 func (s *HTTPChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/http.go
+++ b/pkg/cluster/healthcheck/http.go
@@ -18,13 +18,7 @@
 package healthcheck
 
 import (
-	"net"
-	"strings"
 	"time"
-)
-
-import (
-	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
 type HTTPChecker struct {
@@ -34,21 +28,7 @@ type HTTPChecker struct {
 
 func (s *HTTPChecker) CheckHealth() bool {
 	tarAddr := s.address
-	if _, _, err := net.SplitHostPort(tarAddr); err != nil {
-		if strings.Contains(err.Error(), "missing port in address") {
-			tarAddr = tarAddr + ":80"
-		} else {
-			logger.Infof("[health check] invalid address format: %s", s.address)
-			return false
-		}
-	}
-	conn, err := net.DialTimeout("tcp", tarAddr, s.timeout)
-	if err != nil {
-		logger.Infof("[health check] http checker for host %s error: %v", tarAddr, err)
-		return false
-	}
-	conn.Close()
-	return true
+	return TcpConn(tarAddr, 80, s.timeout)
 }
 
 func (s *HTTPChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/http.go
+++ b/pkg/cluster/healthcheck/http.go
@@ -19,6 +19,7 @@ package healthcheck
 
 import (
 	"net"
+	"strings"
 	"time"
 )
 
@@ -26,19 +27,28 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
-type TCPChecker struct {
+type HTTPChecker struct {
 	address string
 	timeout time.Duration
 }
 
-func (s *TCPChecker) CheckHealth() bool {
-	conn, err := net.DialTimeout("tcp", s.address, s.timeout)
+func (s *HTTPChecker) CheckHealth() bool {
+	tarAddr := s.address
+	if _, _, err := net.SplitHostPort(tarAddr); err != nil {
+		if strings.Contains(err.Error(), "missing port in address") {
+			tarAddr = tarAddr + ":80"
+		} else {
+			logger.Infof("[health check] invalid address format: %s", s.address)
+			return false
+		}
+	}
+	conn, err := net.DialTimeout("tcp", tarAddr, s.timeout)
 	if err != nil {
-		logger.Infof("[health check] tcp checker for host %s error: %v", s.address, err)
+		logger.Infof("[health check] http checker for host %s error: %v", tarAddr, err)
 		return false
 	}
 	conn.Close()
 	return true
 }
 
-func (s *TCPChecker) OnTimeout() {}
+func (s *HTTPChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/http.go
+++ b/pkg/cluster/healthcheck/http.go
@@ -28,7 +28,7 @@ type HTTPChecker struct {
 
 func (s *HTTPChecker) CheckHealth() bool {
 	tarAddr := s.address
-	return TcpConn(tarAddr, 80, s.timeout)
+	return TcpConn(tarAddr, "80", s.timeout)
 }
 
 func (s *HTTPChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/https.go
+++ b/pkg/cluster/healthcheck/https.go
@@ -18,13 +18,7 @@
 package healthcheck
 
 import (
-	"net"
-	"strings"
 	"time"
-)
-
-import (
-	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
 type HTTPSChecker struct {
@@ -34,21 +28,8 @@ type HTTPSChecker struct {
 
 func (s *HTTPSChecker) CheckHealth() bool {
 	tarAddr := s.address
-	if _, _, err := net.SplitHostPort(tarAddr); err != nil {
-		if strings.Contains(err.Error(), "missing port in address") {
-			tarAddr = tarAddr + ":443"
-		} else {
-			logger.Infof("[health check] invalid address format: %s", s.address)
-			return false
-		}
-	}
-	conn, err := net.DialTimeout("tcp", tarAddr, s.timeout)
-	if err != nil {
-		logger.Infof("[health check] http checker for host %s error: %v", tarAddr, err)
-		return false
-	}
-	conn.Close()
-	return true
+	return TcpConn(tarAddr, 443, s.timeout)
+
 }
 
 func (s *HTTPSChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/https.go
+++ b/pkg/cluster/healthcheck/https.go
@@ -28,7 +28,7 @@ type HTTPSChecker struct {
 
 func (s *HTTPSChecker) CheckHealth() bool {
 	tarAddr := s.address
-	return TcpConn(tarAddr, 443, s.timeout)
+	return TcpConn(tarAddr, "443", s.timeout)
 
 }
 

--- a/pkg/cluster/healthcheck/https.go
+++ b/pkg/cluster/healthcheck/https.go
@@ -28,7 +28,7 @@ type HTTPSChecker struct {
 
 func (s *HTTPSChecker) CheckHealth() bool {
 	tarAddr := s.address
-	return TcpConn(tarAddr, "443", s.timeout)
+	return CheckTcpConn(tarAddr, "443", s.timeout)
 
 }
 

--- a/pkg/cluster/healthcheck/https.go
+++ b/pkg/cluster/healthcheck/https.go
@@ -19,6 +19,7 @@ package healthcheck
 
 import (
 	"net"
+	"strings"
 	"time"
 )
 
@@ -26,19 +27,28 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
-type TCPChecker struct {
+type HTTPSChecker struct {
 	address string
 	timeout time.Duration
 }
 
-func (s *TCPChecker) CheckHealth() bool {
-	conn, err := net.DialTimeout("tcp", s.address, s.timeout)
+func (s *HTTPSChecker) CheckHealth() bool {
+	tarAddr := s.address
+	if _, _, err := net.SplitHostPort(tarAddr); err != nil {
+		if strings.Contains(err.Error(), "missing port in address") {
+			tarAddr = tarAddr + ":443"
+		} else {
+			logger.Infof("[health check] invalid address format: %s", s.address)
+			return false
+		}
+	}
+	conn, err := net.DialTimeout("tcp", tarAddr, s.timeout)
 	if err != nil {
-		logger.Infof("[health check] tcp checker for host %s error: %v", s.address, err)
+		logger.Infof("[health check] http checker for host %s error: %v", tarAddr, err)
 		return false
 	}
 	conn.Close()
 	return true
 }
 
-func (s *TCPChecker) OnTimeout() {}
+func (s *HTTPSChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/tcp.go
+++ b/pkg/cluster/healthcheck/tcp.go
@@ -18,12 +18,7 @@
 package healthcheck
 
 import (
-	"net"
 	"time"
-)
-
-import (
-	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
 type TCPChecker struct {
@@ -32,13 +27,7 @@ type TCPChecker struct {
 }
 
 func (s *TCPChecker) CheckHealth() bool {
-	conn, err := net.DialTimeout("tcp", s.address, s.timeout)
-	if err != nil {
-		logger.Infof("[health check] tcp checker for host %s error: %v", s.address, err)
-		return false
-	}
-	conn.Close()
-	return true
+	return TcpConn(s.address, 8081, s.timeout)
 }
 
 func (s *TCPChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/tcp.go
+++ b/pkg/cluster/healthcheck/tcp.go
@@ -27,7 +27,7 @@ type TCPChecker struct {
 }
 
 func (s *TCPChecker) CheckHealth() bool {
-	return TcpConn(s.address, 8081, s.timeout)
+	return TcpConn(s.address, "", s.timeout)
 }
 
 func (s *TCPChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/tcp.go
+++ b/pkg/cluster/healthcheck/tcp.go
@@ -27,7 +27,7 @@ type TCPChecker struct {
 }
 
 func (s *TCPChecker) CheckHealth() bool {
-	return TcpConn(s.address, "", s.timeout)
+	return CheckTcpConn(s.address, "", s.timeout)
 }
 
 func (s *TCPChecker) OnTimeout() {}

--- a/pkg/cluster/healthcheck/utils.go
+++ b/pkg/cluster/healthcheck/utils.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package healthcheck
 
 import (

--- a/pkg/cluster/healthcheck/utils.go
+++ b/pkg/cluster/healthcheck/utils.go
@@ -1,0 +1,27 @@
+package healthcheck
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/logger"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func TcpConn(tarAddr string, port int, timeout time.Duration) bool {
+	if _, _, err := net.SplitHostPort(tarAddr); err != nil {
+		if strings.Contains(err.Error(), "missing port in address") {
+			tarAddr = tarAddr + ":" + strconv.Itoa(port)
+		} else {
+			logger.Infof("[health check] invalid address format: %s", tarAddr)
+			return false
+		}
+	}
+	conn, err := net.DialTimeout("tcp", tarAddr, timeout)
+	if err != nil {
+		logger.Infof("[health check] http checker for host %s error: %v", tarAddr, err)
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/pkg/cluster/healthcheck/utils.go
+++ b/pkg/cluster/healthcheck/utils.go
@@ -27,37 +27,37 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
-func TcpConn(tarAddr string, tarPort string, timeout time.Duration) bool {
+func TcpConn(address string, port string, timeout time.Duration) bool {
 
-	if tarPort == "" {
-		// if tarPort is empty, tarAddr must has port
-		_, _, err := net.SplitHostPort(tarAddr)
+	if port == "" {
+		// if port is empty, address must has port
+		_, _, err := net.SplitHostPort(address)
 		if err != nil {
-			logger.Infof("[health check] no port specified, invalid address format: %s", tarAddr)
+			logger.Infof("[health check] no port specified, invalid address format: %s", address)
 			return false
 		}
 	} else {
-		// if tarPort is not empty, check tarAddr has port or not
-		realAddress, realPort, err := net.SplitHostPort(tarAddr)
+		// if port is not empty, check address has port or not
+		realAddress, realPort, err := net.SplitHostPort(address)
 		if err != nil {
-			// if tarAddr has no port, add tarPort to tarAddr
+			// if address has no port, add port to address
 			if strings.Contains(err.Error(), "missing port in address") {
-				tarAddr = net.JoinHostPort(tarAddr, tarPort)
+				address = net.JoinHostPort(address, port)
 			} else {
-				logger.Infof("[health check] invalid address format: %s", tarAddr)
+				logger.Infof("[health check] invalid address format: %s", address)
 				return false
 			}
 		} else {
-			// if tarAddr has port, check if it is the same as tarPort
-			if realPort != tarPort {
-				tarAddr = net.JoinHostPort(realAddress, tarPort)
+			// if address has port, check if it is the same as port
+			if realPort != port {
+				address = net.JoinHostPort(realAddress, port)
 			}
 		}
 	}
 
-	conn, err := net.DialTimeout("tcp", tarAddr, timeout)
+	conn, err := net.DialTimeout("tcp", address, timeout)
 	if err != nil {
-		logger.Infof("[health check] http checker for host %s error: %v", tarAddr, err)
+		logger.Infof("[health check] http checker for host %s error: %v", address, err)
 		return false
 	}
 	defer conn.Close()

--- a/pkg/cluster/healthcheck/utils.go
+++ b/pkg/cluster/healthcheck/utils.go
@@ -20,25 +20,43 @@ package healthcheck
 import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 	"net"
-	"strconv"
 	"strings"
 	"time"
 )
 
-func TcpConn(tarAddr string, port int, timeout time.Duration) bool {
-	if _, _, err := net.SplitHostPort(tarAddr); err != nil {
-		if strings.Contains(err.Error(), "missing port in address") {
-			tarAddr = tarAddr + ":" + strconv.Itoa(port)
-		} else {
-			logger.Infof("[health check] invalid address format: %s", tarAddr)
+func TcpConn(tarAddr string, tarPort string, timeout time.Duration) bool {
+
+	if tarPort == "" {
+		// if tarPort is empty, tarAddr must has port
+		_, _, err := net.SplitHostPort(tarAddr)
+		if err != nil {
+			logger.Infof("[health check] no port specified, invalid address format: %s", tarAddr)
 			return false
 		}
+	} else {
+		// if tarPort is not empty, check tarAddr has port or not
+		realAddress, realPort, err := net.SplitHostPort(tarAddr)
+		if err != nil {
+			// if tarAddr has no port, add tarPort to tarAddr
+			if strings.Contains(err.Error(), "missing port in address") {
+				tarAddr = net.JoinHostPort(tarAddr, tarPort)
+			} else {
+				logger.Infof("[health check] invalid address format: %s", tarAddr)
+				return false
+			}
+		} else {
+			// if tarAddr has port, check if it is the same as tarPort
+			if realPort != tarPort {
+				tarAddr = net.JoinHostPort(realAddress, tarPort)
+			}
+		}
 	}
+
 	conn, err := net.DialTimeout("tcp", tarAddr, timeout)
 	if err != nil {
 		logger.Infof("[health check] http checker for host %s error: %v", tarAddr, err)
 		return false
 	}
-	conn.Close()
+	defer conn.Close()
 	return true
 }

--- a/pkg/cluster/healthcheck/utils.go
+++ b/pkg/cluster/healthcheck/utils.go
@@ -27,7 +27,7 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
-func TcpConn(address string, port string, timeout time.Duration) bool {
+func CheckTcpConn(address string, port string, timeout time.Duration) bool {
 
 	if port == "" {
 		// if port is empty, address must has port

--- a/pkg/cluster/healthcheck/utils.go
+++ b/pkg/cluster/healthcheck/utils.go
@@ -18,10 +18,13 @@
 package healthcheck
 
 import (
-	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 	"net"
 	"strings"
 	"time"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
 func TcpConn(tarAddr string, tarPort string, timeout time.Duration) bool {

--- a/pkg/cluster/healthcheck/utils.go
+++ b/pkg/cluster/healthcheck/utils.go
@@ -28,38 +28,49 @@ import (
 )
 
 func CheckTcpConn(address string, port string, timeout time.Duration) bool {
-
-	if port == "" {
-		// if port is empty, address must has port
-		_, _, err := net.SplitHostPort(address)
-		if err != nil {
-			logger.Infof("[health check] no port specified, invalid address format: %s", address)
-			return false
-		}
-	} else {
-		// if port is not empty, check address has port or not
-		realAddress, realPort, err := net.SplitHostPort(address)
-		if err != nil {
-			// if address has no port, add port to address
-			if strings.Contains(err.Error(), "missing port in address") {
-				address = net.JoinHostPort(address, port)
-			} else {
-				logger.Infof("[health check] invalid address format: %s", address)
-				return false
-			}
-		} else {
-			// if address has port, check if it is the same as port
-			if realPort != port {
-				address = net.JoinHostPort(realAddress, port)
-			}
-		}
+	normalizedAddress, err := normalizeAddress(address, port)
+	if err != nil {
+		logger.Infof("[health check] address format for address \"%s\" failed, %s", address, err.Error())
+		return false
 	}
 
-	conn, err := net.DialTimeout("tcp", address, timeout)
+	conn, err := net.DialTimeout("tcp", normalizedAddress, timeout)
 	if err != nil {
-		logger.Infof("[health check] http checker for host %s error: %v", address, err)
+		logger.Infof("[health check] health check for address \"%s\" failed, %s", normalizedAddress, err.Error())
 		return false
 	}
 	defer conn.Close()
 	return true
+}
+
+// normalizeAddress normalizes the address by ensuring it has the correct port.
+// If the port field is empty, it will check if the address already has a port.
+//   - If the address has a port, it will return the address as is.
+//   - If the address does not have a port, it will return err.
+//
+// If the port field is not empty, it will check if the address's port matches the provided port.
+//   - If it matches, it will return the address as is.
+//   - If it does not match, it will return the address with the new port.
+func normalizeAddress(address string, port string) (string, error) {
+	if port == "" {
+		_, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return "", err
+		}
+		return address, nil
+	}
+
+	host, existingPort, err := net.SplitHostPort(address)
+	if err != nil {
+		if strings.Contains(err.Error(), "missing port in address") {
+			return net.JoinHostPort(strings.Trim(address, "[]"), port), nil
+		}
+		return "", err
+	}
+
+	if existingPort != port {
+		return net.JoinHostPort(host, port), nil
+	}
+
+	return address, nil
 }

--- a/pkg/cluster/healthcheck/utils_test.go
+++ b/pkg/cluster/healthcheck/utils_test.go
@@ -1,0 +1,70 @@
+package healthcheck
+
+import (
+	"log"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTcpConn(t *testing.T) {
+
+	go func() {
+		listener, err := net.Listen("tcp", ":12347")
+		if err != nil {
+			log.Fatalf("listen failed: %v", err)
+		}
+
+		for {
+			client, err := listener.Accept()
+			if err != nil {
+				log.Printf("accept new client failed: %v", err)
+				continue
+			}
+
+			client.Close()
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond) // Give the server some time to start
+
+	type TestCase struct {
+		name         string
+		addr         string
+		port         int
+		timeout      time.Duration
+		shouldListen bool
+		expected     bool
+	}
+
+	testCases := []TestCase{
+		{
+			name:     "12347",
+			addr:     "127.0.0.1",
+			port:     12347,
+			timeout:  100 * time.Millisecond,
+			expected: true,
+		},
+		{
+			name:     "12348",
+			addr:     "127.0.0.1",
+			port:     12348,
+			timeout:  100 * time.Millisecond,
+			expected: false,
+		},
+	}
+
+	var wg sync.WaitGroup
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := TcpConn(tc.addr, tc.port, tc.timeout)
+			if actual != tc.expected {
+				t.Fail()
+			}
+		})
+	}
+
+	wg.Wait()
+}

--- a/pkg/model/base.go
+++ b/pkg/model/base.go
@@ -143,7 +143,7 @@ type (
 )
 
 func (a SocketAddress) GetAddress() string {
-	if a.Domains != nil && len(a.Domains) > 0 {
+	if len(a.Domains) > 0 {
 		return a.Domains[0]
 	}
 	return fmt.Sprintf("%s:%v", a.Address, a.Port)

--- a/pkg/model/base.go
+++ b/pkg/model/base.go
@@ -143,5 +143,8 @@ type (
 )
 
 func (a SocketAddress) GetAddress() string {
+	if a.Domains != nil && len(a.Domains) > 0 {
+		return a.Domains[0]
+	}
 	return fmt.Sprintf("%s:%v", a.Address, a.Port)
 }

--- a/pkg/model/health.go
+++ b/pkg/model/health.go
@@ -19,15 +19,15 @@ package model
 
 // HealthCheck
 type HealthCheckConfig struct {
-	Protocol            string                 `json:"protocol,omitempty"`
-	TimeoutConfig       string                 `json:"timeout,omitempty"`
-	IntervalConfig      string                 `json:"interval,omitempty"`
-	InitialDelaySeconds string                 `json:"initial_delay_seconds,omitempty"`
-	HealthyThreshold    uint32                 `json:"healthy_threshold,omitempty"`
-	UnhealthyThreshold  uint32                 `json:"unhealthy_threshold,omitempty"`
-	ServiceName         string                 `json:"service_name,omitempty"`
-	SessionConfig       map[string]interface{} `json:"check_config,omitempty"`
-	CommonCallbacks     []string               `json:"common_callbacks,omitempty"`
+	Protocol            string                 `yaml:"protocol" json:"protocol,omitempty" mapstructure:"protocol"`
+	TimeoutConfig       string                 `yaml:"timeout" json:"timeout,omitempty" mapstructure:"timeout"`
+	IntervalConfig      string                 `yaml:"interval" json:"interval,omitempty" mapstructure:"interval"`
+	InitialDelaySeconds string                 `yaml:"initial_delay_seconds" json:"initial_delay_seconds,omitempty" mapstructure:"initial_delay_seconds"`
+	HealthyThreshold    uint32                 `yaml:"healthy_threshold" json:"healthy_threshold,omitempty" mapstructure:"healthy_threshold"`
+	UnhealthyThreshold  uint32                 `yaml:"unhealthy_threshold" json:"unhealthy_threshold,omitempty" mapstructure:"unhealthy_threshold"`
+	ServiceName         string                 `yaml:"service_name" json:"service_name,omitempty" mapstructure:"service_name"`
+	SessionConfig       map[string]interface{} `yaml:"check_config" json:"check_config,omitempty" mapstructure:"check_config"`
+	CommonCallbacks     []string               `yaml:"common_callbacks" json:"common_callbacks,omitempty" mapstructure:"common_callbacks"`
 }
 
 // HttpHealthCheck


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:


- feat: Now can specify the protocol field in the conf file as the target protocol to be checked by health_checks, previewsly protocol only supports for tcp and the ```protocol``` field is neglected. Currently only supports tcp/http/https, for example:

```yaml
health_checks:
  - protocol: "https"
    timeout: 1s
    interval: 2s
    healthy_threshold: 4
    unhealthy_threshold: 4
```

The new implmented health check also support specifying the domains field.

- fix #667: now can specify the domains field in the conf file as endpoint address.

