### PR TITLE
fix: Fixed ARM64 Build Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "https://golang.org/dl/go1.25.0.linux-amd64.tar.gz"
+          goversion: "1.25.0"
           project_path: "./cmd/pixiu"
           binary_name: "dubbo-go-pixiu"
           extra_files: LICENSE README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ RUN go mod download
 COPY . .
 
 ENV CGO_ENABLED=1 \
-    GOOS=linux \
-    GOARCH=amd64
+    GOOS=linux
 
 # Here I still remains "wasmer" tag, because we need to build the wasmer plugin
 # if wasm feature is removed in the future, this tag and following wasm related command can be removed


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

 Fixed ARM64 Build Support
    - Modified Dockerfile to remove the hardcoded GOARCH=amd64 setting.
    - This allows the build process to respect the host's native architecture (ARM64 on Apple Silicon), resolving the unrecognized command-line option '-m64' error

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```