### PR TITLE
fix(cluster): complete Issue #905 step 2 correctness for Rand and Rou…

### DIFF
--- a/pkg/cluster/loadbalancer/rand/load_balancer_rand.go
+++ b/pkg/cluster/loadbalancer/rand/load_balancer_rand.go
@@ -32,6 +32,13 @@ func init() {
 
 type Rand struct{}
 
+// randIntn lets tests replace randomness with deterministic choices.
+var randIntn = rand.Intn
+
 func (Rand) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
-	return c.GetEndpoint(true)[rand.Intn(len(c.Endpoints)-1)] // NOSONAR
+	endpoints := c.GetEndpoint(true)
+	if len(endpoints) == 0 {
+		return nil
+	}
+	return endpoints[randIntn(len(endpoints))] // NOSONAR
 }

--- a/pkg/cluster/loadbalancer/rand/load_balancer_rand_test.go
+++ b/pkg/cluster/loadbalancer/rand/load_balancer_rand_test.go
@@ -19,9 +19,13 @@ package rand
 
 import (
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
+)
 
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 

--- a/pkg/cluster/loadbalancer/rand/load_balancer_rand_test.go
+++ b/pkg/cluster/loadbalancer/rand/load_balancer_rand_test.go
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rand
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+// Force Rand to pick index 1 so the test checks which slice length it uses.
+func TestRand_TwoHealthyEndpoints_CanSelectSecondEndpoint(t *testing.T) {
+	originalRandIntn := randIntn
+	randIntn = func(n int) int {
+		assert.Equal(t, 2, n)
+		return 1
+	}
+	defer func() {
+		randIntn = originalRandIntn
+	}()
+
+	cluster := &model.ClusterConfig{
+		Endpoints: []*model.Endpoint{
+			{ID: "ep-1"},
+			{ID: "ep-2"},
+		},
+	}
+
+	var got *model.Endpoint
+	assert.NotPanics(t, func() {
+		got = Rand{}.Handler(cluster, nil)
+	})
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "ep-2", got.ID)
+	}
+}
+
+// With only one healthy endpoint left, Rand must index into the healthy slice, not the full list.
+func TestRand_PartiallyUnhealthyEndpoints_DoesNotIndexPastHealthySlice(t *testing.T) {
+	originalRandIntn := randIntn
+	randIntn = func(n int) int {
+		assert.Equal(t, 1, n)
+		return 0
+	}
+	defer func() {
+		randIntn = originalRandIntn
+	}()
+
+	cluster := &model.ClusterConfig{
+		Endpoints: []*model.Endpoint{
+			{ID: "ep-1", UnHealthy: true},
+			{ID: "ep-2"},
+			{ID: "ep-3", UnHealthy: true},
+		},
+	}
+
+	var got *model.Endpoint
+	assert.NotPanics(t, func() {
+		got = Rand{}.Handler(cluster, nil)
+	})
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "ep-2", got.ID)
+	}
+}
+
+// Rand should return nil before calling randIntn when no healthy endpoints remain.
+func TestRand_AllEndpointsUnhealthy_ReturnsNilWithoutPanic(t *testing.T) {
+	originalRandIntn := randIntn
+	randIntn = func(n int) int {
+		t.Fatalf("randIntn should not be called, got n=%d", n)
+		return 0
+	}
+	defer func() {
+		randIntn = originalRandIntn
+	}()
+
+	cluster := &model.ClusterConfig{
+		Endpoints: []*model.Endpoint{
+			{ID: "ep-1", UnHealthy: true},
+			{ID: "ep-2", UnHealthy: true},
+		},
+	}
+
+	var got *model.Endpoint
+	assert.NotPanics(t, func() {
+		got = Rand{}.Handler(cluster, nil)
+	})
+	assert.Nil(t, got)
+}

--- a/pkg/cluster/loadbalancer/roundrobin/round_robin.go
+++ b/pkg/cluster/loadbalancer/roundrobin/round_robin.go
@@ -19,7 +19,9 @@ package roundrobin
 
 import (
 	"sync/atomic"
+)
 
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )

--- a/pkg/cluster/loadbalancer/roundrobin/round_robin.go
+++ b/pkg/cluster/loadbalancer/roundrobin/round_robin.go
@@ -18,6 +18,8 @@
 package roundrobin
 
 import (
+	"sync/atomic"
+
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
@@ -30,11 +32,10 @@ type RoundRobin struct{}
 
 func (RoundRobin) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
 	endpoints := c.GetEndpoint(true)
-	lens := len(endpoints)
-	if c.PrePickEndpointIndex >= lens {
-		c.PrePickEndpointIndex = 0
+	if len(endpoints) == 0 {
+		return nil
 	}
-	e := endpoints[c.PrePickEndpointIndex]
-	c.PrePickEndpointIndex = (c.PrePickEndpointIndex + 1) % lens
-	return e
+	// AddUint32 returns the incremented value, so subtract 1 for a zero-based index.
+	index := atomic.AddUint32(&c.PrePickEndpointIndex, 1) - 1
+	return endpoints[int(index%uint32(len(endpoints)))]
 }

--- a/pkg/cluster/loadbalancer/roundrobin/round_robin_test.go
+++ b/pkg/cluster/loadbalancer/roundrobin/round_robin_test.go
@@ -19,9 +19,13 @@ package roundrobin
 
 import (
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
+)
 
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 

--- a/pkg/cluster/loadbalancer/roundrobin/round_robin_test.go
+++ b/pkg/cluster/loadbalancer/roundrobin/round_robin_test.go
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package roundrobin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+// RoundRobin should return nil instead of indexing an empty healthy slice.
+func TestRoundRobin_AllEndpointsUnhealthy_ReturnsNilWithoutPanic(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		Endpoints: []*model.Endpoint{
+			{ID: "ep-1", UnHealthy: true},
+			{ID: "ep-2", UnHealthy: true},
+		},
+	}
+
+	var got *model.Endpoint
+	assert.NotPanics(t, func() {
+		got = RoundRobin{}.Handler(cluster, nil)
+	})
+	assert.Nil(t, got)
+}
+
+func TestRoundRobin_RepeatedPicksFollowHealthyOrder(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		Endpoints: []*model.Endpoint{
+			{ID: "ep-1"},
+			{ID: "ep-2"},
+			{ID: "ep-3"},
+		},
+	}
+
+	rr := RoundRobin{}
+	got := []string{
+		rr.Handler(cluster, nil).ID,
+		rr.Handler(cluster, nil).ID,
+		rr.Handler(cluster, nil).ID,
+		rr.Handler(cluster, nil).ID,
+	}
+
+	assert.Equal(t, []string{"ep-1", "ep-2", "ep-3", "ep-1"}, got)
+}
+
+func TestRoundRobin_MixedHealthyEndpointsHonorNonZeroCursor(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		Endpoints: []*model.Endpoint{
+			{ID: "ep-1", UnHealthy: true},
+			{ID: "ep-2"},
+			{ID: "ep-3", UnHealthy: true},
+			{ID: "ep-4"},
+		},
+		PrePickEndpointIndex: 3,
+	}
+
+	rr := RoundRobin{}
+	first := rr.Handler(cluster, nil)
+	second := rr.Handler(cluster, nil)
+
+	if assert.NotNil(t, first) {
+		assert.Equal(t, "ep-4", first.ID)
+	}
+	if assert.NotNil(t, second) {
+		assert.Equal(t, "ep-2", second.ID)
+	}
+}

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -60,7 +60,7 @@ type (
 		ConsistentHash       ConsistentHash      `yaml:"consistent" json:"consistent"` // Consistent hash config info
 		HealthChecks         []HealthCheckConfig `yaml:"health_checks" json:"health_checks"`
 		Endpoints            []*Endpoint         `yaml:"endpoints" json:"endpoints"`
-		PrePickEndpointIndex int
+		PrePickEndpointIndex uint32
 	}
 
 	// EdsClusterConfig todo remove un-used EdsClusterConfig

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -60,7 +60,7 @@ type (
 		ConsistentHash       ConsistentHash      `yaml:"consistent" json:"consistent"` // Consistent hash config info
 		HealthChecks         []HealthCheckConfig `yaml:"health_checks" json:"health_checks"`
 		Endpoints            []*Endpoint         `yaml:"endpoints" json:"endpoints"`
-		PrePickEndpointIndex uint32
+		PrePickEndpointIndex uint32              `yaml:"-" json:"-"` // runtime-only round-robin cursor state
 	}
 
 	// EdsClusterConfig todo remove un-used EdsClusterConfig

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -18,12 +18,19 @@
 package model_test
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
 
+import (
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"
+	"github.com/apache/dubbo-go-pixiu/pkg/common/yaml"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
@@ -68,6 +75,21 @@ func TestClusterConfig_CreateConsistentHashRegistersHash(t *testing.T) {
 	hash, err := cluster.ConsistentHash.Hash.GetHash(cluster.ConsistentHash.Hash.Hash("coverage-key"))
 	require.NoError(t, err)
 	assert.Equal(t, "127.0.0.1:20880", hash)
+}
+
+func TestClusterConfig_PrePickEndpointIndexIsRuntimeOnly(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		Name:                 "runtime-cursor",
+		PrePickEndpointIndex: 7,
+	}
+
+	jsonBytes, err := json.Marshal(cluster)
+	require.NoError(t, err)
+	assert.NotContains(t, strings.ToLower(string(jsonBytes)), "prepickendpointindex")
+
+	yamlBytes, err := yaml.MarshalYML(cluster)
+	require.NoError(t, err)
+	assert.NotContains(t, strings.ToLower(string(yamlBytes)), "prepickendpointindex")
 }
 
 func TestEndpoint_GetHost(t *testing.T) {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 import (
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash" // Register RingHash for consistent-hash tests.
 	"github.com/apache/dubbo-go-pixiu/pkg/common/yaml"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+func TestClusterConfig_GetEndpointFiltersByHealth(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		Endpoints: []*model.Endpoint{
+			{ID: "ep-1"},
+			{ID: "ep-2", UnHealthy: true},
+			{ID: "ep-3"},
+		},
+	}
+
+	all := cluster.GetEndpoint(false)
+	healthy := cluster.GetEndpoint(true)
+
+	require.Len(t, all, 3)
+	require.Len(t, healthy, 2)
+	assert.Equal(t, []string{"ep-1", "ep-3"}, []string{healthy[0].ID, healthy[1].ID})
+}
+
+func TestClusterConfig_CreateConsistentHashRegistersHash(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		LbStr: model.LoadBalancerRingHashing,
+		ConsistentHash: model.ConsistentHash{
+			ReplicaNum:  32,
+			MaxVnodeNum: 1023,
+		},
+		Endpoints: []*model.Endpoint{
+			{
+				ID: "ep-1",
+				Address: model.SocketAddress{
+					Address: "127.0.0.1",
+					Port:    20880,
+				},
+			},
+		},
+	}
+
+	cluster.CreateConsistentHash()
+
+	require.NotNil(t, cluster.ConsistentHash.Hash)
+	hash, err := cluster.ConsistentHash.Hash.GetHash(cluster.ConsistentHash.Hash.Hash("coverage-key"))
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:20880", hash)
+}
+
+func TestEndpoint_GetHost(t *testing.T) {
+	endpoint := model.Endpoint{
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    20880,
+		},
+	}
+
+	assert.Equal(t, "127.0.0.1:20880", endpoint.GetHost())
+}

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -151,6 +151,7 @@ func (cm *ClusterManager) CompareAndSetStore(store *ClusterStore) bool {
 		return false
 	}
 
+	store.carryOverRuntimeStateFrom(cm.store)
 	cm.store = store
 	return true
 }
@@ -385,4 +386,27 @@ func (s *ClusterStore) HasCluster(clusterName string) bool {
 
 func (s *ClusterStore) IncreaseVersion() {
 	atomic.AddInt32(&s.Version, 1)
+}
+
+func (s *ClusterStore) carryOverRuntimeStateFrom(old *ClusterStore) {
+	if s == nil || old == nil {
+		return
+	}
+
+	oldConfigsByName := make(map[string]*model.ClusterConfig, len(old.Config))
+	for _, clusterConfig := range old.Config {
+		if clusterConfig != nil {
+			oldConfigsByName[clusterConfig.Name] = clusterConfig
+		}
+	}
+
+	// Preserve runtime-only load-balancer state when a rebuilt store is swapped in.
+	for _, clusterConfig := range s.Config {
+		if clusterConfig == nil {
+			continue
+		}
+		if oldConfig := oldConfigsByName[clusterConfig.Name]; oldConfig != nil {
+			clusterConfig.PrePickEndpointIndex = oldConfig.PrePickEndpointIndex
+		}
+	}
 }

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -406,7 +406,10 @@ func (s *ClusterStore) carryOverRuntimeStateFrom(old *ClusterStore) {
 			continue
 		}
 		if oldConfig := oldConfigsByName[clusterConfig.Name]; oldConfig != nil {
-			clusterConfig.PrePickEndpointIndex = oldConfig.PrePickEndpointIndex
+			atomic.StoreUint32(
+				&clusterConfig.PrePickEndpointIndex,
+				atomic.LoadUint32(&oldConfig.PrePickEndpointIndex),
+			)
 		}
 	}
 }

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+)
 
-	"github.com/stretchr/testify/require"
-
+import (
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"
@@ -147,8 +147,12 @@ func BenchmarkClusterCompareAndSetStoreMixed(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		if i%20 == 19 {
 			newStore, err := benchmarkFreshStore(cm, names, model.LoadBalancerRoundRobin, 4)
-			require.NoError(b, err)
-			require.True(b, cm.CompareAndSetStore(newStore))
+			if err != nil {
+				b.Fatal(err)
+			}
+			if !cm.CompareAndSetStore(newStore) {
+				b.Fatal("CompareAndSetStore returned false")
+			}
 			continue
 		}
 

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+var (
+	// Keep benchmark results live so the compiler cannot optimize the hot path away.
+	benchmarkEndpointSink  *model.Endpoint
+	benchmarkEndpointsSink []*model.Endpoint
+	benchmarkClusterSink   *model.ClusterConfig
+)
+
+type benchmarkHashPolicy string
+
+func (p benchmarkHashPolicy) GenerateHash() string {
+	return string(p)
+}
+
+func BenchmarkClusterPickEndpointSerial(b *testing.B) {
+	for _, lbType := range []model.LbPolicyType{model.LoadBalancerRand, model.LoadBalancerRoundRobin} {
+		for _, clusterCount := range []int{1, 32, 256, 1024} {
+			b.Run(fmt.Sprintf("%s/clusters=%d", lbType, clusterCount), func(b *testing.B) {
+				cm, names := benchmarkClusterManager(clusterCount, 4, lbType)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					benchmarkEndpointSink = cm.PickEndpoint(names[i%len(names)], nil)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkClusterLookupSerial(b *testing.B) {
+	for _, clusterCount := range []int{1, 32, 256, 1024} {
+		b.Run(fmt.Sprintf("clusters=%d", clusterCount), func(b *testing.B) {
+			cm, names := benchmarkClusterManager(clusterCount, 4, model.LoadBalancerRoundRobin)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cm.rw.RLock()
+				benchmarkClusterSink = cm.getCluster(names[i%len(names)])
+				cm.rw.RUnlock()
+			}
+		})
+	}
+}
+
+func BenchmarkClusterPickEndpointParallel(b *testing.B) {
+	for _, lbType := range []model.LbPolicyType{model.LoadBalancerRand, model.LoadBalancerRoundRobin} {
+		b.Run(string(lbType), func(b *testing.B) {
+			cm, names := benchmarkClusterManager(256, 4, lbType)
+			var workerCounter uint64
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				// Give each worker a stable starting offset once so bookkeeping stays off the hot path.
+				idx := int(atomic.AddUint64(&workerCounter, 1)-1) % len(names)
+				var endpoint *model.Endpoint
+				for pb.Next() {
+					endpoint = cm.PickEndpoint(names[idx], nil)
+					idx++
+					if idx == len(names) {
+						idx = 0
+					}
+				}
+				benchmarkEndpointSink = endpoint
+			})
+		})
+	}
+}
+
+func BenchmarkClusterLoadBalancerHotPathSerial(b *testing.B) {
+	for _, lbType := range []model.LbPolicyType{model.LoadBalancerRand, model.LoadBalancerRoundRobin} {
+		for _, endpointCount := range []int{4, 64, 512} {
+			b.Run(fmt.Sprintf("%s/endpoints=%d", lbType, endpointCount), func(b *testing.B) {
+				cm := &ClusterManager{}
+				cluster := benchmarkClusterConfig("lb-hot-path", lbType, endpointCount, 0)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					benchmarkEndpointSink = cm.pickOneEndpoint(cluster, nil)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkClusterHealthyFilterCost(b *testing.B) {
+	for _, endpointCount := range []int{8, 64, 512} {
+		for _, healthyRatio := range []int{100, 50, 0} {
+			b.Run(fmt.Sprintf("endpoints=%d/healthy=%d", endpointCount, healthyRatio), func(b *testing.B) {
+				cluster := benchmarkClusterConfig("healthy-filter", model.LoadBalancerRoundRobin, endpointCount, 0)
+				healthyCount := endpointCount * healthyRatio / 100
+				for i := healthyCount; i < len(cluster.Endpoints); i++ {
+					cluster.Endpoints[i].UnHealthy = true
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					benchmarkEndpointsSink = cluster.GetEndpoint(true)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkClusterCompareAndSetStoreMixed(b *testing.B) {
+	cm, names := benchmarkClusterManager(128, 4, model.LoadBalancerRoundRobin)
+	readIndex := 0
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%20 == 19 {
+			newStore, err := benchmarkFreshStore(cm, names, model.LoadBalancerRoundRobin, 4)
+			require.NoError(b, err)
+			require.True(b, cm.CompareAndSetStore(newStore))
+			continue
+		}
+
+		benchmarkEndpointSink = cm.PickEndpoint(names[readIndex%len(names)], nil)
+		readIndex++
+	}
+}
+
+func BenchmarkClusterConsistentHashResolve(b *testing.B) {
+	keys := make([]benchmarkHashPolicy, 1024)
+	for i := range keys {
+		keys[i] = benchmarkHashPolicy(fmt.Sprintf("hash-key-%d", i))
+	}
+
+	for _, lbType := range []model.LbPolicyType{model.LoadBalancerRingHashing, model.LoadBalancerMaglevHashing} {
+		b.Run(string(lbType), func(b *testing.B) {
+			cm, names := benchmarkClusterManager(1, 64, lbType)
+			clusterName := names[0]
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkEndpointSink = cm.PickEndpoint(clusterName, keys[i%len(keys)])
+			}
+		})
+	}
+}
+
+func benchmarkClusterManager(clusterCount int, endpointCount int, lbType model.LbPolicyType) (*ClusterManager, []string) {
+	clusters := make([]*model.ClusterConfig, 0, clusterCount)
+	names := make([]string, 0, clusterCount)
+	for i := 0; i < clusterCount; i++ {
+		name := fmt.Sprintf("cluster-%d", i)
+		names = append(names, name)
+		clusters = append(clusters, benchmarkClusterConfig(name, lbType, endpointCount, i*endpointCount))
+	}
+	return testClusterManager(clusters...), names
+}
+
+func benchmarkClusterConfig(name string, lbType model.LbPolicyType, endpointCount int, offset int) *model.ClusterConfig {
+	endpoints := make([]*model.Endpoint, 0, endpointCount)
+	for i := 0; i < endpointCount; i++ {
+		endpoints = append(endpoints, testEndpoint(fmt.Sprintf("%s-ep-%d", name, i), "127.0.0.1", 20000+offset+i))
+	}
+
+	cluster := testCluster(name, lbType, endpoints)
+	switch lbType {
+	case model.LoadBalancerRingHashing:
+		cluster.ConsistentHash = model.ConsistentHash{
+			ReplicaNum:  128,
+			MaxVnodeNum: 4099,
+		}
+	case model.LoadBalancerMaglevHashing:
+		cluster.ConsistentHash = model.ConsistentHash{}
+	}
+	return cluster
+}
+
+func benchmarkFreshStore(cm *ClusterManager, names []string, lbType model.LbPolicyType, endpointCount int) (*ClusterStore, error) {
+	oldStore, err := cm.CloneStore()
+	if err != nil {
+		return nil, err
+	}
+
+	newStore := cm.NewStore(oldStore.Version)
+	for i, name := range names {
+		newStore.AddCluster(benchmarkClusterConfig(name, lbType, endpointCount, i*endpointCount))
+	}
+	return newStore, nil
+}

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 import (
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"     // Register Maglev for benchmark coverage.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"       // Register Rand for benchmark coverage.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"   // Register RingHash for benchmark coverage.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin" // Register RoundRobin for benchmark coverage.
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -18,53 +18,143 @@
 package server
 
 import (
+	"fmt"
+	"sync"
 	"testing"
-)
 
-import (
 	"github.com/stretchr/testify/assert"
-)
 
-import (
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
 func TestClusterManager(t *testing.T) {
-	bs := &model.Bootstrap{
-		StaticResources: model.StaticResources{
-			Clusters: []*model.ClusterConfig{
-				{
-					Name: "test",
-					Endpoints: []*model.Endpoint{
-						{
-							Address: model.SocketAddress{},
-							ID:      "1",
-						},
-					},
+	cm := testClusterManager(
+		testCluster("test", model.LoadBalancerRoundRobin, []*model.Endpoint{
+			testEndpoint("1", "127.0.0.1", 18080),
+		}),
+	)
+
+	assert.Len(t, cm.store.Config, 1)
+
+	cm.AddCluster(testCluster("test2", model.LoadBalancerRoundRobin, []*model.Endpoint{
+		testEndpoint("1", "127.0.0.1", 18081),
+	}))
+
+	assert.Len(t, cm.store.Config, 2)
+
+	cm.SetEndpoint("test2", testEndpoint("2", "127.0.0.1", 18082))
+	assert.Equal(t, "1", cm.PickEndpoint("test", nil).ID)
+	cm.DeleteEndpoint("test2", "1")
+}
+
+func TestClusterManager_PickEndpointReturnsNilForMissingCluster(t *testing.T) {
+	cm := testClusterManager()
+	assert.Nil(t, cm.PickEndpoint("missing-cluster", nil))
+}
+
+func TestClusterManager_PickEndpointSingleUnhealthyReturnsNil(t *testing.T) {
+	cm := testClusterManager(
+		testCluster("single-unhealthy", model.LoadBalancerRoundRobin, []*model.Endpoint{
+			{
+				ID:        "ep-1",
+				Name:      "endpoint-ep-1",
+				UnHealthy: true,
+				Address: model.SocketAddress{
+					Address: "127.0.0.1",
+					Port:    18090,
 				},
 			},
-		},
+		}),
+	)
+
+	assert.Nil(t, cm.PickEndpoint("single-unhealthy", nil))
+}
+
+func TestClusterManager_PickEndpointAllUnhealthyReturnsNil(t *testing.T) {
+	cm := testClusterManager(
+		testCluster("all-unhealthy", model.LoadBalancerRoundRobin, []*model.Endpoint{
+			{
+				ID:        "ep-1",
+				Name:      "endpoint-ep-1",
+				UnHealthy: true,
+				Address: model.SocketAddress{
+					Address: "127.0.0.1",
+					Port:    18091,
+				},
+			},
+			{
+				ID:        "ep-2",
+				Name:      "endpoint-ep-2",
+				UnHealthy: true,
+				Address: model.SocketAddress{
+					Address: "127.0.0.1",
+					Port:    18092,
+				},
+			},
+		}),
+	)
+
+	assert.Nil(t, cm.PickEndpoint("all-unhealthy", nil))
+}
+
+func TestClusterManager_Race_RoundRobinPickEndpoint(t *testing.T) {
+	cluster := testCluster("race-round-robin", model.LoadBalancerRoundRobin, []*model.Endpoint{
+		testEndpoint("ep-1", "127.0.0.1", 19100),
+		testEndpoint("ep-2", "127.0.0.1", 19101),
+		testEndpoint("ep-3", "127.0.0.1", 19102),
+		testEndpoint("ep-4", "127.0.0.1", 19103),
+	})
+	cm := testClusterManager(cluster)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 4000; j++ {
+				_ = cm.PickEndpoint(cluster.Name, nil)
+			}
+		}()
 	}
 
-	cm := CreateDefaultClusterManager(bs)
-	assert.Equal(t, len(cm.store.Config), 1)
+	close(start)
+	wg.Wait()
+}
 
-	cm.AddCluster(&model.ClusterConfig{
-		Name: "test2",
-		Endpoints: []*model.Endpoint{
-			{
-				Address: model.SocketAddress{},
-				ID:      "1",
-			},
+func testClusterManager(clusters ...*model.ClusterConfig) *ClusterManager {
+	return CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: clusters,
 		},
 	})
+}
 
-	assert.Equal(t, len(cm.store.Config), 2)
+func testCluster(name string, lb model.LbPolicyType, endpoints []*model.Endpoint, healthChecks ...model.HealthCheckConfig) *model.ClusterConfig {
+	cluster := &model.ClusterConfig{
+		Name:      name,
+		LbStr:     lb,
+		Endpoints: endpoints,
+	}
+	if len(healthChecks) > 0 {
+		cluster.HealthChecks = append([]model.HealthCheckConfig(nil), healthChecks...)
+	}
+	return cluster
+}
 
-	cm.SetEndpoint("test2", &model.Endpoint{
-		Address: model.SocketAddress{},
-		ID:      "2",
-	})
-	assert.Equal(t, cm.PickEndpoint("test", nil).ID, "1")
-	cm.DeleteEndpoint("test2", "1")
+func testEndpoint(id string, host string, port int) *model.Endpoint {
+	return &model.Endpoint{
+		ID:   id,
+		Name: fmt.Sprintf("endpoint-%s", id),
+		Address: model.SocketAddress{
+			Address: host,
+			Port:    port,
+		},
+	}
 }

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -28,10 +28,10 @@ import (
 )
 
 import (
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"     // Register Maglev for cluster-manager tests.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"       // Register Rand for cluster-manager tests.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"   // Register RingHash for cluster-manager tests.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin" // Register RoundRobin for cluster-manager tests.
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -21,9 +21,13 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
+)
 
+import (
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -105,6 +105,38 @@ func TestClusterManager_PickEndpointAllUnhealthyReturnsNil(t *testing.T) {
 	assert.Nil(t, cm.PickEndpoint("all-unhealthy", nil))
 }
 
+func TestClusterManager_CompareAndSetStorePreservesRoundRobinCursorAcrossRefresh(t *testing.T) {
+	cluster := testCluster("refresh-round-robin", model.LoadBalancerRoundRobin, []*model.Endpoint{
+		testEndpoint("ep-1", "127.0.0.1", 19200),
+		testEndpoint("ep-2", "127.0.0.1", 19201),
+		testEndpoint("ep-3", "127.0.0.1", 19202),
+	})
+	cm := testClusterManager(cluster)
+
+	const expectedCursor uint32 = 5
+	cm.store.Config[0].PrePickEndpointIndex = expectedCursor
+
+	oldStore, err := cm.CloneStore()
+	if !assert.NoError(t, err) {
+		return
+	}
+	newStore := cm.NewStore(oldStore.Version)
+	for _, endpoint := range oldStore.Config[0].Endpoints {
+		copied := *endpoint
+		newStore.SetEndpoint(cluster.Name, &copied)
+	}
+
+	assert.True(t, cm.CompareAndSetStore(newStore))
+	if assert.Len(t, cm.store.Config, 1) {
+		assert.Equal(t, expectedCursor, cm.store.Config[0].PrePickEndpointIndex)
+	}
+
+	endpoint := cm.PickEndpoint(cluster.Name, nil)
+	if assert.NotNil(t, endpoint) {
+		assert.Equal(t, "ep-3", endpoint.ID)
+	}
+}
+
 func TestClusterManager_Race_RoundRobinPickEndpoint(t *testing.T) {
 	cluster := testCluster("race-round-robin", model.LoadBalancerRoundRobin, []*model.Endpoint{
 		testEndpoint("ep-1", "127.0.0.1", 19100),

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -20,6 +20,7 @@ package server
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -114,7 +115,7 @@ func TestClusterManager_CompareAndSetStorePreservesRoundRobinCursorAcrossRefresh
 	cm := testClusterManager(cluster)
 
 	const expectedCursor uint32 = 5
-	cm.store.Config[0].PrePickEndpointIndex = expectedCursor
+	atomic.StoreUint32(&cm.store.Config[0].PrePickEndpointIndex, expectedCursor)
 
 	oldStore, err := cm.CloneStore()
 	if !assert.NoError(t, err) {
@@ -128,7 +129,7 @@ func TestClusterManager_CompareAndSetStorePreservesRoundRobinCursorAcrossRefresh
 
 	assert.True(t, cm.CompareAndSetStore(newStore))
 	if assert.Len(t, cm.store.Config, 1) {
-		assert.Equal(t, expectedCursor, cm.store.Config[0].PrePickEndpointIndex)
+		assert.Equal(t, expectedCursor, atomic.LoadUint32(&cm.store.Config[0].PrePickEndpointIndex))
 	}
 
 	endpoint := cm.PickEndpoint(cluster.Name, nil)


### PR DESCRIPTION
**What this PR does**:

This PR delivers **Step 1 (tests + benchmarks)** and **Step 2 (correctness)** for Issue #905, and is intended to be the first mergeable slice with a clean boundary.

It:
- fixes `Rand` to choose only from the healthy endpoint slice and return `nil` when no healthy endpoint exists
- fixes `RoundRobin` to return `nil` when no healthy endpoint exists
- makes the round-robin cursor safe for concurrent picks
- adds deterministic regression coverage for the current `Rand` / `RoundRobin` correctness issues
- extends manager-path regression coverage for missing-cluster / unhealthy-endpoint nil behavior
- adds and refines the benchmark suite, including:
  - `PickEndpoint` serial baseline
  - cleaner `PickEndpoint` parallel baseline
  - lookup-only benchmark
  - simple LB hot-path-only benchmark
  - healthy endpoint filtering cost
  - mixed `CompareAndSetStore` workload
  - consistent-hash resolve baseline

This PR does **not** start the Step 3+ runtime-consistency / snapshot refactor yet. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #905

**Special notes for your reviewer**:

Issue #905 step progress:
- [x] Add tests and benchmarks
- [x] Fix current correctness issues
- [ ] Tighten runtime consistency
- [ ] Switch cluster lookup to O(1)
- [ ] Introduce healthy endpoint snapshots
- [ ] Optimize simple LB hot path
- [ ] Optimize consistent-hash LB last

- This PR intentionally covers **Step 1 (tests + benchmarks)** and **Step 2 (correctness)** only.
- Runtime consistency for `UpdateCluster` / `CompareAndSetStore`, O(1) cluster lookup, healthy endpoint snapshots, simple LB hot-path optimization, and consistent-hash optimization will follow in later PRs.
- Detailed benchmark baseline numbers are posted in a separate PR comment so later steps can compare against the same baseline.
- Local validation completed:
  - `go test ./pkg/model ./pkg/server ./pkg/cluster/loadbalancer/rand ./pkg/cluster/loadbalancer/roundrobin -count=1`
  - `go test ./pkg/server ./pkg/cluster/loadbalancer/rand ./pkg/cluster/loadbalancer/roundrobin -race -gcflags=-l -count=1`
  - `go vet ./pkg/server ./pkg/cluster/loadbalancer/... ./pkg/model`
  - `go test ./pkg/server -run '^$' -bench '^BenchmarkCluster' -benchmem -count=5`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
