### PR TITLE
feat: add scheme field in http proxy filter, enable httpproxy filter to make https call

### DIFF
--- a/pkg/filter/http/httpproxy/routerfilter.go
+++ b/pkg/filter/http/httpproxy/routerfilter.go
@@ -19,9 +19,11 @@ package httpproxy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -51,9 +53,9 @@ type (
 		cfg    *Config
 		client http.Client
 	}
-	//Filter
 	Filter struct {
 		client http.Client
+		scheme string
 	}
 	// Config describe the config of FilterFactory
 	Config struct {
@@ -61,6 +63,7 @@ type (
 		MaxIdleConns        int           `yaml:"maxIdleConns" json:"maxIdleConns,omitempty"`
 		MaxIdleConnsPerHost int           `yaml:"maxIdleConnsPerHost" json:"maxIdleConnsPerHost,omitempty"`
 		MaxConnsPerHost     int           `yaml:"maxConnsPerHost" json:"maxConnsPerHost,omitempty"`
+		Scheme              string        `yaml:"scheme" json:"scheme,omitempty" default:"http"`
 	}
 )
 
@@ -77,6 +80,14 @@ func (factory *FilterFactory) Config() interface{} {
 }
 
 func (factory *FilterFactory) Apply() error {
+	scheme := strings.TrimSpace(strings.ToLower(factory.cfg.Scheme))
+
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("%s: scheme must be http or https", Kind)
+	}
+
+	factory.cfg.Scheme = scheme
+
 	cfg := factory.cfg
 	client := http.Client{
 		Timeout: cfg.Timeout,
@@ -92,7 +103,7 @@ func (factory *FilterFactory) Apply() error {
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, chain filter.FilterChain) error {
 	//reuse http client
-	f := &Filter{factory.client}
+	f := &Filter{factory.client, factory.cfg.Scheme}
 	chain.AppendDecodeFilters(f)
 	return nil
 }
@@ -124,7 +135,7 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 
 	parsedURL := url.URL{
 		Host:     endpoint.Address.GetAddress(),
-		Scheme:   "http",
+		Scheme:   f.scheme,
 		Path:     r.URL.Path,
 		RawQuery: r.URL.RawQuery,
 	}
@@ -139,7 +150,8 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 
 	resp, err := f.client.Do(req)
 	if err != nil {
-		urlErr, ok := err.(*url.Error)
+		var urlErr *url.Error
+		ok := errors.As(err, &urlErr)
 		if ok && urlErr.Timeout() {
 			hc.SendLocalReply(http.StatusGatewayTimeout, []byte(err.Error()))
 			return filter.Stop

--- a/pkg/filter/http/httpproxy/routerfilter.go
+++ b/pkg/filter/http/httpproxy/routerfilter.go
@@ -76,10 +76,6 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 }
 
 func (factory *FilterFactory) Config() interface{} {
-	return factory.cfg
-}
-
-func (factory *FilterFactory) Apply() error {
 	scheme := strings.TrimSpace(strings.ToLower(factory.cfg.Scheme))
 
 	if scheme != "http" && scheme != "https" {
@@ -88,6 +84,10 @@ func (factory *FilterFactory) Apply() error {
 
 	factory.cfg.Scheme = scheme
 
+	return factory.cfg
+}
+
+func (factory *FilterFactory) Apply() error {
 	cfg := factory.cfg
 	client := http.Client{
 		Timeout: cfg.Timeout,

--- a/pkg/filter/http/httpproxy/routerfilter.go
+++ b/pkg/filter/http/httpproxy/routerfilter.go
@@ -76,6 +76,10 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 }
 
 func (factory *FilterFactory) Config() interface{} {
+	return factory.cfg
+}
+
+func (factory *FilterFactory) Apply() error {
 	scheme := strings.TrimSpace(strings.ToLower(factory.cfg.Scheme))
 
 	if scheme != "http" && scheme != "https" {
@@ -84,10 +88,6 @@ func (factory *FilterFactory) Config() interface{} {
 
 	factory.cfg.Scheme = scheme
 
-	return factory.cfg
-}
-
-func (factory *FilterFactory) Apply() error {
 	cfg := factory.cfg
 	client := http.Client{
 		Timeout: cfg.Timeout,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Add a new config field ```scheme``` to httpproxy filter. This commit makes pixiu to make https call through httpproxy filter by explicitly specifying ```scheme: "https"```.

If the scheme field is not specified, it uses http as default scheme, which is compatible with previous implementations.
 
```yaml
http_filters:
  - name: dgp.filter.http.httpproxy
    config:
      maxIdleConns: 100
      maxIdleConnsPerHost: 100
      maxConnsPerHost: 100
      scheme: "https"
```