### PR TITLE
fix: Correct logger hotreload logic

### DIFF
--- a/pkg/hotreload/logger.go
+++ b/pkg/hotreload/logger.go
@@ -18,9 +18,12 @@
 package hotreload
 
 import (
+	"go.uber.org/zap"
+)
+
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
-	"go.uber.org/zap"
 )
 
 // LoggerReloader implements the HotReloader interface for reloading logger configurations.

--- a/pkg/hotreload/logger.go
+++ b/pkg/hotreload/logger.go
@@ -20,6 +20,7 @@ package hotreload
 import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
+	"go.uber.org/zap"
 )
 
 // LoggerReloader implements the HotReloader interface for reloading logger configurations.
@@ -30,12 +31,12 @@ func (r *LoggerReloader) CheckUpdate(oldConfig, newConfig *model.Bootstrap) bool
 	oc := oldConfig.Log
 	nc := newConfig.Log
 
-	if oc == nil && nc != nil {
+	if nc == nil && oc != nil {
 		return true
-	}
-
-	if oc != nil && nc == nil {
+	} else if nc == nil && oc == nil {
 		return false
+	} else if nc != nil && oc == nil {
+		return true
 	}
 
 	// Check if any logger configuration fields have changed.
@@ -67,7 +68,11 @@ func (r *LoggerReloader) CheckUpdate(oldConfig, newConfig *model.Bootstrap) bool
 
 // HotReload applies the new logger configuration.
 func (r *LoggerReloader) HotReload(oldConfig, newConfig *model.Bootstrap) error {
-	if err := logger.HotReload(newConfig.Log.Build()); err != nil {
+	var newConfBuild *zap.Config
+	if newConfig.Log != nil {
+		newConfBuild = newConfig.Log.Build()
+	}
+	if err := logger.HotReload(newConfBuild); err != nil {
 		logger.Errorf("Failed to reload logger configuration: %v", err)
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

- fix: #681 
- In previous implemention, if we want to hotreload logger's config and the new config is nil, panic will happen. This pr fixs this issue and if the logger's new config is nil, it loads default config instead of panic.