### PR TITLE
feat(ai-gateway): enhance upstream request tracking and metrics reporting

### DIFF
--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -42,7 +42,19 @@ import (
 
 const (
 	Kind = constant.LLMProxyFilter
+	// Context key to pass attempt data from proxy to downstream filters
+	LLMUpstreamAttemptsKey = "llm_upstream_attempts"
 )
+
+// UpstreamAttempt holds details for a single request attempt to an endpoint.
+type UpstreamAttempt struct {
+	EndpointID      string
+	EndpointAddress string
+	ClusterName     string
+	Success         bool
+	StatusCode      int
+	ErrorType       string // e.g., "network_error", "status_code_error"
+}
 
 func init() {
 	filter.RegisterHttpFilter(&Plugin{})
@@ -233,8 +245,9 @@ type Strategy struct{}
 // Execute orchestrates the request lifecycle using dynamic policies from endpoints.
 func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 	var (
-		resp *http.Response
-		err  error
+		resp     *http.Response
+		err      error
+		attempts []UpstreamAttempt
 	)
 
 	// 1. Pick initial endpoint from the cluster
@@ -266,15 +279,31 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 
 			resp, err = executor.filter.client.Do(req)
 
-			if err != nil {
-				logger.Warnf("[dubbo-go-pixiu] request to endpoint [%s: %v] failed: %v", endpoint.ID, endpoint.Address.GetAddress(), err)
-				break // Exit the retry loop on any error
+			attempt := UpstreamAttempt{
+				EndpointID:      endpoint.ID,
+				EndpointAddress: endpoint.Address.GetAddress(),
+				ClusterName:     executor.clusterName,
 			}
 
-			// If success, we are done. Return immediately.
+			if err != nil {
+				logger.Warnf("[dubbo-go-pixiu] request to endpoint [%s: %v] failed: %v", endpoint.ID, endpoint.Address.GetAddress(), err)
+				attempt.Success = false
+				attempt.ErrorType = "network_error"
+				attempts = append(attempts, attempt)
+				break
+			}
+
+			attempt.StatusCode = resp.StatusCode
 			if util.IsHTTPRespSuccessful(resp.StatusCode) {
+				attempt.Success = true
+				attempts = append(attempts, attempt)
+				executor.hc.Params[LLMUpstreamAttemptsKey] = attempts
 				return resp, nil
 			}
+
+			attempt.Success = false
+			attempt.ErrorType = "status_code_error"
+			attempts = append(attempts, attempt)
 
 			logger.Debugf("[dubbo-go-pixiu] attempt failed for endpoint [%s: %v]. Error: %v, Status: %s trying to retry",
 				endpoint.ID, endpoint.Address.GetAddress(), err, resp.Status)
@@ -284,6 +313,8 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 		// Get the next endpoint for fallback. The loop will terminate if it's nil.
 		endpoint = getNextFallbackEndpoint(endpoint, executor)
 	}
+
+	executor.hc.Params[LLMUpstreamAttemptsKey] = attempts
 
 	// 6. If we've exited the loop, all attempts and fallbacks have failed.
 	// Return the last known error and response.

--- a/pkg/filter/llm/tokenizer/tokenizer.go
+++ b/pkg/filter/llm/tokenizer/tokenizer.go
@@ -443,6 +443,9 @@ func registerLLMMetrics() error {
 		instrument.WithDescription("Total number of streaming LLM requests."),
 		instrument.WithUnit("1"),
 	)
+	if err != nil {
+		return err
+	}
 
 	logger.Info("LLM metrics registered successfully.")
 	return nil

--- a/pkg/filter/llm/tokenizer/tokenizer.go
+++ b/pkg/filter/llm/tokenizer/tokenizer.go
@@ -23,9 +23,20 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"go.opentelemetry.io/otel/metric/unit"
 	"io"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
+)
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/instrument/syncfloat64"
+	"go.opentelemetry.io/otel/metric/instrument/syncint64"
 )
 
 import (
@@ -33,13 +44,61 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
 	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
+	"github.com/apache/dubbo-go-pixiu/pkg/filter/llm/proxy"
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
 
 const (
+	// General constants
 	Kind                = constant.LLMTokenizerFilter
 	LoggerFmt           = "[Tokenizer] [DOWNSTREAM] "
 	PromptTokensDetails = "prompt_tokens_details"
+
+	// Metric meter name
+	meterName = "dubbo-go-pixiu.ai-gateway"
+
+	// Attribute Keys for metrics
+	attrClusterName     = "cluster_name"
+	attrEndpointID      = "endpoint_id"
+	attrEndpointAddress = "endpoint_address"
+	attrStatusCode      = "status_code"
+	attrErrorType       = "error_type"
+	attrModel           = "model"
+
+	// JSON Keys from LLM response
+	jsonKeyUsage            = "usage"
+	jsonKeyModel            = "model"
+	jsonKeyPromptTokens     = "prompt_tokens"
+	jsonKeyCompletionTokens = "completion_tokens"
+	jsonKeyTotalTokens      = "total_tokens"
+
+	// Server-Sent Events (SSE) constants
+	sseDone       = "[DONE]"
+	sseDataPrefix = "data:"
+
+	// Metric Names
+	metricPromptTokens      = "pixiu_llm_prompt_tokens_total"
+	metricCompletionTokens  = "pixiu_llm_completion_tokens_total"
+	metricTotalTokens       = "pixiu_llm_total_tokens_total"
+	metricUpstreamRequests  = "pixiu_llm_upstream_requests_total"
+	metricUpstreamSuccess   = "pixiu_llm_upstream_requests_success_total"
+	metricUpstreamFailure   = "pixiu_llm_upstream_requests_failure_total"
+	metricTotalDurationSum  = "pixiu_llm_total_duration_microseconds_sum_total"
+	metricTTFTSum           = "pixiu_llm_time_to_first_token_milliseconds_sum_total"
+	metricStreamingRequests = "pixiu_llm_streaming_requests_total"
+)
+
+var (
+	// Metric Instruments
+	llmPromptTokens                 syncint64.Counter
+	llmCompletionTokens             syncint64.Counter
+	llmTotalTokens                  syncint64.Counter
+	llmUpstreamRequestsTotal        syncint64.Counter
+	llmUpstreamRequestsSuccessTotal syncint64.Counter
+	llmUpstreamRequestsFailureTotal syncint64.Counter
+	llmTotalDurationSum             syncfloat64.Counter
+	llmTimeToFirstTokenSum          syncfloat64.Counter
+	llmStreamingRequestsTotal       syncint64.Counter
 )
 
 func init() {
@@ -47,115 +106,231 @@ func init() {
 }
 
 type (
-	// Plugin is http filter plugin.
-	Plugin struct {
+	Plugin        struct{}
+	FilterFactory struct{ cfg *Config }
+	Filter        struct {
+		cfg            *Config
+		start          time.Time
+		recordTTFTOnce sync.Once
 	}
-	// FilterFactory is http filter instance
-	FilterFactory struct {
-		cfg *Config
-	}
-	// Filter is http filter instance
-	Filter struct {
-		cfg *Config
-	}
-	// Config describes the config of FilterFactory
 	Config struct {
+		LogToConsole bool `yaml:"log_to_console" json:"log_to_console,omitempty" default:"false"`
 	}
 )
 
-func (p *Plugin) Kind() string {
-	return Kind
-}
+func (p *Plugin) Kind() string { return Kind }
 
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 	return &FilterFactory{cfg: &Config{}}, nil
 }
 
-func (factory *FilterFactory) Config() any {
-	return factory.cfg
-}
+func (factory *FilterFactory) Config() any { return factory.cfg }
 
-func (factory *FilterFactory) Apply() error {
-	return nil
-}
+func (factory *FilterFactory) Apply() error { return registerLLMMetrics() }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{
-		cfg: factory.cfg,
-	}
+	f := &Filter{cfg: factory.cfg}
+	chain.AppendDecodeFilters(f)
 	chain.AppendEncodeFilters(f)
 	return nil
 }
 
-func (f *Filter) Encode(hc *contexthttp.HttpContext) filter.FilterStatus {
-	encoding := hc.Writer.Header().Get(constant.HeaderKeyContentEncoding)
+func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
+	f.start = time.Now()
+	return filter.Continue
+}
 
+func (f *Filter) Encode(hc *contexthttp.HttpContext) filter.FilterStatus {
+	// Report all metrics from a central place
+	f.reportUpstreamMetrics(hc)
+	f.reportTotalDurationMetric(hc)
+
+	// Handle response body for token counting and TTFT
+	encoding := hc.Writer.Header().Get(constant.HeaderKeyContentEncoding)
 	switch res := hc.TargetResp.(type) {
 	case *client.StreamResponse:
 		pr, pw := io.Pipe()
 		res.Stream = newTeeReadCloser(res.Stream, pw)
-		go f.processStreamResponse(pr, encoding)
+		go f.processStreamResponse(hc, pr, encoding)
 	case *client.UnaryResponse:
-		f.processUsageData(res.Data, encoding) // Unary response is not a stream
+		f.processUnaryResponse(hc, res.Data, encoding)
 	default:
-		logger.Warnf(LoggerFmt+"Response type not suitable for token calc: %T", res)
+		logger.Warnf(LoggerFmt+"Response type not suitable for token calculation: %T", res)
 	}
-
 	return filter.Continue
 }
 
-func (f *Filter) processStreamResponse(body io.Reader, encoding string) {
-	// For streams, we decompress the entire stream first, then process its content.
-	// The content itself (with "data:" prefixes) is passed to processUsageData.
-	decompressedData, ok := decompress(body, encoding)
+// reportUpstreamMetrics reads attempt data from context and reports endpoint-level metrics.
+func (f *Filter) reportUpstreamMetrics(hc *contexthttp.HttpContext) {
+	attemptsVal, ok := hc.Params[proxy.LLMUpstreamAttemptsKey]
 	if !ok {
+		return // No attempt data found, likely not an LLM proxy request
+	}
+	attempts, ok := attemptsVal.([]proxy.UpstreamAttempt)
+	if !ok {
+		logger.Warnf(LoggerFmt+"Upstream attempt data in context has wrong type: %T", attemptsVal)
 		return
 	}
 
-	decompressedDataTrim := strings.TrimPrefix(string(decompressedData), "data:")
+	for _, attempt := range attempts {
+		attrs := []attribute.KeyValue{
+			attribute.String(attrClusterName, attempt.ClusterName),
+			attribute.String(attrEndpointID, attempt.EndpointID),
+			attribute.String(attrEndpointAddress, attempt.EndpointAddress),
+		}
 
-	// Now process the fully decompressed stream data
-	f.processUsageData([]byte(decompressedDataTrim), "")
+		llmUpstreamRequestsTotal.Add(hc.Ctx, 1, attrs...)
+
+		if attempt.Success {
+			successAttrs := append(attrs, attribute.String(attrStatusCode, strconv.Itoa(attempt.StatusCode)))
+			llmUpstreamRequestsSuccessTotal.Add(hc.Ctx, 1, successAttrs...)
+		} else {
+			failureAttrs := append(attrs,
+				attribute.String(attrStatusCode, strconv.Itoa(attempt.StatusCode)),
+				attribute.String(attrErrorType, attempt.ErrorType),
+			)
+			llmUpstreamRequestsFailureTotal.Add(hc.Ctx, 1, failureAttrs...)
+		}
+	}
 }
 
-func (f *Filter) processUsageData(data []byte, encoding string) {
+// reportTotalDurationMetric calculates and reports the total request-response duration.
+func (f *Filter) reportTotalDurationMetric(hc *contexthttp.HttpContext) {
+	totalDuration := time.Since(f.start)
+	clusterName := "unknown"
+	if rEntry := hc.GetRouteEntry(); rEntry != nil {
+		clusterName = rEntry.Cluster
+	}
+	durationAttrs := []attribute.KeyValue{
+		attribute.String(attrClusterName, clusterName),
+		attribute.String(attrStatusCode, strconv.Itoa(hc.GetStatusCode())),
+	}
+	llmTotalDurationSum.Add(hc.Ctx, float64(totalDuration.Microseconds()), durationAttrs...)
+}
+
+// processStreamResponse handles streaming responses to calculate TTFT and count tokens.
+func (f *Filter) processStreamResponse(hc *contexthttp.HttpContext, body io.Reader, encoding string) {
+	streamStartTime := time.Now()
+	decompressedReader, err := getDecompressedReader(body, encoding)
+	if err != nil {
+		logger.Errorf(LoggerFmt+"could not create decompressing reader: %v", err)
+		return
+	}
+	defer decompressedReader.Close()
+
+	buf := make([]byte, 4096)
+	var eventBuffer bytes.Buffer
+
+	for {
+		n, err := decompressedReader.Read(buf)
+		if n > 0 {
+			eventBuffer.Write(buf[:n])
+			for {
+				event, remaining, found := splitSSEEvent(eventBuffer.Bytes())
+				if !found {
+					break
+				}
+				jsonData := strings.TrimSpace(strings.TrimPrefix(string(event), sseDataPrefix))
+				if len(jsonData) > 0 {
+					f.parseAndReportTokens(hc, []byte(jsonData))
+				}
+				eventBuffer.Reset()
+				eventBuffer.Write(remaining)
+			}
+		}
+
+		if err == io.EOF {
+			if eventBuffer.Len() > 0 {
+				jsonData := strings.TrimSpace(strings.TrimPrefix(eventBuffer.String(), sseDataPrefix))
+				if len(jsonData) > 0 {
+					f.parseAndReportTokens(hc, []byte(jsonData))
+				}
+			}
+			break
+		}
+		if err != nil {
+			logger.Errorf(LoggerFmt+"error reading decompressed stream: %v", err)
+			break
+		}
+	}
+
+	// On the very first successful read, record Time to First Token.
+	f.recordTTFTOnce.Do(func() {
+		ttft := time.Since(streamStartTime)
+		clusterName := "unknown"
+		if rEntry := hc.GetRouteEntry(); rEntry != nil {
+			clusterName = rEntry.Cluster
+		}
+		attrs := attribute.String(attrClusterName, clusterName)
+
+		llmTimeToFirstTokenSum.Add(hc.Ctx, float64(ttft.Milliseconds()), attrs)
+		llmStreamingRequestsTotal.Add(hc.Ctx, 1, attrs)
+	})
+}
+
+// splitSSEEvent finds the next complete SSE event (ending in \n\n) in a byte slice.
+func splitSSEEvent(data []byte) (event, remaining []byte, found bool) {
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
+		return data[:i], data[i+2:], true
+	}
+	return nil, data, false
+}
+
+// processUnaryResponse handles non-streaming responses for token counting.
+func (f *Filter) processUnaryResponse(hc *contexthttp.HttpContext, data []byte, encoding string) {
 	processedData := data
-	// Decompress data if an encoding is specified (primarily for unary responses)
 	if encoding != "" {
 		bodyReader := bytes.NewReader(data)
 		if decompressedData, ok := decompress(bodyReader, encoding); ok {
 			processedData = decompressedData
 		}
 	}
-
 	if len(processedData) == 0 {
 		return
 	}
-
-	f.parseAndLogUsage(processedData)
+	f.parseAndReportTokens(hc, processedData)
 }
 
-// parseAndLogUsage is a helper to parse the final JSON data and log it.
-func (f *Filter) parseAndLogUsage(data []byte) {
-	if len(data) == 0 {
+// parseAndReportTokens parses a JSON data chunk and reports token usage metrics.
+func (f *Filter) parseAndReportTokens(hc *contexthttp.HttpContext, data []byte) {
+	if len(data) == 0 || string(data) == sseDone {
 		return
 	}
 	var dataCont map[string]any
-	err := json.Unmarshal(data, &dataCont)
-	if err != nil {
-		// Suppress unmarshal errors for potentially incomplete stream chunks
+	if err := json.Unmarshal(data, &dataCont); err != nil {
 		return
 	}
-
-	usage, ok := dataCont["usage"].(map[string]any)
+	usage, ok := dataCont[jsonKeyUsage].(map[string]any)
 	if !ok || usage == nil {
 		return
 	}
-
-	// todo: currently we only log the usage, we should export it to metrics
-	f.logUsage(usage)
+	if f.cfg.LogToConsole {
+		f.logUsage(usage)
+	}
+	modelName := "unknown"
+	if m, ok := dataCont[jsonKeyModel].(string); ok {
+		modelName = m
+	}
+	clusterName := "unknown"
+	if rEntry := hc.GetRouteEntry(); rEntry != nil {
+		clusterName = rEntry.Cluster
+	}
+	tokenAttrs := []attribute.KeyValue{
+		attribute.String(attrModel, modelName),
+		attribute.String(attrClusterName, clusterName),
+	}
+	if pTokens, ok := usage[jsonKeyPromptTokens].(float64); ok {
+		llmPromptTokens.Add(hc.Ctx, int64(pTokens), tokenAttrs...)
+	}
+	if cTokens, ok := usage[jsonKeyCompletionTokens].(float64); ok {
+		llmCompletionTokens.Add(hc.Ctx, int64(cTokens), tokenAttrs...)
+	}
+	if tTokens, ok := usage[jsonKeyTotalTokens].(float64); ok {
+		llmTotalTokens.Add(hc.Ctx, int64(tTokens), tokenAttrs...)
+	}
 }
 
+// logUsage prints usage details to the log.
 func (f *Filter) logUsage(usage map[string]any) {
 	for key, value := range usage {
 		if key == PromptTokensDetails {
@@ -185,6 +360,7 @@ func getDecompressedReader(body io.Reader, encoding string) (io.ReadCloser, erro
 	}
 }
 
+// decompress reads all data from a reader and returns the decompressed byte slice.
 func decompress(body io.Reader, encoding string) ([]byte, bool) {
 	decompressedReader, err := getDecompressedReader(body, encoding)
 	if err != nil {
@@ -200,6 +376,81 @@ func decompress(body io.Reader, encoding string) ([]byte, bool) {
 	}
 	return decompressedData, true
 }
+
+// registerLLMMetrics creates and registers all metrics for this plugin.
+func registerLLMMetrics() error {
+	meter := global.MeterProvider().Meter(meterName)
+	var err error
+
+	llmPromptTokens, err = meter.SyncInt64().Counter(metricPromptTokens,
+		instrument.WithDescription("Total prompt tokens."),
+		instrument.WithUnit("1"))
+	if err != nil {
+		return err
+	}
+	llmCompletionTokens, err = meter.SyncInt64().Counter(metricCompletionTokens,
+		instrument.WithDescription("Total completion tokens."),
+		instrument.WithUnit("1"))
+	if err != nil {
+		return err
+	}
+	llmTotalTokens, err = meter.SyncInt64().Counter(metricTotalTokens,
+		instrument.WithDescription("Total tokens."),
+		instrument.WithUnit("1"))
+	if err != nil {
+		return err
+	}
+
+	llmUpstreamRequestsTotal, err = meter.SyncInt64().Counter(metricUpstreamRequests,
+		instrument.WithDescription("Total requests to upstream endpoints."),
+		instrument.WithUnit("1"))
+	if err != nil {
+		return err
+	}
+	llmUpstreamRequestsSuccessTotal, err = meter.SyncInt64().Counter(metricUpstreamSuccess,
+		instrument.WithDescription("Total successful requests to upstream endpoints."),
+		instrument.WithUnit("1"))
+	if err != nil {
+		return err
+	}
+	llmUpstreamRequestsFailureTotal, err = meter.SyncInt64().Counter(metricUpstreamFailure,
+		instrument.WithDescription("Total failed requests to upstream endpoints."),
+		instrument.WithUnit("1"))
+	if err != nil {
+		return err
+	}
+
+	llmTotalDurationSum, err = meter.SyncFloat64().Counter(
+		metricTotalDurationSum,
+		instrument.WithDescription("Sum of total duration of LLM requests in microseconds."),
+		instrument.WithUnit(unit.Unit("µs")),
+	)
+	if err != nil {
+		return err
+	}
+
+	llmTimeToFirstTokenSum, err = meter.SyncFloat64().Counter(
+		metricTTFTSum,
+		instrument.WithDescription("Sum of Time to First Token for streaming responses in milliseconds."),
+		instrument.WithUnit("ms"),
+	)
+	if err != nil {
+		return err
+	}
+
+	llmStreamingRequestsTotal, err = meter.SyncInt64().Counter(
+		metricStreamingRequests,
+		instrument.WithDescription("Total number of streaming LLM requests."),
+		instrument.WithUnit("1"),
+	)
+
+	logger.Info("LLM metrics registered successfully.")
+	return nil
+}
+
+// --- TeeReadCloser Implementation ---
+// This is necessary to read the response body for tokenizing without consuming it,
+// so the original response can still be sent to the client.
 
 type teeReadCloser struct {
 	reader   io.Reader
@@ -219,19 +470,17 @@ func newTeeReadCloser(r io.ReadCloser, w io.Writer) *teeReadCloser {
 
 func (t *teeReadCloser) Read(p []byte) (n int, err error) {
 	n, err = t.reader.Read(p)
-	if n <= 0 || err != nil {
-		return
+	if n > 0 {
+		nw, writeErr := t.writer.Write(p[:n])
+		if writeErr != nil {
+			logger.Errorf(LoggerFmt+"Error writing to tee writer: %v", writeErr)
+			return n, err // Return original read error, but log the write error
+		}
+		if nw != n {
+			logger.Errorf(LoggerFmt+"Short write to tee writer: %d/%d", nw, n)
+		}
 	}
-	nw, err := t.writer.Write(p[:n])
-	if err != nil {
-		logger.Errorf(LoggerFmt+"Error writing to tee writer: %v", err)
-		return
-	}
-	if nw != n {
-		logger.Errorf(LoggerFmt+"Short write to tee writer: %d/%d", nw, n)
-		//err = fmt.Errorf("short write to tee writer: %d/%d", nw, n)
-	}
-	return n, nil
+	return n, err
 }
 
 func (t *teeReadCloser) Close() (err error) {
@@ -239,7 +488,6 @@ func (t *teeReadCloser) Close() (err error) {
 		closerErr error
 		writerErr error
 	)
-
 	t.once.Do(func() {
 		closerErr = t.closer.Close()
 		if closerErr != nil {
@@ -247,8 +495,7 @@ func (t *teeReadCloser) Close() (err error) {
 		}
 
 		if t.writer != nil {
-			writerCloser, ok := t.writer.(io.Closer)
-			if ok {
+			if writerCloser, ok := t.writer.(io.Closer); ok {
 				writerErr = writerCloser.Close()
 				if writerErr != nil {
 					logger.Errorf(LoggerFmt+"Error closing writer: %v", writerErr)

--- a/pkg/filter/llm/tokenizer/tokenizer.go
+++ b/pkg/filter/llm/tokenizer/tokenizer.go
@@ -54,6 +54,7 @@ const (
 	Kind                = constant.LLMTokenizerFilter
 	LoggerFmt           = "[Tokenizer] [DOWNSTREAM] "
 	PromptTokensDetails = "prompt_tokens_details"
+	StreamBufferSIze    = 4096
 
 	// Metric meter name
 	meterName = "dubbo-go-pixiu.ai-gateway"
@@ -85,7 +86,7 @@ const (
 	metricUpstreamSuccess   = "pixiu_llm_upstream_requests_success_total"
 	metricUpstreamFailure   = "pixiu_llm_upstream_requests_failure_total"
 	metricTotalDurationSum  = "pixiu_llm_total_duration_microseconds_sum_total"
-	metricTTFTSum           = "pixiu_llm_time_to_first_token_milliseconds_sum_total"
+	metricTTLTSum           = "pixiu_llm_time_to_last_token_milliseconds_sum_total"
 	metricStreamingRequests = "pixiu_llm_streaming_requests_total"
 )
 
@@ -98,7 +99,7 @@ var (
 	llmUpstreamRequestsSuccessTotal syncint64.Counter
 	llmUpstreamRequestsFailureTotal syncint64.Counter
 	llmTotalDurationSum             syncfloat64.Counter
-	llmTimeToFirstTokenSum          syncfloat64.Counter
+	llmTimeToLastTokenSum           syncfloat64.Counter
 	llmStreamingRequestsTotal       syncint64.Counter
 )
 
@@ -219,7 +220,7 @@ func (f *Filter) processStreamResponse(hc *contexthttp.HttpContext, body io.Read
 	}
 	defer decompressedReader.Close()
 
-	buf := make([]byte, 4096)
+	buf := make([]byte, StreamBufferSIze)
 	var eventBuffer bytes.Buffer
 
 	for {
@@ -257,14 +258,14 @@ func (f *Filter) processStreamResponse(hc *contexthttp.HttpContext, body io.Read
 
 	// On the very first successful read, record Time to First Token.
 	f.recordTTFTOnce.Do(func() {
-		ttft := time.Since(streamStartTime)
+		ttlt := time.Since(streamStartTime)
 		clusterName := "unknown"
 		if rEntry := hc.GetRouteEntry(); rEntry != nil {
 			clusterName = rEntry.Cluster
 		}
 		attrs := attribute.String(attrClusterName, clusterName)
 
-		llmTimeToFirstTokenSum.Add(hc.Ctx, float64(ttft.Milliseconds()), attrs)
+		llmTimeToLastTokenSum.Add(hc.Ctx, float64(ttlt.Milliseconds()), attrs)
 		llmStreamingRequestsTotal.Add(hc.Ctx, 1, attrs)
 	})
 }
@@ -430,9 +431,9 @@ func registerLLMMetrics() error {
 		return err
 	}
 
-	llmTimeToFirstTokenSum, err = meter.SyncFloat64().Counter(
-		metricTTFTSum,
-		instrument.WithDescription("Sum of Time to First Token for streaming responses in milliseconds."),
+	llmTimeToLastTokenSum, err = meter.SyncFloat64().Counter(
+		metricTTLTSum,
+		instrument.WithDescription("Sum of Time to Last Token for streaming responses in milliseconds."),
 		instrument.WithUnit("ms"),
 	)
 	if err != nil {

--- a/pkg/filter/llm/tokenizer/tokenizer.go
+++ b/pkg/filter/llm/tokenizer/tokenizer.go
@@ -23,7 +23,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"go.opentelemetry.io/otel/metric/unit"
 	"io"
 	"strconv"
 	"strings"
@@ -37,6 +36,7 @@ import (
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/syncfloat64"
 	"go.opentelemetry.io/otel/metric/instrument/syncint64"
+	"go.opentelemetry.io/otel/metric/unit"
 )
 
 import (

--- a/pkg/filter/llm/tokenizer/tokenizer.go
+++ b/pkg/filter/llm/tokenizer/tokenizer.go
@@ -32,6 +32,7 @@ import (
 
 import (
 	"go.opentelemetry.io/otel/attribute"
+
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/syncfloat64"

--- a/pkg/filter/llm/tokenizer/tokenizer_test.go
+++ b/pkg/filter/llm/tokenizer/tokenizer_test.go
@@ -36,6 +36,8 @@ import (
 import (
 	"github.com/apache/dubbo-go-pixiu/pkg/client"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
+	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
+	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/context/mock"
 )
 
@@ -100,7 +102,15 @@ func TestUnaryResponseWithEncodings(t *testing.T) {
 	// Run the tests for each case.
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			filter := &Filter{}
+
+			var (
+				filterFactory = FilterFactory{}
+				filterChain   = filter.NewDefaultFilterChain()
+			)
+
+			filterFactory.cfg = &Config{LogToConsole: true}
+			filterFactory.Apply()
+			filterFactory.PrepareFilterChain(&contexthttp.HttpContext{}, filterChain)
 
 			request, err := http.NewRequest("POST", "http://www.dubbogopixiu.com/mock/test?name=tc", bytes.NewReader([]byte("{\"id\":\"12345\"}")))
 			assert.NoError(t, err)
@@ -115,7 +125,7 @@ func TestUnaryResponseWithEncodings(t *testing.T) {
 			c.AddHeader(constant.HeaderKeyContentEncoding, tc.encoding)
 
 			// Call the filter's Encode method
-			filter.Encode(c)
+			filterChain.OnEncode(c)
 		})
 	}
 }
@@ -179,7 +189,14 @@ func TestStreamResponseWithEncodings(t *testing.T) {
 	// Run the tests for each case.
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			filter := &Filter{}
+			var (
+				filterFactory = FilterFactory{}
+				filterChain   = filter.NewDefaultFilterChain()
+			)
+
+			filterFactory.cfg = &Config{LogToConsole: true}
+			filterFactory.Apply()
+			filterFactory.PrepareFilterChain(&contexthttp.HttpContext{}, filterChain)
 
 			req, err := http.NewRequest("POST", "http://www.dubbogopixiu.com/mock/test?name=tc", bytes.NewReader([]byte("{\"id\":\"12345\"}")))
 			assert.NoError(t, err)
@@ -196,7 +213,7 @@ func TestStreamResponseWithEncodings(t *testing.T) {
 			ctx.AddHeader(constant.HeaderKeyContentEncoding, tc.encoding)
 
 			// Call the filter's Encode method
-			filter.Encode(ctx)
+			filterChain.OnEncode(ctx)
 
 			// Give the goroutine a moment to process the data
 			buf := make([]byte, 1024)


### PR DESCRIPTION
## Export metrics to prometheus and create grafana panel

the demo of this pr, see https://github.com/apache/dubbo-go-pixiu-samples/pull/89

<img width="2770" height="1650" alt="image" src="https://github.com/user-attachments/assets/a16a02f9-fb3d-412e-a739-47acef8432c7" />
<img width="2770" height="1650" alt="image" src="https://github.com/user-attachments/assets/1b407d89-41fb-49df-bf6d-78c206a54d39" />

### 目前支持的指标有：

#### 流量与负载指标 (Traffic & Load)
这些指标反映了网关处理AI请求的基本流量情况。

1. Total QPS (Queries Per Second): 网关当前处理AI请求的总速率，是衡量系统负载的核心指标。

2. Request Rate Trend: 按成功和失败分类的QPS时序图，直观展示流量高峰、低谷以及异常波动。

#### 性能与延迟指标 (Performance & Latency)
这些指标用于评估端到端的响应速度和用户体验。

1. Average TTFT (Time to First Token): 衡量流式请求从开始到收到第一个Token的平均耗时（单位：毫秒）。这是评估大模型响应速度和流式体验的关键指标。

2. Average Total Duration: 衡量请求从开始到完全结束的平均总耗时（单位：微秒），反映了完整的端到端延迟。

3. Latency Trends: TTFT和总耗时的平均值随时间变化的趋势图，便于定位性能抖动和瓶颈。

#### Token消耗与成本指标 (Token Usage & Cost)
这些指标是AI服务成本控制和用量分析的核心。

1. Total Token Rate: 网关当前每秒处理的总Token数（包括输入和输出），是衡量成本速率的实时指标。

2. Token Usage Rate Trend: 按**输入（Prompt）和输出（Completion）**分类的Token消耗速率时序图，可按不同模型（model）进行筛选，清晰地展示了各类模型的成本构成和使用趋势。

#### 健康度与稳定性指标 (Health & Stability)
这些指标帮助您快速诊断服务可用性和潜在问题。

1. Success Rate: AI请求的实时成功率，是衡量服务健康度的最重要指标之一。

2. Endpoint Status Table: 一个详细的表格，按每个上游端点（endpoint_address）展示其QPS、成功率、失败率和平均延迟，是定位单个实例问题的关键工具。

3. Error Breakdown Table: 按HTTP状态码（status_code）和错误类型（error_type）对失败请求进行分类和计数，帮助您快速识别是网络问题还是服务本身返回的错误。