### PR TITLE
[AI] feat: Implement LLM proxy filter with retry and fallback mechanisms

### DIFF
--- a/pkg/common/constant/key.go
+++ b/pkg/common/constant/key.go
@@ -52,6 +52,7 @@ const (
 	DubboHttpFilter  = "dgp.filter.dubbo.http"
 	DubboProxyFilter = "dgp.filter.dubbo.proxy"
 
+	LLMProxyFilter     = "dgp.filter.llm.proxy"
 	LLMTokenizerFilter = "dgp.filter.llm.tokenizer"
 )
 

--- a/pkg/common/http/manager.go
+++ b/pkg/common/http/manager.go
@@ -100,7 +100,7 @@ func (hcm *HttpConnectionManager) handleHTTPRequest(c *pch.HttpContext) {
 	// recover any err when filterChain run
 	defer func() {
 		if err := recover(); err != nil {
-			logger.Warnf("[dubbopixiu go] Occur An Unexpected Err: %+v", err)
+			logger.Warnf("[dubbo-go-pixiu] Occur An Unexpected Err: %+v", err)
 			c.SendLocalReply(stdHttp.StatusInternalServerError, []byte(fmt.Sprintf("Occur An Unexpected Err: %v", err)))
 		}
 	}()

--- a/pkg/common/util/response.go
+++ b/pkg/common/util/response.go
@@ -181,7 +181,7 @@ func struct2Map(obj any) map[string]any {
 	return data
 }
 
-// HTTPRespIsSuccessful checks if the HTTP response status code indicates success (2xx).
-func HTTPRespIsSuccessful(statusCode int) bool {
+// IsHTTPRespSuccessful checks if the HTTP response status code indicates success (2xx).
+func IsHTTPRespSuccessful(statusCode int) bool {
 	return statusCode >= 200 && statusCode < 300
 }

--- a/pkg/common/util/response.go
+++ b/pkg/common/util/response.go
@@ -180,3 +180,7 @@ func struct2Map(obj any) map[string]any {
 	}
 	return data
 }
+
+func HTTPRespIsSuccessful(statusCode int) bool {
+	return statusCode >= 200 && statusCode < 300
+}

--- a/pkg/common/util/response.go
+++ b/pkg/common/util/response.go
@@ -181,6 +181,7 @@ func struct2Map(obj any) map[string]any {
 	return data
 }
 
+// HTTPRespIsSuccessful checks if the HTTP response status code indicates success (2xx).
 func HTTPRespIsSuccessful(statusCode int) bool {
 	return statusCode >= 200 && statusCode < 300
 }

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -158,7 +158,7 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 FALLBACK:
 	for {
 	RETRY:
-		for retry := uint(0); retry < endpoint.LLMMeta.RetryTimes; retry++ {
+		for retry := uint(0); retry <= endpoint.LLMMeta.RetryTimes; retry++ {
 			req, err = f.assembleRequest(endpoint, r)
 			if err != nil {
 				break RETRY
@@ -174,12 +174,15 @@ FALLBACK:
 				break RETRY
 			}
 			if util.HTTPRespIsSuccessful(resp.StatusCode) {
+				// If the response is successful, we can break out of the fallback loop.
 				break FALLBACK
 			}
+			// If the response is not successful, we will retry with the next endpoint.
 			logger.Debugf("[dubbo-go-pixiu] client retry endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())
 		}
 
 		if !endpoint.LLMMeta.Fallback {
+			// If fallback is not enabled, we will break out of the fallback loop.
 			break FALLBACK
 		}
 
@@ -188,6 +191,7 @@ FALLBACK:
 			break FALLBACK
 		}
 
+		// If we have a next endpoint, we will retry with the next endpoint.
 		logger.Debugf("[dubbo-go-pixiu] client fallback to endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())
 	}
 

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
+	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
+	"github.com/apache/dubbo-go-pixiu/pkg/common/util"
+	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
+	"github.com/apache/dubbo-go-pixiu/pkg/logger"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+	"github.com/apache/dubbo-go-pixiu/pkg/server"
+)
+
+const (
+	// Kind is the kind of Fallback.
+	Kind = constant.LLMProxyFilter
+)
+
+func init() {
+	filter.RegisterHttpFilter(&Plugin{})
+}
+
+type (
+	// Plugin is http filter plugin.
+	Plugin struct {
+	}
+	// FilterFactory is http filter instance
+	FilterFactory struct {
+		cfg    *Config
+		client http.Client
+	}
+	Filter struct {
+		client http.Client
+		scheme string
+	}
+	// Config describe the config of FilterFactory
+	Config struct {
+		Timeout             time.Duration `yaml:"timeout" json:"timeout,omitempty"`
+		MaxIdleConns        int           `yaml:"maxIdleConns" json:"maxIdleConns,omitempty"`
+		MaxIdleConnsPerHost int           `yaml:"maxIdleConnsPerHost" json:"maxIdleConnsPerHost,omitempty"`
+		MaxConnsPerHost     int           `yaml:"maxConnsPerHost" json:"maxConnsPerHost,omitempty"`
+		Scheme              string        `yaml:"scheme" json:"scheme,omitempty" default:"http"`
+	}
+)
+
+func (p *Plugin) Kind() string {
+	return Kind
+}
+
+func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
+	return &FilterFactory{cfg: &Config{}}, nil
+}
+
+func (factory *FilterFactory) Config() any {
+	return factory.cfg
+}
+
+func (factory *FilterFactory) Apply() error {
+	scheme := strings.TrimSpace(strings.ToLower(factory.cfg.Scheme))
+
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("%s: scheme must be http or https", Kind)
+	}
+
+	factory.cfg.Scheme = scheme
+
+	cfg := factory.cfg
+	client := http.Client{
+		Timeout: cfg.Timeout,
+		Transport: http.RoundTripper(&http.Transport{
+			MaxIdleConns:        cfg.MaxIdleConns,
+			MaxIdleConnsPerHost: cfg.MaxIdleConnsPerHost,
+			MaxConnsPerHost:     cfg.MaxConnsPerHost,
+		}),
+	}
+	factory.client = client
+	return nil
+}
+
+func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, chain filter.FilterChain) error {
+	//reuse http client
+	f := &Filter{factory.client, factory.cfg.Scheme}
+	chain.AppendDecodeFilters(f)
+	return nil
+}
+
+func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
+	logger.SetLoggerLevel("debug")
+	rEntry := hc.GetRouteEntry()
+	if rEntry == nil {
+		panic("no route entry")
+	}
+
+	logger.Debugf("[dubbo-go-pixiu] client choose endpoint from cluster: %v", rEntry.Cluster)
+
+	var (
+		clusterName    = rEntry.Cluster
+		clusterManager = server.GetClusterManager()
+		endpoint       = clusterManager.PickEndpoint(clusterName, hc)
+	)
+
+	if endpoint == nil {
+		logger.Debugf("[dubbo-go-pixiu] cluster not found endpoint")
+		bt, _ := json.Marshal(contexthttp.ErrResponse{Message: "cluster not found endpoint"})
+		hc.SendLocalReply(http.StatusServiceUnavailable, bt)
+		return filter.Stop
+	}
+
+	r := hc.Request
+
+	var (
+		req  *http.Request
+		resp *http.Response
+		err  error
+	)
+
+	var bodyBytes []byte
+	if r.Body != nil {
+		bodyBytes, err = io.ReadAll(r.Body)
+		if err != nil {
+			bt, _ := json.Marshal(contexthttp.ErrResponse{Message: fmt.Sprintf("failed to read request body: %v", err)})
+			hc.SendLocalReply(http.StatusInternalServerError, bt)
+			return filter.Stop
+		}
+		r.Body.Close() // Close the original body
+	}
+
+	logger.Debugf("[dubbo-go-pixiu] client choose endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())
+
+	// make request
+FALLBACK:
+	for {
+	RETRY:
+		for retry := uint(0); retry < endpoint.LLMMeta.RetryTimes; retry++ {
+			req, err = f.assembleRequest(endpoint, r)
+			if err != nil {
+				break RETRY
+			}
+			if bodyBytes != nil {
+				req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				// Also reset the ContentLength, as it's based on the body.
+				req.ContentLength = int64(len(bodyBytes))
+			}
+
+			resp, err = f.client.Do(req)
+			if err != nil {
+				break RETRY
+			}
+			if util.HTTPRespIsSuccessful(resp.StatusCode) {
+				break FALLBACK
+			}
+			logger.Debugf("[dubbo-go-pixiu] client retry endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())
+		}
+
+		if !endpoint.LLMMeta.Fallback {
+			break FALLBACK
+		}
+
+		endpoint = clusterManager.PickNextEndpoint(clusterName, endpoint.ID)
+		if endpoint == nil {
+			break FALLBACK
+		}
+
+		logger.Debugf("[dubbo-go-pixiu] client fallback to endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())
+	}
+
+	if err != nil {
+		var urlErr *url.Error
+		ok := errors.As(err, &urlErr)
+		if ok && urlErr.Timeout() {
+			hc.SendLocalReply(http.StatusGatewayTimeout, []byte(err.Error()))
+			return filter.Stop
+		}
+		hc.SendLocalReply(http.StatusServiceUnavailable, []byte(err.Error()))
+		return filter.Stop
+	}
+
+	logger.Debugf("[dubbo-go-pixiu] client call resp:%v", resp)
+	hc.SourceResp = resp
+	// response write in hcm
+	return filter.Continue
+
+}
+
+func (f *Filter) assembleRequest(endpoint *model.Endpoint, r *http.Request) (*http.Request, error) {
+	parsedURL := url.URL{
+		Host:     endpoint.Address.GetAddress(),
+		Scheme:   f.scheme,
+		Path:     r.URL.Path,
+		RawQuery: r.URL.RawQuery,
+	}
+
+	req, err := http.NewRequest(r.Method, parsedURL.String(), r.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = r.Header
+
+	return req, nil
+}

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -144,13 +144,19 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 		err  error
 	)
 
-	var bodyBytes []byte
-	if r.Body != nil {
-		bodyBytes, err = io.ReadAll(r.Body)
+	if hc.Request.Body != nil && hc.Request.GetBody == nil {
+		bodyBytes, err := io.ReadAll(hc.Request.Body)
+		hc.Request.Body.Close()
+
 		if err != nil {
 			bt, _ := json.Marshal(contexthttp.ErrResponse{Message: fmt.Sprintf("failed to read request body: %v", err)})
 			hc.SendLocalReply(http.StatusInternalServerError, bt)
 			return filter.Stop
+		}
+
+		hc.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		hc.Request.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
 		}
 	}
 
@@ -164,11 +170,6 @@ FALLBACK:
 			req, err = f.assembleRequest(endpoint, r)
 			if err != nil {
 				break RETRY
-			}
-			if bodyBytes != nil {
-				req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-				// Also reset the ContentLength, as it's based on the body.
-				req.ContentLength = int64(len(bodyBytes))
 			}
 
 			resp, err = f.client.Do(req)

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -135,6 +135,7 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 	}
 
 	r := hc.Request
+	defer r.Body.Close()
 
 	var (
 		req  *http.Request
@@ -150,7 +151,6 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 			hc.SendLocalReply(http.StatusInternalServerError, bt)
 			return filter.Stop
 		}
-		defer r.Body.Close() // Close the original body
 	}
 
 	logger.Debugf("[dubbo-go-pixiu] client choose endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -113,7 +113,6 @@ func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, c
 }
 
 func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
-	logger.SetLoggerLevel("debug")
 	rEntry := hc.GetRouteEntry()
 	if rEntry == nil {
 		panic("no route entry")

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -150,7 +150,7 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 			hc.SendLocalReply(http.StatusInternalServerError, bt)
 			return filter.Stop
 		}
-		r.Body.Close() // Close the original body
+		defer r.Body.Close() // Close the original body
 	}
 
 	logger.Debugf("[dubbo-go-pixiu] client choose endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -115,7 +115,9 @@ func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, c
 func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 	rEntry := hc.GetRouteEntry()
 	if rEntry == nil {
-		panic("no route entry")
+		bt, _ := json.Marshal(contexthttp.ErrResponse{Message: "no route entry"})
+		hc.SendLocalReply(http.StatusBadRequest, bt)
+		return filter.Stop
 	}
 
 	logger.Debugf("[dubbo-go-pixiu] client choose endpoint from cluster: %v", rEntry.Cluster)

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -40,7 +40,6 @@ import (
 )
 
 const (
-	// Kind is the kind of Fallback.
 	Kind = constant.LLMProxyFilter
 )
 
@@ -169,14 +168,16 @@ FALLBACK:
 		for retry := uint(0); retry <= endpoint.LLMMeta.RetryTimes; retry++ {
 			req, err = f.assembleRequest(endpoint, r)
 			if err != nil {
+				logger.Warnf("[dubbo-go-pixiu] client assemble request failed: %v", err)
 				break RETRY
 			}
 
 			resp, err = f.client.Do(req)
 			if err != nil {
+				logger.Warnf("[dubbo-go-pixiu] client call endpoint [%s: %v] failed: %v", endpoint.ID, endpoint.Address.GetAddress(), err)
 				break RETRY
 			}
-			if util.HTTPRespIsSuccessful(resp.StatusCode) {
+			if util.IsHTTPRespSuccessful(resp.StatusCode) {
 				// If the response is successful, we can break out of the fallback loop.
 				break FALLBACK
 			}

--- a/pkg/model/llm.go
+++ b/pkg/model/llm.go
@@ -32,8 +32,10 @@ import (
 type (
 	// LLMMeta LLM metadata for llm call
 	LLMMeta struct {
-		Provider string      `yaml:"provider" json:"provider"`                         // Provider the cluster unique name
-		APIKeys  []LLMAPIKey `yaml:"api_keys" json:"api_keys" mapstructure:"api_keys"` // APIKey the cluster unique name
+		Provider   string      `yaml:"provider" json:"provider"`                                              // Provider the cluster unique name
+		APIKeys    []LLMAPIKey `yaml:"api_keys" json:"api_keys" mapstructure:"api_keys"`                      // APIKey the cluster unique name
+		RetryTimes uint        `yaml:"retry_times" json:"retry_times" mapstructure:"retry_times" default:"0"` // Retry times for failed call
+		Fallback   bool        `yaml:"fallback" json:"fallback" mapstructure:"fallback"`                      // Fallback to other provider if failed
 	}
 
 	LLMAPIKey struct {

--- a/pkg/pluginregistry/registry.go
+++ b/pkg/pluginregistry/registry.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/http/loadbalancer"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/http/proxyrewrite"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/http/remote"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/llm/proxy"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/llm/tokenizer"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/metric"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/filter/network/dubboproxy"

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -160,6 +160,7 @@ func (cm *ClusterManager) PickEndpoint(clusterName string, policy model.LbPolicy
 
 	c := cm.getCluster(clusterName)
 	if c == nil {
+		logger.Warnf("[dubbo-go-pixiu] cluster %s not found", clusterName)
 		return nil
 	}
 	return cm.pickOneEndpoint(c, policy)
@@ -172,6 +173,7 @@ func (cm *ClusterManager) PickNextEndpoint(clusterName string, curEndpointID str
 
 	c := cm.getCluster(clusterName)
 	if c == nil {
+		logger.Warnf("[dubbo-go-pixiu] cluster %s not found", clusterName)
 		return nil
 	}
 

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -157,9 +157,39 @@ func (cm *ClusterManager) PickEndpoint(clusterName string, policy model.LbPolicy
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
 
+	c := cm.getCluster(clusterName)
+	if c == nil {
+		return nil
+	}
+	return cm.pickOneEndpoint(c, policy)
+}
+
+func (cm *ClusterManager) PickNextEndpoint(clusterName string, curEndpointID string) *model.Endpoint {
+	cm.rw.RLock()
+	defer cm.rw.RUnlock()
+
+	c := cm.getCluster(clusterName)
+	if c == nil {
+		return nil
+	}
+
+	for i, endpoint := range c.Endpoints {
+		if endpoint.ID == curEndpointID {
+			// pick next endpoint
+			if i < len(c.Endpoints)-1 {
+				return c.Endpoints[i+1]
+			}
+			return nil // have tried all endpoints
+		}
+	}
+
+	return nil
+}
+
+func (cm *ClusterManager) getCluster(clusterName string) *model.ClusterConfig {
 	for _, c := range cm.store.Config {
 		if c.Name == clusterName {
-			return cm.pickOneEndpoint(c, policy)
+			return c
 		}
 	}
 	return nil

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -153,6 +153,7 @@ func (cm *ClusterManager) CompareAndSetStore(store *ClusterStore) bool {
 	return true
 }
 
+// PickEndpoint picks an endpoint from the cluster by its name and load balancing policy.
 func (cm *ClusterManager) PickEndpoint(clusterName string, policy model.LbPolicy) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
@@ -164,6 +165,7 @@ func (cm *ClusterManager) PickEndpoint(clusterName string, policy model.LbPolicy
 	return cm.pickOneEndpoint(c, policy)
 }
 
+// PickNextEndpoint picks the next endpoint in the cluster after the current endpoint ID.
 func (cm *ClusterManager) PickNextEndpoint(clusterName string, curEndpointID string) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
@@ -186,6 +188,7 @@ func (cm *ClusterManager) PickNextEndpoint(clusterName string, curEndpointID str
 	return nil
 }
 
+// getCluster returns the cluster configuration by its name.
 func (cm *ClusterManager) getCluster(clusterName string) *model.ClusterConfig {
 	for _, c := range cm.store.Config {
 		if c.Name == clusterName {


### PR DESCRIPTION
### New LLM Proxy Filter Implementation:

* Implemented the `pkg/filter/llm/proxy/filter.go` file, which includes the LLM Proxy filter's logic for handling HTTP requests, retries, and fallbacks. 

### Usage
```yaml
static_resources:
  listeners:
    - name: "llm_proxy"
      protocol_type: "HTTP"
      address:
        socket_address:
          address: "0.0.0.0"
          port: 8888
      filter_chains:
        filters:
          - name: dgp.filter.httpconnectionmanager
            config:
              route_config:
                routes:
                  - match:
                      prefix: "/chat/completions"
                    route:
                      cluster: "chat"
                      cluster_not_found_response_code: 505
              http_filters:
                - name: dgp.filter.llm.proxy
                  config:
                    maxIdleConns: 100
                    maxIdleConnsPerHost: 100
                    maxConnsPerHost: 100
                    scheme: "https"
                # - name: dgp.filter.llm.tokenizer
      config:
        idle_timeout: 5s
        read_timeout: 5s
        write_timeout: 5s
  clusters:
    - name: "chat"
      lb_policy: "lb"
      endpoints:
        - id: 1
          llm_meta:
            provider: "deepseek"
            fallback: true
            retry_times: 5
        - id: 2
          llm_meta:
            provider: "deepseek"
            retry_times: 3
            fallback: true
      health_checks:
        - protocol: "https"
          timeout: 1s
          interval: 5s
          healthy_threshold: 4
          unhealthy_threshold: 4
  shutdown_config:
    timeout: "60s"
    step_timeout: "10s"
    reject_policy: "immediacy"
```