### PR TITLE
feature(cluster): introduce healthy endpoint snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@ Numerous refactors, cleanups, and CI/build upgrades improve overall stability, m
 
 ### Bug Fixes
 
+* Stabilize Maglev request-key hashing [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* Nacos LLM registry endpoint loses address when metadata port is invalid [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
 * SSE stream not closed on `io.EOF` [#676](https://github.com/apache/dubbo-go-pixiu/pull/676)
 * HTTP proxy connection reuse issue [#578](https://github.com/apache/dubbo-go-pixiu/pull/578)
 * Nil-pointer issue and non-unary response handling in access log filter [#713](https://github.com/apache/dubbo-go-pixiu/pull/713)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,14 @@ Numerous refactors, cleanups, and CI/build upgrades improve overall stability, m
   [#714](https://github.com/apache/dubbo-go-pixiu/pull/714),
   [#723](https://github.com/apache/dubbo-go-pixiu/pull/723)
 
+#### Cluster / Load Balancer
+
+* Introduce immutable healthy-endpoint snapshots for cluster runtime state; the request-path picker no longer scans config for health filtering [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* Lazy-built healthy consistent-hash view skipped when not consumed by the configured load balancer [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* LB hot path reduced to one allocation per pick on `endpoints=4` Rand (213 ns/8 allocs → 65 ns/1 alloc) [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* Per-API-key LLM fallback cooldown moved out of `Endpoint.Metadata` into the LLM proxy filter with bounded LRU + throttled sweep [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* Runtime endpoint health preserved across config refresh when endpoint ID and address still match [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+
 ### Bug Fixes
 
 * Stabilize Maglev request-key hashing [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
@@ -155,6 +163,7 @@ Numerous refactors, cleanups, and CI/build upgrades improve overall stability, m
 * Removal of unused Seata proxy [#628](https://github.com/apache/dubbo-go-pixiu/pull/628)
 * Removal of Istio integration [#622](https://github.com/apache/dubbo-go-pixiu/pull/622)
 * Removal of static config providers [#764](https://github.com/apache/dubbo-go-pixiu/pull/764)
+* Drop direct dependency on `hashicorp/go-uuid`; endpoint IDs derive deterministically via `GeneratedEndpointID` [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
 
 ### Contributors
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -97,6 +97,14 @@
 * Pipeline 清理与无用 GitHub Action 移除 [#775](https://github.com/apache/dubbo-go-pixiu/pull/775)，[#786](https://github.com/apache/dubbo-go-pixiu/pull/786)
 * Docker 构建优化 [#714](https://github.com/apache/dubbo-go-pixiu/pull/714)，[#723](https://github.com/apache/dubbo-go-pixiu/pull/723)
 
+#### 集群 / 负载均衡（Cluster / Load Balancer）
+
+* 引入不可变的健康 Endpoint 快照,请求路径选点不再扫描 config 进行健康过滤 [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* 一致性哈希视图按需懒构建,未使用一致性哈希的 LB 跳过构建 [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* 简单 LB 热路径降至单次分配(`endpoints=4` Rand:213 ns/8 allocs → 65 ns/1 alloc) [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* 按 API Key 隔离的 LLM 回退冷却从 `Endpoint.Metadata` 迁移到 LLM Proxy Filter,带容量上限的 LRU 与节流清理 [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* 配置刷新时,Endpoint ID 与地址未变的运行时健康状态得以保留 [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+
 ### Bug 修复（Bug Fixes）
 
 * 修复 Maglev 请求 key 哈希不稳定问题 [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
@@ -125,6 +133,7 @@
 * 移除未使用的 Seata Proxy [#628](https://github.com/apache/dubbo-go-pixiu/pull/628)
 * 移除 Istio 集成 [#622](https://github.com/apache/dubbo-go-pixiu/pull/622)
 * 移除静态配置 Provider [#764](https://github.com/apache/dubbo-go-pixiu/pull/764)
+* 移除对 `hashicorp/go-uuid` 的直接依赖,Endpoint ID 通过 `GeneratedEndpointID` 确定性派生 [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
 
 ### 贡献者（Contributors）
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -99,6 +99,8 @@
 
 ### Bug 修复（Bug Fixes）
 
+* 修复 Maglev 请求 key 哈希不稳定问题 [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
+* 修复 Nacos LLM 注册中心 endpoint 在 metadata port 无效时丢失地址的问题 [#925](https://github.com/apache/dubbo-go-pixiu/pull/925)
 * SSE 流在 `io.EOF` 时未正确关闭 [#676](https://github.com/apache/dubbo-go-pixiu/pull/676)
 * HTTP Proxy 连接复用问题 [#578](https://github.com/apache/dubbo-go-pixiu/pull/578)
 * Access Log Filter 的空指针问题及非 Unary 响应处理 [#713](https://github.com/apache/dubbo-go-pixiu/pull/713)

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
-	github.com/hashicorp/go-uuid v1.0.3
 	github.com/jhump/protoreflect v1.17.0
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
 	github.com/lestrrat-go/httprc/v3 v3.0.1
@@ -160,6 +159,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/vault/sdk v0.7.0 // indirect

--- a/pkg/adapter/llmregistry/registry/nacos/listener.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener.go
@@ -31,8 +31,6 @@ import (
 
 	"github.com/creasty/defaults"
 
-	"github.com/hashicorp/go-uuid"
-
 	"github.com/nacos-group/nacos-sdk-go/clients/naming_client"
 	nacosModel "github.com/nacos-group/nacos-sdk-go/model"
 	"github.com/nacos-group/nacos-sdk-go/vo"
@@ -275,6 +273,9 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 		return nil
 	}
 
+	ret.Address.Address = instance.Ip
+	ret.Address.Port = int(instance.Port)
+
 	if ip, ok := instance.Metadata["ip"]; ok {
 		ret.Address.Address = ip
 	}
@@ -283,14 +284,9 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 		p, err := strconv.Atoi(port)
 		if err != nil {
 			logger.Warnf("Invalid port in metadata: %s, error: %v", port, err)
+		} else {
+			ret.Address.Port = p
 		}
-		ret.Address.Port = p
-	}
-
-	if id, ok := instance.Metadata["id"]; ok {
-		ret.ID = id
-	} else {
-		ret.ID, _ = uuid.GenerateUUID()
 	}
 
 	if name, ok := instance.Metadata["name"]; ok {
@@ -316,8 +312,19 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 	}
 
 	ret.Metadata = instance.Metadata
+	ret.ID = nacosEndpointID(instance, ret)
 
 	return ret
+}
+
+func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) string {
+	if id, ok := instance.Metadata["id"]; ok && strings.TrimSpace(id) != "" {
+		return strings.TrimSpace(id)
+	}
+	if instanceID := strings.TrimSpace(instance.InstanceId); instanceID != "" {
+		return instanceID
+	}
+	return model.GeneratedEndpointID(instance.Metadata["cluster"], endpoint)
 }
 
 func generateInstance(ss nacosModel.SubscribeService) nacosModel.Instance {

--- a/pkg/adapter/llmregistry/registry/nacos/listener_test.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener_test.go
@@ -154,10 +154,60 @@ func TestGenerateEndpoint(t *testing.T) {
 	})
 
 	t.Run("Invalid port", func(t *testing.T) {
-		instance := nacosModel.Instance{Metadata: map[string]string{"port": "not-a-number"}}
+		instance := nacosModel.Instance{
+			Port:     8080,
+			Metadata: map[string]string{"port": "not-a-number"},
+		}
 		endpoint := generateEndpoint(instance)
 		assert.NotNil(t, endpoint)
-		assert.Equal(t, 0, endpoint.Address.Port)
+		assert.Equal(t, 8080, endpoint.Address.Port)
+	})
+
+	t.Run("Missing metadata ID uses Nacos instance identity", func(t *testing.T) {
+		instance := nacosModel.Instance{
+			InstanceId: "nacos-instance-1",
+			Ip:         "10.0.0.1",
+			Port:       18080,
+			Metadata: map[string]string{
+				"cluster": "llm-cluster",
+				"name":    "shared-llm",
+			},
+		}
+
+		endpoint := generateEndpoint(instance)
+		assert.NotNil(t, endpoint)
+		assert.Equal(t, "nacos-instance-1", endpoint.ID)
+		assert.Equal(t, "10.0.0.1", endpoint.Address.Address)
+		assert.Equal(t, 18080, endpoint.Address.Port)
+	})
+
+	t.Run("Missing ID uses stable generated endpoint ID", func(t *testing.T) {
+		instance := nacosModel.Instance{
+			Metadata: map[string]string{
+				"cluster":          "llm-cluster",
+				"name":             "shared-llm",
+				"ip":               "127.0.0.1",
+				"port":             "8080",
+				"llm-meta.api_key": "key-a",
+			},
+		}
+
+		first := generateEndpoint(instance)
+		second := generateEndpoint(instance)
+		changedCredential := instance
+		changedCredential.Metadata = map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm",
+			"ip":               "127.0.0.1",
+			"port":             "8080",
+			"llm-meta.api_key": "key-b",
+		}
+
+		assert.NotNil(t, first)
+		assert.Equal(t, first.ID, second.ID)
+		assert.NotEqual(t, first.ID, generateEndpoint(changedCredential).ID)
+		assert.Contains(t, first.ID, "generated-")
+		assert.NotContains(t, first.ID, "key-a")
 	})
 }
 
@@ -271,6 +321,151 @@ func TestServiceCallback(t *testing.T) {
 		assert.Empty(t, adapterListener.addedEndpoints, "Should not trigger add for unchanged instance")
 		assert.Empty(t, adapterListener.removedEndpoints, "Should not trigger remove for unchanged instance")
 	})
+}
+
+func TestServiceCallbackUsesStableGeneratedEndpointID(t *testing.T) {
+	l, client, adapterListener := testSetup()
+
+	_ = client.Subscribe(&vo.SubscribeParam{
+		ServiceName:       "service-generated",
+		SubscribeCallback: l.serviceCallback,
+	})
+
+	instance1 := nacosModel.SubscribeService{
+		ServiceName: "service-generated",
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm-a",
+			"ip":               "127.0.0.1",
+			"port":             "8080",
+			"llm-meta.api_key": "key-a",
+		},
+	}
+	instance2 := nacosModel.SubscribeService{
+		ServiceName: "service-generated",
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm-b",
+			"ip":               "127.0.0.1",
+			"port":             "8080",
+			"llm-meta.api_key": "key-b",
+		},
+	}
+
+	client.subscribeCallback([]nacosModel.SubscribeService{instance1, instance2}, nil)
+	assert.Len(t, adapterListener.addedEndpoints, 2)
+
+	var removedID string
+	for id, endpoint := range adapterListener.addedEndpoints {
+		if endpoint.Name == "shared-llm-a" {
+			removedID = id
+		}
+	}
+	assert.NotEmpty(t, removedID)
+
+	adapterListener.reset()
+	client.subscribeCallback([]nacosModel.SubscribeService{instance2}, nil)
+
+	assert.Empty(t, adapterListener.addedEndpoints)
+	assert.Contains(t, adapterListener.removedEndpoints, removedID)
+}
+
+func TestServiceCallbackKeepsGeneratedEndpointIDWhenNameChanges(t *testing.T) {
+	l, client, adapterListener := testSetup()
+
+	_ = client.Subscribe(&vo.SubscribeParam{
+		ServiceName:       "service-rename",
+		SubscribeCallback: l.serviceCallback,
+	})
+
+	instance := nacosModel.SubscribeService{
+		ServiceName: "service-rename",
+		Ip:          "127.0.0.1",
+		Port:        8080,
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm-old",
+			"llm-meta.api_key": "key-a",
+		},
+	}
+
+	client.subscribeCallback([]nacosModel.SubscribeService{instance}, nil)
+	assert.Len(t, adapterListener.addedEndpoints, 1)
+
+	var endpointID string
+	for id := range adapterListener.addedEndpoints {
+		endpointID = id
+	}
+	assert.NotEmpty(t, endpointID)
+
+	renamed := instance
+	renamed.Metadata = map[string]string{
+		"cluster":          "llm-cluster",
+		"name":             "shared-llm-new",
+		"llm-meta.api_key": "key-a",
+	}
+
+	adapterListener.reset()
+	client.subscribeCallback([]nacosModel.SubscribeService{renamed}, nil)
+
+	assert.Empty(t, adapterListener.removedEndpoints)
+	if assert.Contains(t, adapterListener.addedEndpoints, endpointID) {
+		assert.Equal(t, "shared-llm-new", adapterListener.addedEndpoints[endpointID].Name)
+	}
+}
+
+func TestServiceCallbackKeepsNacosInstancesWithoutMetadataIDDistinct(t *testing.T) {
+	l, client, adapterListener := testSetup()
+
+	_ = client.Subscribe(&vo.SubscribeParam{
+		ServiceName:       "service-instance-id",
+		SubscribeCallback: l.serviceCallback,
+	})
+
+	instance1 := nacosModel.SubscribeService{
+		InstanceId:  "nacos-instance-a",
+		ServiceName: "service-instance-id",
+		Ip:          "10.0.0.1",
+		Port:        18080,
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm",
+			"llm-meta.api_key": "same-key",
+		},
+	}
+	instance2 := nacosModel.SubscribeService{
+		InstanceId:  "nacos-instance-b",
+		ServiceName: "service-instance-id",
+		Ip:          "10.0.0.2",
+		Port:        18081,
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm",
+			"llm-meta.api_key": "same-key",
+		},
+	}
+
+	client.subscribeCallback([]nacosModel.SubscribeService{instance1, instance2}, nil)
+
+	assert.Len(t, adapterListener.addedEndpoints, 2)
+	assert.Contains(t, adapterListener.addedEndpoints, "nacos-instance-a")
+	assert.Contains(t, adapterListener.addedEndpoints, "nacos-instance-b")
+
+	adapterListener.reset()
+	client.subscribeCallback([]nacosModel.SubscribeService{instance2}, nil)
+
+	assert.Empty(t, adapterListener.addedEndpoints)
+	assert.Contains(t, adapterListener.removedEndpoints, "nacos-instance-a")
 }
 
 func TestLifecycle(t *testing.T) {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -356,6 +356,29 @@ func (s *EndpointSnapshot) HealthyEndpointCount() int {
 	return len(s.healthy)
 }
 
+// HealthyEndpointsForPick returns the snapshot-internal healthy endpoint slice
+// without cloning. The returned slice and its endpoints are owned by the
+// snapshot; callers MUST NOT mutate elements, append into the slice, or retain
+// the slice past the current pick. This accessor exists for the request-path
+// picker; external callers should use HealthyEndpoints (defensive deep copy) or
+// PickHealthyEndpoint (zero-copy callback that clones only the chosen endpoint).
+func (s *EndpointSnapshot) HealthyEndpointsForPick() []*model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return s.healthy
+}
+
+// AllEndpointsForPick mirrors HealthyEndpointsForPick for the full endpoint set.
+// The same no-mutate / no-retain contract applies. The slice may contain nil
+// entries to preserve positional alignment with the originating cluster config.
+func (s *EndpointSnapshot) AllEndpointsForPick() []*model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return s.all
+}
+
 func (s *EndpointSnapshot) HealthyConsistentHash() model.LbConsistentHashView {
 	if s == nil {
 		return nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -37,6 +37,7 @@ type Cluster struct {
 	// without health checks.
 	Config             *model.ClusterConfig
 	healthMu           sync.Mutex
+	legacyPickMu       sync.Mutex
 	acceptHealthEvents bool
 	endpoints          atomic.Pointer[EndpointSnapshot]
 }
@@ -80,6 +81,14 @@ func (c *Cluster) AddEndpoint(endpoint *model.Endpoint) {
 	if c.HealthCheck != nil {
 		c.HealthCheck.StartOne(endpoint)
 	}
+}
+
+// LegacyPickLock returns the runtime-scoped lock for legacy load balancer picks.
+func (c *Cluster) LegacyPickLock() sync.Locker {
+	if c == nil {
+		return nil
+	}
+	return &c.legacyPickMu
 }
 
 func (c *Cluster) EndpointSnapshot() *EndpointSnapshot {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -18,23 +18,47 @@
 package cluster
 
 import (
+	"sync"
+	"sync/atomic"
+)
+
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/healthcheck"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
 type Cluster struct {
 	HealthCheck *healthcheck.HealthChecker
-	Config      *model.ClusterConfig
+	// Config is the desired cluster configuration. Runtime picks read the
+	// published EndpointSnapshot, so direct edits to Config.Endpoints or
+	// Endpoint.UnHealthy are not observed by PickEndpoint immediately. Publish
+	// membership/address changes with RefreshEndpoints; publish runtime health
+	// changes with UpdateEndpointHealth, or RefreshEndpoints for clusters
+	// without health checks.
+	Config             *model.ClusterConfig
+	healthMu           sync.Mutex
+	acceptHealthEvents bool
+	endpoints          atomic.Pointer[EndpointSnapshot]
 }
 
 func NewCluster(clusterConfig *model.ClusterConfig) *Cluster {
+	return NewClusterWithEndpointSnapshot(clusterConfig, nil)
+}
+
+func NewClusterWithEndpointSnapshot(clusterConfig *model.ClusterConfig, previous *EndpointSnapshot) *Cluster {
 	c := &Cluster{
-		Config: clusterConfig,
+		Config:             clusterConfig,
+		acceptHealthEvents: true,
 	}
+	c.RefreshEndpointsFrom(previous)
 
 	// only handle one health checker
 	if len(c.Config.HealthChecks) != 0 {
-		c.HealthCheck = healthcheck.CreateHealthCheck(clusterConfig, c.Config.HealthChecks[0])
+		c.HealthCheck = healthcheck.CreateHealthCheckWithCallback(
+			clusterConfig,
+			c.Config.HealthChecks[0],
+			c.handleEndpointHealth,
+		)
 		c.HealthCheck.Start()
 	}
 	return c
@@ -56,4 +80,337 @@ func (c *Cluster) AddEndpoint(endpoint *model.Endpoint) {
 	if c.HealthCheck != nil {
 		c.HealthCheck.StartOne(endpoint)
 	}
+}
+
+func (c *Cluster) EndpointSnapshot() *EndpointSnapshot {
+	snapshot := c.endpoints.Load()
+	if snapshot == nil {
+		return emptyEndpointSnapshot
+	}
+	return snapshot
+}
+
+func (c *Cluster) RefreshEndpoints() {
+	c.RefreshEndpointsFrom(c.endpoints.Load())
+}
+
+func (c *Cluster) RefreshEndpointsFrom(previous *EndpointSnapshot) {
+	for {
+		current := c.endpoints.Load()
+		source := previous
+		if current != nil && current != previous {
+			source = current
+		}
+		next := newEndpointSnapshot(c.Config.Endpoints, source, len(c.Config.HealthChecks) != 0)
+		if c.endpoints.CompareAndSwap(current, next) {
+			return
+		}
+	}
+}
+
+func (c *Cluster) UpdateEndpointHealth(endpointID string, endpointAddress string, healthy bool) bool {
+	c.healthMu.Lock()
+	defer c.healthMu.Unlock()
+	if !c.acceptHealthEvents {
+		return false
+	}
+
+	for {
+		current := c.endpoints.Load()
+		if current == nil {
+			return false
+		}
+		next, ok := current.withEndpointHealth(endpointID, endpointAddress, healthy)
+		if !ok {
+			return false
+		}
+		if next == current {
+			return true
+		}
+		if c.endpoints.CompareAndSwap(current, next) {
+			return true
+		}
+	}
+}
+
+// SnapshotForRuntimeReplacement freezes health updates on this runtime and
+// returns the final snapshot that a replacement runtime should inherit.
+func (c *Cluster) SnapshotForRuntimeReplacement() *EndpointSnapshot {
+	if c == nil {
+		return nil
+	}
+	c.healthMu.Lock()
+	defer c.healthMu.Unlock()
+	c.acceptHealthEvents = false
+	return c.EndpointSnapshot()
+}
+
+func (c *Cluster) EndpointRuntimeState(endpointID string, endpointAddress string) *EndpointRuntimeState {
+	return c.EndpointSnapshot().EndpointRuntimeState(endpointID, endpointAddress)
+}
+
+func (c *Cluster) handleEndpointHealth(event healthcheck.EndpointHealthEvent) {
+	c.UpdateEndpointHealth(event.EndpointID, event.EndpointAddress, event.Healthy)
+}
+
+// EndpointSnapshot endpoint membership and health indexes are immutable after
+// publication. Returned *model.Endpoint values are shared config objects, so
+// runtime-only state must stay in EndpointRuntimeState instead of endpoint
+// fields or metadata.
+type EndpointSnapshot struct {
+	all                 []*model.Endpoint
+	healthy             []*model.Endpoint
+	endpointByID        map[string]*model.Endpoint
+	healthyEndpointByID map[string]*model.Endpoint
+	addressByID         map[string]string
+	healthyByID         map[string]bool
+	runtimeStateByID    map[string]*EndpointRuntimeState
+}
+
+var emptyEndpointSnapshot = &EndpointSnapshot{
+	all:                 []*model.Endpoint{},
+	healthy:             []*model.Endpoint{},
+	endpointByID:        map[string]*model.Endpoint{},
+	healthyEndpointByID: map[string]*model.Endpoint{},
+	addressByID:         map[string]string{},
+	healthyByID:         map[string]bool{},
+	runtimeStateByID:    map[string]*EndpointRuntimeState{},
+}
+
+// EndpointRuntimeState holds runtime-only mutable endpoint state. It is keyed
+// by endpoint ID plus address through EndpointSnapshot, so config refreshes can
+// retain state for the same backend without leaking it to a replaced address.
+type EndpointRuntimeState struct {
+	mu     sync.RWMutex
+	values map[string]string
+}
+
+func newEndpointRuntimeState() *EndpointRuntimeState {
+	return &EndpointRuntimeState{
+		values: map[string]string{},
+	}
+}
+
+func (s *EndpointRuntimeState) Load(key string) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	value, ok := s.values[key]
+	return value, ok
+}
+
+func (s *EndpointRuntimeState) LoadMany(keys ...string) map[string]string {
+	loaded := make(map[string]string, len(keys))
+	if s == nil || len(keys) == 0 {
+		return loaded
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, key := range keys {
+		if value, ok := s.values[key]; ok {
+			loaded[key] = value
+		}
+	}
+	return loaded
+}
+
+func (s *EndpointRuntimeState) Store(key string, value string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.values[key] = value
+}
+
+func (s *EndpointRuntimeState) StoreMany(values map[string]string) {
+	if s == nil || len(values) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, value := range values {
+		s.values[key] = value
+	}
+}
+
+func (s *EndpointRuntimeState) Delete(keys ...string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, key := range keys {
+		delete(s.values, key)
+	}
+}
+
+func (s *EndpointRuntimeState) DeleteIfMatches(expected map[string]string, keys ...string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, expectedValue := range expected {
+		currentValue, ok := s.values[key]
+		if !ok || currentValue != expectedValue {
+			return false
+		}
+	}
+	for _, key := range keys {
+		delete(s.values, key)
+	}
+	return true
+}
+
+func newEndpointSnapshot(endpoints []*model.Endpoint, previous *EndpointSnapshot, inheritRuntimeHealth bool) *EndpointSnapshot {
+	snapshot := &EndpointSnapshot{
+		all:                 cloneEndpoints(endpoints),
+		healthy:             make([]*model.Endpoint, 0, len(endpoints)),
+		endpointByID:        make(map[string]*model.Endpoint, len(endpoints)),
+		healthyEndpointByID: make(map[string]*model.Endpoint, len(endpoints)),
+		addressByID:         make(map[string]string, len(endpoints)),
+		healthyByID:         make(map[string]bool, len(endpoints)),
+		runtimeStateByID:    make(map[string]*EndpointRuntimeState, len(endpoints)),
+	}
+
+	for _, endpoint := range endpoints {
+		if endpoint == nil {
+			continue
+		}
+
+		address := endpoint.Address.GetAddress()
+		healthy := !endpoint.UnHealthy
+		runtimeState := newEndpointRuntimeState()
+		if previous != nil {
+			if previousAddress, ok := previous.addressByID[endpoint.ID]; ok && previousAddress == address {
+				// Carry health only while this runtime still has a health checker
+				// that can later correct it; otherwise seed health from config.
+				if inheritRuntimeHealth {
+					healthy = previous.healthyByID[endpoint.ID]
+				}
+				if previousRuntimeState := previous.runtimeStateByID[endpoint.ID]; previousRuntimeState != nil {
+					runtimeState = previousRuntimeState
+				}
+			}
+		}
+
+		snapshot.endpointByID[endpoint.ID] = endpoint
+		snapshot.addressByID[endpoint.ID] = address
+		snapshot.healthyByID[endpoint.ID] = healthy
+		snapshot.runtimeStateByID[endpoint.ID] = runtimeState
+		if healthy {
+			snapshot.healthy = append(snapshot.healthy, endpoint)
+			snapshot.healthyEndpointByID[endpoint.ID] = endpoint
+		}
+	}
+
+	return snapshot
+}
+
+func (s *EndpointSnapshot) AllEndpoints() []*model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return cloneEndpoints(s.all)
+}
+
+func (s *EndpointSnapshot) EndpointCount() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.all)
+}
+
+func (s *EndpointSnapshot) HealthyEndpoints() []*model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return cloneEndpoints(s.healthy)
+}
+
+func (s *EndpointSnapshot) EndpointByID(endpointID string) *model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return s.endpointByID[endpointID]
+}
+
+func (s *EndpointSnapshot) HealthyEndpointByID(endpointID string) *model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return s.healthyEndpointByID[endpointID]
+}
+
+func (s *EndpointSnapshot) EndpointRuntimeState(endpointID string, endpointAddress string) *EndpointRuntimeState {
+	if s == nil {
+		return nil
+	}
+	address, ok := s.addressByID[endpointID]
+	if !ok || address != endpointAddress {
+		return nil
+	}
+	return s.runtimeStateByID[endpointID]
+}
+
+func (s *EndpointSnapshot) withEndpointHealth(
+	endpointID string,
+	endpointAddress string,
+	healthy bool,
+) (*EndpointSnapshot, bool) {
+	if s == nil {
+		return nil, false
+	}
+	address, ok := s.addressByID[endpointID]
+	if !ok || address != endpointAddress {
+		return nil, false
+	}
+	if s.healthyByID[endpointID] == healthy {
+		return s, true
+	}
+
+	// Reuse the immutable endpoint/address views and rebuild only the health
+	// views that change for this event.
+	next := &EndpointSnapshot{
+		all:                 s.all,
+		healthy:             make([]*model.Endpoint, 0, len(s.all)),
+		endpointByID:        s.endpointByID,
+		healthyEndpointByID: make(map[string]*model.Endpoint, len(s.endpointByID)),
+		addressByID:         s.addressByID,
+		healthyByID:         make(map[string]bool, len(s.healthyByID)),
+		runtimeStateByID:    s.runtimeStateByID,
+	}
+
+	for id, wasHealthy := range s.healthyByID {
+		nextHealthy := wasHealthy
+		if id == endpointID {
+			nextHealthy = healthy
+		}
+		next.healthyByID[id] = nextHealthy
+	}
+
+	for _, endpoint := range s.all {
+		if endpoint == nil {
+			continue
+		}
+		id := endpoint.ID
+		if next.healthyByID[id] {
+			next.healthy = append(next.healthy, endpoint)
+			next.healthyEndpointByID[id] = endpoint
+		}
+	}
+
+	return next, true
+}
+
+func cloneEndpoints(endpoints []*model.Endpoint) []*model.Endpoint {
+	if endpoints == nil {
+		return nil
+	}
+	cloned := make([]*model.Endpoint, len(endpoints))
+	copy(cloned, endpoints)
+	return cloned
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -234,6 +234,7 @@ func (s *EndpointSnapshot) addEndpoint(
 	address string,
 	healthy bool,
 ) {
+	endpoint.UnHealthy = !healthy
 	s.all = append(s.all, endpoint)
 	s.endpointByID[endpoint.ID] = endpoint
 	s.addressByID[endpoint.ID] = address
@@ -265,6 +266,51 @@ func (s *EndpointSnapshot) HealthyEndpoints() []*model.Endpoint {
 	return cloneEndpoints(s.healthy)
 }
 
+func (s *EndpointSnapshot) HealthyEndpointCount() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.healthy)
+}
+
+// PickHealthyEndpoint gives request-path selectors a read-only view of healthy
+// endpoints and clones only the selected endpoint before returning it. The pick
+// callback must not mutate or retain the endpoint view.
+func (s *EndpointSnapshot) PickHealthyEndpoint(pick func([]*model.Endpoint) *model.Endpoint) *model.Endpoint {
+	if s == nil || len(s.healthy) == 0 || pick == nil {
+		return nil
+	}
+	return cloneEndpoint(pick(s.healthy))
+}
+
+func (s *EndpointSnapshot) NextHealthyEndpoint(curEndpointID string) *model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	start := s.nextEndpointStartIndex(curEndpointID)
+	if start < 0 {
+		return nil
+	}
+	for _, endpoint := range s.all[start:] {
+		if endpoint == nil {
+			continue
+		}
+		if s.healthyByID[endpoint.ID] {
+			return cloneEndpoint(endpoint)
+		}
+	}
+	return nil
+}
+
+func (s *EndpointSnapshot) nextEndpointStartIndex(curEndpointID string) int {
+	for i, endpoint := range s.all {
+		if endpoint != nil && endpoint.ID == curEndpointID {
+			return i + 1
+		}
+	}
+	return -1
+}
+
 func (s *EndpointSnapshot) EndpointByID(endpointID string) *model.Endpoint {
 	if s == nil {
 		return nil
@@ -294,12 +340,12 @@ func (s *EndpointSnapshot) withEndpointHealth(
 		return s, true
 	}
 
-	// Reuse the immutable endpoint/address views and rebuild only the health
-	// views that change for this event.
+	// Reuse unchanged endpoint/address views and rebuild the endpoint clone
+	// whose runtime health flag changed.
 	next := &EndpointSnapshot{
-		all:                 s.all,
+		all:                 make([]*model.Endpoint, 0, len(s.all)),
 		healthy:             make([]*model.Endpoint, 0, len(s.all)),
-		endpointByID:        s.endpointByID,
+		endpointByID:        make(map[string]*model.Endpoint, len(s.endpointByID)),
 		healthyEndpointByID: make(map[string]*model.Endpoint, len(s.endpointByID)),
 		addressByID:         s.addressByID,
 		healthyByID:         make(map[string]bool, len(s.healthyByID)),
@@ -315,12 +361,20 @@ func (s *EndpointSnapshot) withEndpointHealth(
 
 	for _, endpoint := range s.all {
 		if endpoint == nil {
+			next.all = append(next.all, nil)
 			continue
 		}
 		id := endpoint.ID
+		nextEndpoint := endpoint
+		if id == endpointID {
+			nextEndpoint = cloneEndpoint(endpoint)
+			nextEndpoint.UnHealthy = !healthy
+		}
+		next.all = append(next.all, nextEndpoint)
+		next.endpointByID[id] = nextEndpoint
 		if next.healthyByID[id] {
-			next.healthy = append(next.healthy, endpoint)
-			next.healthyEndpointByID[id] = endpoint
+			next.healthy = append(next.healthy, nextEndpoint)
+			next.healthyEndpointByID[id] = nextEndpoint
 		}
 	}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -154,18 +154,14 @@ func (c *Cluster) SnapshotForRuntimeReplacement() *EndpointSnapshot {
 	return c.EndpointSnapshot()
 }
 
-func (c *Cluster) EndpointRuntimeState(endpointID, endpointAddress string) *EndpointRuntimeState {
-	return c.EndpointSnapshot().EndpointRuntimeState(endpointID, endpointAddress)
-}
-
 func (c *Cluster) handleEndpointHealth(event healthcheck.EndpointHealthEvent) {
 	c.UpdateEndpointHealth(event.EndpointID, event.EndpointAddress, event.Healthy)
 }
 
 // EndpointSnapshot endpoint membership and health indexes are immutable after
-// publication. Returned *model.Endpoint values are shared config objects, so
-// runtime-only state must stay in EndpointRuntimeState instead of endpoint
-// fields or metadata.
+// publication. Snapshot endpoints are cloned from config endpoints when the
+// snapshot is built, so request-path health changes do not mutate config
+// Endpoint.UnHealthy or config metadata.
 type EndpointSnapshot struct {
 	all                 []*model.Endpoint
 	healthy             []*model.Endpoint
@@ -173,7 +169,6 @@ type EndpointSnapshot struct {
 	healthyEndpointByID map[string]*model.Endpoint
 	addressByID         map[string]string
 	healthyByID         map[string]bool
-	runtimeStateByID    map[string]*EndpointRuntimeState
 }
 
 var emptyEndpointSnapshot = &EndpointSnapshot{
@@ -183,136 +178,47 @@ var emptyEndpointSnapshot = &EndpointSnapshot{
 	healthyEndpointByID: map[string]*model.Endpoint{},
 	addressByID:         map[string]string{},
 	healthyByID:         map[string]bool{},
-	runtimeStateByID:    map[string]*EndpointRuntimeState{},
-}
-
-// EndpointRuntimeState holds runtime-only mutable endpoint state. It is keyed
-// by endpoint ID plus address through EndpointSnapshot, so config refreshes can
-// retain state for the same backend without leaking it to a replaced address.
-type EndpointRuntimeState struct {
-	mu     sync.RWMutex
-	values map[string]string
-}
-
-func newEndpointRuntimeState() *EndpointRuntimeState {
-	return &EndpointRuntimeState{
-		values: map[string]string{},
-	}
-}
-
-func (s *EndpointRuntimeState) Load(key string) (string, bool) {
-	if s == nil {
-		return "", false
-	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	value, ok := s.values[key]
-	return value, ok
-}
-
-func (s *EndpointRuntimeState) LoadMany(keys ...string) map[string]string {
-	loaded := make(map[string]string, len(keys))
-	if s == nil || len(keys) == 0 {
-		return loaded
-	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, key := range keys {
-		if value, ok := s.values[key]; ok {
-			loaded[key] = value
-		}
-	}
-	return loaded
-}
-
-func (s *EndpointRuntimeState) Store(key, value string) {
-	if s == nil {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.values[key] = value
-}
-
-func (s *EndpointRuntimeState) StoreMany(values map[string]string) {
-	if s == nil || len(values) == 0 {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for key, value := range values {
-		s.values[key] = value
-	}
-}
-
-func (s *EndpointRuntimeState) Delete(keys ...string) {
-	if s == nil {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, key := range keys {
-		delete(s.values, key)
-	}
-}
-
-func (s *EndpointRuntimeState) DeleteIfMatches(expected map[string]string, keys ...string) bool {
-	if s == nil {
-		return false
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for key, expectedValue := range expected {
-		currentValue, ok := s.values[key]
-		if !ok || currentValue != expectedValue {
-			return false
-		}
-	}
-	for _, key := range keys {
-		delete(s.values, key)
-	}
-	return true
 }
 
 func newEndpointSnapshot(endpoints []*model.Endpoint, previous *EndpointSnapshot, inheritRuntimeHealth bool) *EndpointSnapshot {
-	snapshot := newEndpointSnapshotIndex(endpoints)
+	snapshot := newEndpointSnapshotIndex(len(endpoints))
 	for _, endpoint := range endpoints {
 		if endpoint == nil {
+			snapshot.all = append(snapshot.all, nil)
 			continue
 		}
-		address := endpoint.Address.GetAddress()
-		healthy, runtimeState := endpointSnapshotRuntimeState(endpoint, address, previous, inheritRuntimeHealth)
-		snapshot.addEndpoint(endpoint, address, healthy, runtimeState)
+		snapshotEndpoint := cloneEndpoint(endpoint)
+		address := snapshotEndpoint.Address.GetAddress()
+		healthy := endpointSnapshotHealth(snapshotEndpoint, address, previous, inheritRuntimeHealth)
+		snapshot.addEndpoint(snapshotEndpoint, address, healthy)
 	}
 	return snapshot
 }
 
-func newEndpointSnapshotIndex(endpoints []*model.Endpoint) *EndpointSnapshot {
+func newEndpointSnapshotIndex(endpointCount int) *EndpointSnapshot {
 	return &EndpointSnapshot{
-		all:                 cloneEndpoints(endpoints),
-		healthy:             make([]*model.Endpoint, 0, len(endpoints)),
-		endpointByID:        make(map[string]*model.Endpoint, len(endpoints)),
-		healthyEndpointByID: make(map[string]*model.Endpoint, len(endpoints)),
-		addressByID:         make(map[string]string, len(endpoints)),
-		healthyByID:         make(map[string]bool, len(endpoints)),
-		runtimeStateByID:    make(map[string]*EndpointRuntimeState, len(endpoints)),
+		all:                 make([]*model.Endpoint, 0, endpointCount),
+		healthy:             make([]*model.Endpoint, 0, endpointCount),
+		endpointByID:        make(map[string]*model.Endpoint, endpointCount),
+		healthyEndpointByID: make(map[string]*model.Endpoint, endpointCount),
+		addressByID:         make(map[string]string, endpointCount),
+		healthyByID:         make(map[string]bool, endpointCount),
 	}
 }
 
-func endpointSnapshotRuntimeState(
+func endpointSnapshotHealth(
 	endpoint *model.Endpoint,
 	address string,
 	previous *EndpointSnapshot,
 	inheritRuntimeHealth bool,
-) (bool, *EndpointRuntimeState) {
+) bool {
 	healthy := !endpoint.UnHealthy
-	runtimeState := newEndpointRuntimeState()
 	if previous == nil {
-		return healthy, runtimeState
+		return healthy
 	}
 	previousAddress, ok := previous.addressByID[endpoint.ID]
 	if !ok || previousAddress != address {
-		return healthy, runtimeState
+		return healthy
 	}
 
 	// Carry health only while this runtime still has a health checker that can
@@ -320,22 +226,18 @@ func endpointSnapshotRuntimeState(
 	if inheritRuntimeHealth {
 		healthy = previous.healthyByID[endpoint.ID]
 	}
-	if previousRuntimeState := previous.runtimeStateByID[endpoint.ID]; previousRuntimeState != nil {
-		runtimeState = previousRuntimeState
-	}
-	return healthy, runtimeState
+	return healthy
 }
 
 func (s *EndpointSnapshot) addEndpoint(
 	endpoint *model.Endpoint,
 	address string,
 	healthy bool,
-	runtimeState *EndpointRuntimeState,
 ) {
+	s.all = append(s.all, endpoint)
 	s.endpointByID[endpoint.ID] = endpoint
 	s.addressByID[endpoint.ID] = address
 	s.healthyByID[endpoint.ID] = healthy
-	s.runtimeStateByID[endpoint.ID] = runtimeState
 	if healthy {
 		s.healthy = append(s.healthy, endpoint)
 		s.healthyEndpointByID[endpoint.ID] = endpoint
@@ -377,17 +279,6 @@ func (s *EndpointSnapshot) HealthyEndpointByID(endpointID string) *model.Endpoin
 	return s.healthyEndpointByID[endpointID]
 }
 
-func (s *EndpointSnapshot) EndpointRuntimeState(endpointID, endpointAddress string) *EndpointRuntimeState {
-	if s == nil {
-		return nil
-	}
-	address, ok := s.addressByID[endpointID]
-	if !ok || address != endpointAddress {
-		return nil
-	}
-	return s.runtimeStateByID[endpointID]
-}
-
 func (s *EndpointSnapshot) withEndpointHealth(
 	endpointID, endpointAddress string,
 	healthy bool,
@@ -412,7 +303,6 @@ func (s *EndpointSnapshot) withEndpointHealth(
 		healthyEndpointByID: make(map[string]*model.Endpoint, len(s.endpointByID)),
 		addressByID:         s.addressByID,
 		healthyByID:         make(map[string]bool, len(s.healthyByID)),
-		runtimeStateByID:    s.runtimeStateByID,
 	}
 
 	for id, wasHealthy := range s.healthyByID {
@@ -444,4 +334,48 @@ func cloneEndpoints(endpoints []*model.Endpoint) []*model.Endpoint {
 	cloned := make([]*model.Endpoint, len(endpoints))
 	copy(cloned, endpoints)
 	return cloned
+}
+
+func cloneEndpoint(endpoint *model.Endpoint) *model.Endpoint {
+	if endpoint == nil {
+		return nil
+	}
+	cloned := *endpoint
+	cloned.Address = cloneSocketAddress(endpoint.Address)
+	cloned.Metadata = cloneMetadata(endpoint.Metadata)
+	cloned.LLMMeta = cloneLLMMeta(endpoint.LLMMeta)
+	return &cloned
+}
+
+func cloneSocketAddress(address model.SocketAddress) model.SocketAddress {
+	cloned := address
+	if address.Domains != nil {
+		cloned.Domains = append([]string(nil), address.Domains...)
+	}
+	return cloned
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	if metadata == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneLLMMeta(meta *model.LLMMeta) *model.LLMMeta {
+	if meta == nil {
+		return nil
+	}
+	cloned := *meta
+	if meta.RetryPolicy.Config != nil {
+		cloned.RetryPolicy.Config = make(map[string]any, len(meta.RetryPolicy.Config))
+		for key, value := range meta.RetryPolicy.Config {
+			cloned.RetryPolicy.Config[key] = value
+		}
+	}
+	return &cloned
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -18,6 +18,7 @@
 package cluster
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -110,7 +111,7 @@ func (c *Cluster) RefreshEndpointsFrom(previous *EndpointSnapshot) {
 		if current != nil && current != previous {
 			source = current
 		}
-		next := newEndpointSnapshot(c.Config.Endpoints, source, len(c.Config.HealthChecks) != 0)
+		next := newEndpointSnapshot(c.Config, source, len(c.Config.HealthChecks) != 0)
 		if c.endpoints.CompareAndSwap(current, next) {
 			return
 		}
@@ -142,6 +143,34 @@ func (c *Cluster) UpdateEndpointHealth(endpointID, endpointAddress string, healt
 	}
 }
 
+// UpdateEndpointAddressHealth updates every endpoint that shares an address.
+// Address-keyed health checkers use this path because one probe represents the
+// reachability of all endpoint identities at the same network address.
+func (c *Cluster) UpdateEndpointAddressHealth(endpointAddress string, healthy bool) bool {
+	c.healthMu.Lock()
+	defer c.healthMu.Unlock()
+	if !c.acceptHealthEvents {
+		return false
+	}
+
+	for {
+		current := c.endpoints.Load()
+		if current == nil {
+			return false
+		}
+		next, ok := current.withEndpointAddressHealth(endpointAddress, healthy)
+		if !ok {
+			return false
+		}
+		if next == current {
+			return true
+		}
+		if c.endpoints.CompareAndSwap(current, next) {
+			return true
+		}
+	}
+}
+
 // SnapshotForRuntimeReplacement freezes health updates on this runtime and
 // returns the final snapshot that a replacement runtime should inherit.
 func (c *Cluster) SnapshotForRuntimeReplacement() *EndpointSnapshot {
@@ -155,7 +184,7 @@ func (c *Cluster) SnapshotForRuntimeReplacement() *EndpointSnapshot {
 }
 
 func (c *Cluster) handleEndpointHealth(event healthcheck.EndpointHealthEvent) {
-	c.UpdateEndpointHealth(event.EndpointID, event.EndpointAddress, event.Healthy)
+	c.UpdateEndpointAddressHealth(event.EndpointAddress, event.Healthy)
 }
 
 // EndpointSnapshot endpoint membership and health indexes are immutable after
@@ -163,12 +192,17 @@ func (c *Cluster) handleEndpointHealth(event healthcheck.EndpointHealthEvent) {
 // snapshot is built, so request-path health changes do not mutate config
 // Endpoint.UnHealthy or config metadata.
 type EndpointSnapshot struct {
-	all                 []*model.Endpoint
-	healthy             []*model.Endpoint
-	endpointByID        map[string]*model.Endpoint
-	healthyEndpointByID map[string]*model.Endpoint
-	addressByID         map[string]string
-	healthyByID         map[string]bool
+	all                  []*model.Endpoint
+	healthy              []*model.Endpoint
+	endpointByID         map[string]*model.Endpoint
+	healthyEndpointByID  map[string]*model.Endpoint
+	addressByID          map[string]string
+	healthyByID          map[string]bool
+	healthyByAddress     map[string]bool
+	lbPolicy             model.LbPolicyType
+	consistentHashOnce   sync.Once
+	consistentHash       model.LbConsistentHashView
+	consistentHashConfig model.ConsistentHash
 }
 
 var emptyEndpointSnapshot = &EndpointSnapshot{
@@ -178,16 +212,31 @@ var emptyEndpointSnapshot = &EndpointSnapshot{
 	healthyEndpointByID: map[string]*model.Endpoint{},
 	addressByID:         map[string]string{},
 	healthyByID:         map[string]bool{},
+	healthyByAddress:    map[string]bool{},
 }
 
-func newEndpointSnapshot(endpoints []*model.Endpoint, previous *EndpointSnapshot, inheritRuntimeHealth bool) *EndpointSnapshot {
+func newEndpointSnapshot(config *model.ClusterConfig, previous *EndpointSnapshot, inheritRuntimeHealth bool) *EndpointSnapshot {
+	var endpoints []*model.Endpoint
+	clusterName := ""
+	if config != nil {
+		clusterName = config.Name
+		endpoints = config.Endpoints
+	}
 	snapshot := newEndpointSnapshotIndex(len(endpoints))
+	if config != nil {
+		snapshot.lbPolicy = config.LbStr
+		snapshot.consistentHashConfig = config.ConsistentHash
+		snapshot.consistentHashConfig.Hash = nil
+	}
+	endpointIDs := make(map[string]struct{}, len(endpoints))
 	for _, endpoint := range endpoints {
 		if endpoint == nil {
 			snapshot.all = append(snapshot.all, nil)
 			continue
 		}
-		snapshotEndpoint := cloneEndpoint(endpoint)
+		snapshotEndpoint := model.CloneEndpoint(endpoint)
+		snapshotEndpoint.ID = uniqueSnapshotEndpointID(clusterName, snapshotEndpoint, endpointIDs)
+		endpointIDs[snapshotEndpoint.ID] = struct{}{}
 		address := snapshotEndpoint.Address.GetAddress()
 		healthy := endpointSnapshotHealth(snapshotEndpoint, address, previous, inheritRuntimeHealth)
 		snapshot.addEndpoint(snapshotEndpoint, address, healthy)
@@ -203,6 +252,27 @@ func newEndpointSnapshotIndex(endpointCount int) *EndpointSnapshot {
 		healthyEndpointByID: make(map[string]*model.Endpoint, endpointCount),
 		addressByID:         make(map[string]string, endpointCount),
 		healthyByID:         make(map[string]bool, endpointCount),
+		healthyByAddress:    make(map[string]bool, endpointCount),
+	}
+}
+
+func uniqueSnapshotEndpointID(clusterName string, endpoint *model.Endpoint, endpointIDs map[string]struct{}) string {
+	id := ""
+	if endpoint != nil {
+		id = endpoint.ID
+	}
+	if id == "" {
+		id = model.GeneratedEndpointID(clusterName, endpoint)
+	}
+	if _, exists := endpointIDs[id]; !exists {
+		return id
+	}
+	baseID := model.GeneratedEndpointID(clusterName, endpoint)
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s-%d", baseID, suffix)
+		if _, exists := endpointIDs[candidate]; !exists {
+			return candidate
+		}
 	}
 }
 
@@ -216,15 +286,15 @@ func endpointSnapshotHealth(
 	if previous == nil {
 		return healthy
 	}
-	previousAddress, ok := previous.addressByID[endpoint.ID]
-	if !ok || previousAddress != address {
-		return healthy
-	}
-
 	// Carry health only while this runtime still has a health checker that can
 	// later correct it; otherwise seed health from config.
 	if inheritRuntimeHealth {
-		healthy = previous.healthyByID[endpoint.ID]
+		if previousAddress, ok := previous.addressByID[endpoint.ID]; ok && previousAddress == address {
+			return previous.healthyByID[endpoint.ID]
+		}
+		if addressHealthy, ok := previous.healthyByAddress[address]; ok {
+			return addressHealthy
+		}
 	}
 	return healthy
 }
@@ -239,17 +309,30 @@ func (s *EndpointSnapshot) addEndpoint(
 	s.endpointByID[endpoint.ID] = endpoint
 	s.addressByID[endpoint.ID] = address
 	s.healthyByID[endpoint.ID] = healthy
+	s.addAddressHealth(address, healthy)
 	if healthy {
 		s.healthy = append(s.healthy, endpoint)
 		s.healthyEndpointByID[endpoint.ID] = endpoint
 	}
 }
 
+func (s *EndpointSnapshot) addAddressHealth(address string, healthy bool) {
+	if s == nil {
+		return
+	}
+	addressHealthy, ok := s.healthyByAddress[address]
+	if !ok {
+		s.healthyByAddress[address] = healthy
+		return
+	}
+	s.healthyByAddress[address] = addressHealthy && healthy
+}
+
 func (s *EndpointSnapshot) AllEndpoints() []*model.Endpoint {
 	if s == nil {
 		return nil
 	}
-	return cloneEndpoints(s.all)
+	return model.CloneEndpoints(s.all)
 }
 
 func (s *EndpointSnapshot) EndpointCount() int {
@@ -263,7 +346,7 @@ func (s *EndpointSnapshot) HealthyEndpoints() []*model.Endpoint {
 	if s == nil {
 		return nil
 	}
-	return cloneEndpoints(s.healthy)
+	return model.CloneEndpoints(s.healthy)
 }
 
 func (s *EndpointSnapshot) HealthyEndpointCount() int {
@@ -273,6 +356,14 @@ func (s *EndpointSnapshot) HealthyEndpointCount() int {
 	return len(s.healthy)
 }
 
+func (s *EndpointSnapshot) HealthyConsistentHash() model.LbConsistentHashView {
+	if s == nil {
+		return nil
+	}
+	s.consistentHashOnce.Do(s.rebuildConsistentHash)
+	return s.consistentHash
+}
+
 // PickHealthyEndpoint gives request-path selectors a read-only view of healthy
 // endpoints and clones only the selected endpoint before returning it. The pick
 // callback must not mutate or retain the endpoint view.
@@ -280,7 +371,7 @@ func (s *EndpointSnapshot) PickHealthyEndpoint(pick func([]*model.Endpoint) *mod
 	if s == nil || len(s.healthy) == 0 || pick == nil {
 		return nil
 	}
-	return cloneEndpoint(pick(s.healthy))
+	return model.CloneEndpoint(pick(s.healthy))
 }
 
 func (s *EndpointSnapshot) NextHealthyEndpoint(curEndpointID string) *model.Endpoint {
@@ -296,7 +387,7 @@ func (s *EndpointSnapshot) NextHealthyEndpoint(curEndpointID string) *model.Endp
 			continue
 		}
 		if s.healthyByID[endpoint.ID] {
-			return cloneEndpoint(endpoint)
+			return model.CloneEndpoint(endpoint)
 		}
 	}
 	return nil
@@ -315,14 +406,14 @@ func (s *EndpointSnapshot) EndpointByID(endpointID string) *model.Endpoint {
 	if s == nil {
 		return nil
 	}
-	return cloneEndpoint(s.endpointByID[endpointID])
+	return model.CloneEndpoint(s.endpointByID[endpointID])
 }
 
 func (s *EndpointSnapshot) HealthyEndpointByID(endpointID string) *model.Endpoint {
 	if s == nil {
 		return nil
 	}
-	return cloneEndpoint(s.healthyEndpointByID[endpointID])
+	return model.CloneEndpoint(s.healthyEndpointByID[endpointID])
 }
 
 func (s *EndpointSnapshot) withEndpointHealth(
@@ -336,27 +427,65 @@ func (s *EndpointSnapshot) withEndpointHealth(
 	if !ok || address != endpointAddress {
 		return nil, false
 	}
-	if s.healthyByID[endpointID] == healthy {
+	return s.withEndpointHealthForIDs(map[string]struct{}{endpointID: {}}, healthy)
+}
+
+func (s *EndpointSnapshot) withEndpointAddressHealth(
+	endpointAddress string,
+	healthy bool,
+) (*EndpointSnapshot, bool) {
+	if s == nil {
+		return nil, false
+	}
+	endpointIDs := make(map[string]struct{})
+	for endpointID, address := range s.addressByID {
+		if address == endpointAddress {
+			endpointIDs[endpointID] = struct{}{}
+		}
+	}
+	return s.withEndpointHealthForIDs(endpointIDs, healthy)
+}
+
+func (s *EndpointSnapshot) withEndpointHealthForIDs(
+	endpointIDs map[string]struct{},
+	healthy bool,
+) (*EndpointSnapshot, bool) {
+	if len(endpointIDs) == 0 {
+		return nil, false
+	}
+
+	changed := false
+	for endpointID := range endpointIDs {
+		if s.healthyByID[endpointID] != healthy {
+			changed = true
+			break
+		}
+	}
+	if !changed {
 		return s, true
 	}
 
 	// Reuse unchanged endpoint/address views and rebuild the endpoint clone
 	// whose runtime health flag changed.
 	next := &EndpointSnapshot{
-		all:                 make([]*model.Endpoint, 0, len(s.all)),
-		healthy:             make([]*model.Endpoint, 0, len(s.all)),
-		endpointByID:        make(map[string]*model.Endpoint, len(s.endpointByID)),
-		healthyEndpointByID: make(map[string]*model.Endpoint, len(s.endpointByID)),
-		addressByID:         s.addressByID,
-		healthyByID:         make(map[string]bool, len(s.healthyByID)),
+		all:                  make([]*model.Endpoint, 0, len(s.all)),
+		healthy:              make([]*model.Endpoint, 0, len(s.all)),
+		endpointByID:         make(map[string]*model.Endpoint, len(s.endpointByID)),
+		healthyEndpointByID:  make(map[string]*model.Endpoint, len(s.endpointByID)),
+		addressByID:          s.addressByID,
+		healthyByID:          make(map[string]bool, len(s.healthyByID)),
+		healthyByAddress:     make(map[string]bool, len(s.healthyByAddress)),
+		lbPolicy:             s.lbPolicy,
+		consistentHashConfig: s.consistentHashConfig,
 	}
 
 	for id, wasHealthy := range s.healthyByID {
 		nextHealthy := wasHealthy
-		if id == endpointID {
+		if _, ok := endpointIDs[id]; ok {
 			nextHealthy = healthy
 		}
 		next.healthyByID[id] = nextHealthy
+		next.addAddressHealth(s.addressByID[id], nextHealthy)
 	}
 
 	for _, endpoint := range s.all {
@@ -366,8 +495,8 @@ func (s *EndpointSnapshot) withEndpointHealth(
 		}
 		id := endpoint.ID
 		nextEndpoint := endpoint
-		if id == endpointID {
-			nextEndpoint = cloneEndpoint(endpoint)
+		if _, ok := endpointIDs[id]; ok {
+			nextEndpoint = model.CloneEndpoint(endpoint)
 			nextEndpoint.UnHealthy = !healthy
 		}
 		next.all = append(next.all, nextEndpoint)
@@ -381,90 +510,13 @@ func (s *EndpointSnapshot) withEndpointHealth(
 	return next, true
 }
 
-func cloneEndpoints(endpoints []*model.Endpoint) []*model.Endpoint {
-	if endpoints == nil {
-		return nil
+func (s *EndpointSnapshot) rebuildConsistentHash() {
+	if s == nil || len(s.healthy) == 0 {
+		return
 	}
-	cloned := make([]*model.Endpoint, len(endpoints))
-	for i, endpoint := range endpoints {
-		cloned[i] = cloneEndpoint(endpoint)
+	newConsistentHash, ok := model.ConsistentHashInitMap[s.lbPolicy]
+	if !ok {
+		return
 	}
-	return cloned
-}
-
-func cloneEndpoint(endpoint *model.Endpoint) *model.Endpoint {
-	if endpoint == nil {
-		return nil
-	}
-	cloned := *endpoint
-	cloned.Address = cloneSocketAddress(endpoint.Address)
-	cloned.Metadata = cloneMetadata(endpoint.Metadata)
-	cloned.LLMMeta = cloneLLMMeta(endpoint.LLMMeta)
-	return &cloned
-}
-
-func cloneSocketAddress(address model.SocketAddress) model.SocketAddress {
-	cloned := address
-	if address.Domains != nil {
-		cloned.Domains = append([]string(nil), address.Domains...)
-	}
-	return cloned
-}
-
-func cloneMetadata(metadata map[string]string) map[string]string {
-	if metadata == nil {
-		return nil
-	}
-	cloned := make(map[string]string, len(metadata))
-	for key, value := range metadata {
-		cloned[key] = value
-	}
-	return cloned
-}
-
-func cloneLLMMeta(meta *model.LLMMeta) *model.LLMMeta {
-	if meta == nil {
-		return nil
-	}
-	cloned := *meta
-	cloned.RetryPolicy.Config = cloneAnyMap(meta.RetryPolicy.Config)
-	return &cloned
-}
-
-func cloneAnyMap(input map[string]any) map[string]any {
-	if input == nil {
-		return nil
-	}
-	cloned := make(map[string]any, len(input))
-	for key, value := range input {
-		cloned[key] = cloneAnyValue(value)
-	}
-	return cloned
-}
-
-func cloneAnyValue(value any) any {
-	switch typed := value.(type) {
-	case map[string]any:
-		return cloneAnyMap(typed)
-	case []any:
-		cloned := make([]any, len(typed))
-		for i, item := range typed {
-			cloned[i] = cloneAnyValue(item)
-		}
-		return cloned
-	case []string:
-		return append([]string(nil), typed...)
-	case []int:
-		return append([]int(nil), typed...)
-	case []int64:
-		return append([]int64(nil), typed...)
-	case []float64:
-		return append([]float64(nil), typed...)
-	case []bool:
-		return append([]bool(nil), typed...)
-	case map[string]string:
-		return cloneMetadata(typed)
-	default:
-		return value
-	}
+	s.consistentHash = model.ReadOnlyConsistentHash(newConsistentHash(s.consistentHashConfig, s.healthy))
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -117,7 +117,7 @@ func (c *Cluster) RefreshEndpointsFrom(previous *EndpointSnapshot) {
 	}
 }
 
-func (c *Cluster) UpdateEndpointHealth(endpointID string, endpointAddress string, healthy bool) bool {
+func (c *Cluster) UpdateEndpointHealth(endpointID, endpointAddress string, healthy bool) bool {
 	c.healthMu.Lock()
 	defer c.healthMu.Unlock()
 	if !c.acceptHealthEvents {
@@ -154,7 +154,7 @@ func (c *Cluster) SnapshotForRuntimeReplacement() *EndpointSnapshot {
 	return c.EndpointSnapshot()
 }
 
-func (c *Cluster) EndpointRuntimeState(endpointID string, endpointAddress string) *EndpointRuntimeState {
+func (c *Cluster) EndpointRuntimeState(endpointID, endpointAddress string) *EndpointRuntimeState {
 	return c.EndpointSnapshot().EndpointRuntimeState(endpointID, endpointAddress)
 }
 
@@ -225,7 +225,7 @@ func (s *EndpointRuntimeState) LoadMany(keys ...string) map[string]string {
 	return loaded
 }
 
-func (s *EndpointRuntimeState) Store(key string, value string) {
+func (s *EndpointRuntimeState) Store(key, value string) {
 	if s == nil {
 		return
 	}
@@ -275,7 +275,20 @@ func (s *EndpointRuntimeState) DeleteIfMatches(expected map[string]string, keys 
 }
 
 func newEndpointSnapshot(endpoints []*model.Endpoint, previous *EndpointSnapshot, inheritRuntimeHealth bool) *EndpointSnapshot {
-	snapshot := &EndpointSnapshot{
+	snapshot := newEndpointSnapshotIndex(endpoints)
+	for _, endpoint := range endpoints {
+		if endpoint == nil {
+			continue
+		}
+		address := endpoint.Address.GetAddress()
+		healthy, runtimeState := endpointSnapshotRuntimeState(endpoint, address, previous, inheritRuntimeHealth)
+		snapshot.addEndpoint(endpoint, address, healthy, runtimeState)
+	}
+	return snapshot
+}
+
+func newEndpointSnapshotIndex(endpoints []*model.Endpoint) *EndpointSnapshot {
+	return &EndpointSnapshot{
 		all:                 cloneEndpoints(endpoints),
 		healthy:             make([]*model.Endpoint, 0, len(endpoints)),
 		endpointByID:        make(map[string]*model.Endpoint, len(endpoints)),
@@ -284,39 +297,49 @@ func newEndpointSnapshot(endpoints []*model.Endpoint, previous *EndpointSnapshot
 		healthyByID:         make(map[string]bool, len(endpoints)),
 		runtimeStateByID:    make(map[string]*EndpointRuntimeState, len(endpoints)),
 	}
+}
 
-	for _, endpoint := range endpoints {
-		if endpoint == nil {
-			continue
-		}
-
-		address := endpoint.Address.GetAddress()
-		healthy := !endpoint.UnHealthy
-		runtimeState := newEndpointRuntimeState()
-		if previous != nil {
-			if previousAddress, ok := previous.addressByID[endpoint.ID]; ok && previousAddress == address {
-				// Carry health only while this runtime still has a health checker
-				// that can later correct it; otherwise seed health from config.
-				if inheritRuntimeHealth {
-					healthy = previous.healthyByID[endpoint.ID]
-				}
-				if previousRuntimeState := previous.runtimeStateByID[endpoint.ID]; previousRuntimeState != nil {
-					runtimeState = previousRuntimeState
-				}
-			}
-		}
-
-		snapshot.endpointByID[endpoint.ID] = endpoint
-		snapshot.addressByID[endpoint.ID] = address
-		snapshot.healthyByID[endpoint.ID] = healthy
-		snapshot.runtimeStateByID[endpoint.ID] = runtimeState
-		if healthy {
-			snapshot.healthy = append(snapshot.healthy, endpoint)
-			snapshot.healthyEndpointByID[endpoint.ID] = endpoint
-		}
+func endpointSnapshotRuntimeState(
+	endpoint *model.Endpoint,
+	address string,
+	previous *EndpointSnapshot,
+	inheritRuntimeHealth bool,
+) (bool, *EndpointRuntimeState) {
+	healthy := !endpoint.UnHealthy
+	runtimeState := newEndpointRuntimeState()
+	if previous == nil {
+		return healthy, runtimeState
+	}
+	previousAddress, ok := previous.addressByID[endpoint.ID]
+	if !ok || previousAddress != address {
+		return healthy, runtimeState
 	}
 
-	return snapshot
+	// Carry health only while this runtime still has a health checker that can
+	// later correct it; otherwise seed health from config.
+	if inheritRuntimeHealth {
+		healthy = previous.healthyByID[endpoint.ID]
+	}
+	if previousRuntimeState := previous.runtimeStateByID[endpoint.ID]; previousRuntimeState != nil {
+		runtimeState = previousRuntimeState
+	}
+	return healthy, runtimeState
+}
+
+func (s *EndpointSnapshot) addEndpoint(
+	endpoint *model.Endpoint,
+	address string,
+	healthy bool,
+	runtimeState *EndpointRuntimeState,
+) {
+	s.endpointByID[endpoint.ID] = endpoint
+	s.addressByID[endpoint.ID] = address
+	s.healthyByID[endpoint.ID] = healthy
+	s.runtimeStateByID[endpoint.ID] = runtimeState
+	if healthy {
+		s.healthy = append(s.healthy, endpoint)
+		s.healthyEndpointByID[endpoint.ID] = endpoint
+	}
 }
 
 func (s *EndpointSnapshot) AllEndpoints() []*model.Endpoint {
@@ -354,7 +377,7 @@ func (s *EndpointSnapshot) HealthyEndpointByID(endpointID string) *model.Endpoin
 	return s.healthyEndpointByID[endpointID]
 }
 
-func (s *EndpointSnapshot) EndpointRuntimeState(endpointID string, endpointAddress string) *EndpointRuntimeState {
+func (s *EndpointSnapshot) EndpointRuntimeState(endpointID, endpointAddress string) *EndpointRuntimeState {
 	if s == nil {
 		return nil
 	}
@@ -366,8 +389,7 @@ func (s *EndpointSnapshot) EndpointRuntimeState(endpointID string, endpointAddre
 }
 
 func (s *EndpointSnapshot) withEndpointHealth(
-	endpointID string,
-	endpointAddress string,
+	endpointID, endpointAddress string,
 	healthy bool,
 ) (*EndpointSnapshot, bool) {
 	if s == nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -269,14 +269,14 @@ func (s *EndpointSnapshot) EndpointByID(endpointID string) *model.Endpoint {
 	if s == nil {
 		return nil
 	}
-	return s.endpointByID[endpointID]
+	return cloneEndpoint(s.endpointByID[endpointID])
 }
 
 func (s *EndpointSnapshot) HealthyEndpointByID(endpointID string) *model.Endpoint {
 	if s == nil {
 		return nil
 	}
-	return s.healthyEndpointByID[endpointID]
+	return cloneEndpoint(s.healthyEndpointByID[endpointID])
 }
 
 func (s *EndpointSnapshot) withEndpointHealth(
@@ -332,7 +332,9 @@ func cloneEndpoints(endpoints []*model.Endpoint) []*model.Endpoint {
 		return nil
 	}
 	cloned := make([]*model.Endpoint, len(endpoints))
-	copy(cloned, endpoints)
+	for i, endpoint := range endpoints {
+		cloned[i] = cloneEndpoint(endpoint)
+	}
 	return cloned
 }
 
@@ -371,11 +373,44 @@ func cloneLLMMeta(meta *model.LLMMeta) *model.LLMMeta {
 		return nil
 	}
 	cloned := *meta
-	if meta.RetryPolicy.Config != nil {
-		cloned.RetryPolicy.Config = make(map[string]any, len(meta.RetryPolicy.Config))
-		for key, value := range meta.RetryPolicy.Config {
-			cloned.RetryPolicy.Config[key] = value
-		}
-	}
+	cloned.RetryPolicy.Config = cloneAnyMap(meta.RetryPolicy.Config)
 	return &cloned
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(input))
+	for key, value := range input {
+		cloned[key] = cloneAnyValue(value)
+	}
+	return cloned
+}
+
+func cloneAnyValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneAnyValue(item)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), typed...)
+	case []int:
+		return append([]int(nil), typed...)
+	case []int64:
+		return append([]int64(nil), typed...)
+	case []float64:
+		return append([]float64(nil), typed...)
+	case []bool:
+		return append([]bool(nil), typed...)
+	case map[string]string:
+		return cloneMetadata(typed)
+	default:
+		return value
+	}
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -18,6 +18,8 @@
 package cluster
 
 import (
+	"fmt"
+	"sync/atomic"
 	"testing"
 )
 
@@ -26,6 +28,9 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/healthcheck"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"   // Register Maglev for snapshot hash tests.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash" // Register RingHash for snapshot hash tests.
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
@@ -73,6 +78,110 @@ func TestClusterEndpointSnapshotEndpointCountIsNilSafe(t *testing.T) {
 	var snapshot *EndpointSnapshot
 
 	assert.Zero(t, snapshot.EndpointCount())
+}
+
+func TestClusterEndpointSnapshotBuildsConsistentHashFromRuntimeHealthyEndpoints(t *testing.T) {
+	tests := []model.LbPolicyType{
+		model.LoadBalancerRingHashing,
+		model.LoadBalancerMaglevHashing,
+	}
+
+	for _, lb := range tests {
+		t.Run(string(lb), func(t *testing.T) {
+			first := testEndpoint("ep-1", "127.0.0.1", 18080)
+			second := testEndpoint("ep-2", "127.0.0.1", 18081)
+			temporarilyUnhealthy := testEndpoint("ep-3", "127.0.0.1", 18082)
+			config := testCluster("snapshot-healthy-hash", first, second, temporarilyUnhealthy)
+			config.LbStr = lb
+			config.ConsistentHash = model.ConsistentHash{
+				ReplicaNum:      10,
+				MaxVnodeNum:     1023,
+				MaglevTableSize: 521,
+			}
+			runtimeCluster := NewCluster(config)
+
+			assert.True(t, runtimeCluster.UpdateEndpointHealth(
+				temporarilyUnhealthy.ID,
+				temporarilyUnhealthy.Address.GetAddress(),
+				false,
+			))
+
+			snapshot := runtimeCluster.EndpointSnapshot()
+			hash := snapshot.HealthyConsistentHash()
+			if !assert.NotNil(t, hash) {
+				return
+			}
+			for i := 0; i < 20; i++ {
+				host, err := hash.Get(fmt.Sprintf("request-%d", i))
+				if assert.NoError(t, err) {
+					assert.NotEqual(t, temporarilyUnhealthy.GetHost(), host)
+				}
+			}
+		})
+	}
+}
+
+func TestClusterEndpointSnapshotExposesReadOnlyConsistentHash(t *testing.T) {
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+	config := testCluster("snapshot-readonly-hash", first, second)
+	config.LbStr = model.LoadBalancerRingHashing
+	config.ConsistentHash = model.ConsistentHash{
+		ReplicaNum:  10,
+		MaxVnodeNum: 1023,
+	}
+
+	hashView := NewCluster(config).EndpointSnapshot().HealthyConsistentHash()
+	if !assert.NotNil(t, hashView) {
+		return
+	}
+	_, mutable := hashView.(model.LbConsistentHash)
+	assert.False(t, mutable)
+
+	host, err := hashView.Get("request-key")
+	assert.NoError(t, err)
+	assert.Contains(t, []string{first.GetHost(), second.GetHost()}, host)
+}
+
+func TestClusterEndpointSnapshotBuildsConsistentHashLazily(t *testing.T) {
+	var builds int32
+	lbPolicy := model.LbPolicyType("test-lazy-hash")
+	previousInit, hadPreviousInit := model.ConsistentHashInitMap[lbPolicy]
+	model.ConsistentHashInitMap[lbPolicy] = func(_ model.ConsistentHash, endpoints []*model.Endpoint) model.LbConsistentHash {
+		atomic.AddInt32(&builds, 1)
+		if len(endpoints) == 0 {
+			return countingConsistentHash{}
+		}
+		return countingConsistentHash{host: endpoints[0].GetHost()}
+	}
+	t.Cleanup(func() {
+		if hadPreviousInit {
+			model.ConsistentHashInitMap[lbPolicy] = previousInit
+			return
+		}
+		delete(model.ConsistentHashInitMap, lbPolicy)
+	})
+
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+	config := testCluster("snapshot-lazy-hash", first, second)
+	config.LbStr = lbPolicy
+	runtimeCluster := NewCluster(config)
+
+	assert.Zero(t, atomic.LoadInt32(&builds))
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(second.ID, second.Address.GetAddress(), false))
+	assert.Zero(t, atomic.LoadInt32(&builds))
+
+	snapshot := runtimeCluster.EndpointSnapshot()
+	assert.NotNil(t, snapshot.HealthyConsistentHash())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+	assert.NotNil(t, snapshot.HealthyConsistentHash())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(second.ID, second.Address.GetAddress(), true))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+	assert.NotNil(t, runtimeCluster.EndpointSnapshot().HealthyConsistentHash())
+	assert.Equal(t, int32(2), atomic.LoadInt32(&builds))
 }
 
 func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
@@ -125,6 +234,32 @@ func TestClusterEndpointSnapshotReturnsDefensiveEndpointObjects(t *testing.T) {
 	assertEndpointMatchesOriginalSnapshot(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
 }
 
+func TestNewClusterAssignsUniqueRuntimeIDsForAnonymousEndpoints(t *testing.T) {
+	first := testEndpoint("", "127.0.0.1", 18080)
+	second := testEndpoint("", "127.0.0.2", 18081)
+	runtimeCluster := NewCluster(testCluster("snapshot-anonymous-ids", first, second))
+
+	snapshot := runtimeCluster.EndpointSnapshot()
+	all := snapshot.AllEndpoints()
+	if !assert.Len(t, all, 2) {
+		return
+	}
+	assert.NotEmpty(t, all[0].ID)
+	assert.NotEmpty(t, all[1].ID)
+	assert.NotEqual(t, all[0].ID, all[1].ID)
+
+	assert.True(t, runtimeCluster.UpdateEndpointAddressHealth(first.Address.GetAddress(), false))
+	updated := runtimeCluster.EndpointSnapshot().AllEndpoints()
+	if assert.Len(t, updated, 2) {
+		assert.True(t, updated[0].UnHealthy)
+		assert.False(t, updated[1].UnHealthy)
+	}
+	healthy := runtimeCluster.EndpointSnapshot().HealthyEndpoints()
+	if assert.Len(t, healthy, 1) {
+		assert.Equal(t, second.Address.GetAddress(), healthy[0].Address.GetAddress())
+	}
+}
+
 func TestClusterEndpointHealthEventUpdatesSnapshotWithoutMutatingEndpoint(t *testing.T) {
 	endpoint := testEndpoint("ep-1", "127.0.0.1", 18082)
 	runtimeCluster := NewCluster(testCluster("snapshot-health", endpoint))
@@ -144,6 +279,36 @@ func TestClusterEndpointHealthEventUpdatesSnapshotWithoutMutatingEndpoint(t *tes
 		assert.False(t, healthyEndpoints[0].UnHealthy)
 	}
 	assert.False(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
+}
+
+func TestClusterEndpointHealthEventUpdatesSameAddressEndpoints(t *testing.T) {
+	first := testEndpoint("ep-1", "127.0.0.1", 18082)
+	second := testEndpoint("ep-2", "127.0.0.1", 18082)
+	otherAddress := testEndpoint("ep-3", "127.0.0.1", 18083)
+	runtimeCluster := NewCluster(testCluster("snapshot-shared-address-health", first, second, otherAddress))
+
+	runtimeCluster.handleEndpointHealth(healthcheck.EndpointHealthEvent{
+		EndpointID:      first.ID,
+		EndpointAddress: first.Address.GetAddress(),
+		Healthy:         false,
+	})
+
+	assert.False(t, first.UnHealthy)
+	assert.False(t, second.UnHealthy)
+	assert.True(t, runtimeCluster.EndpointSnapshot().EndpointByID(first.ID).UnHealthy)
+	assert.True(t, runtimeCluster.EndpointSnapshot().EndpointByID(second.ID).UnHealthy)
+	assert.False(t, runtimeCluster.EndpointSnapshot().EndpointByID(otherAddress.ID).UnHealthy)
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(first.ID))
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(second.ID))
+	assert.NotNil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(otherAddress.ID))
+
+	runtimeCluster.handleEndpointHealth(healthcheck.EndpointHealthEvent{
+		EndpointID:      first.ID,
+		EndpointAddress: first.Address.GetAddress(),
+		Healthy:         true,
+	})
+
+	assert.Equal(t, []*model.Endpoint{first, second, otherAddress}, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
 }
 
 func TestClusterEndpointHealthEventRestoresRuntimeEndpointHealthFlag(t *testing.T) {
@@ -222,6 +387,37 @@ func TestClusterSnapshotForRuntimeReplacementFreezesHealthEvents(t *testing.T) {
 	assert.Equal(t, replacement, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
 }
 
+func TestNewClusterWithEndpointSnapshotInheritsAddressHealthForChangedEndpointID(t *testing.T) {
+	endpoint := testEndpoint("ep-old", "127.0.0.1", 18085)
+	oldRuntime := NewCluster(testClusterWithHealthCheck("snapshot-address-old", endpoint))
+	t.Cleanup(oldRuntime.Stop)
+	oldRuntime.handleEndpointHealth(healthcheck.EndpointHealthEvent{
+		EndpointID:      endpoint.ID,
+		EndpointAddress: endpoint.Address.GetAddress(),
+		Healthy:         false,
+	})
+	previous := oldRuntime.SnapshotForRuntimeReplacement()
+
+	replacement := testEndpoint("ep-new", "127.0.0.1", 18085)
+	replacementRuntime := NewClusterWithEndpointSnapshot(
+		testClusterWithHealthCheck("snapshot-address-new", replacement),
+		previous,
+	)
+	t.Cleanup(replacementRuntime.Stop)
+
+	assert.Nil(t, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+	if got := replacementRuntime.EndpointSnapshot().EndpointByID(replacement.ID); assert.NotNil(t, got) {
+		assert.True(t, got.UnHealthy)
+	}
+
+	noHealthCheckReplacement := testEndpoint("ep-new-no-healthcheck", "127.0.0.1", 18085)
+	noHealthCheckRuntime := NewClusterWithEndpointSnapshot(
+		testCluster("snapshot-address-no-healthcheck", noHealthCheckReplacement),
+		previous,
+	)
+	assert.NotNil(t, noHealthCheckRuntime.EndpointSnapshot().HealthyEndpointByID(noHealthCheckReplacement.ID))
+}
+
 func TestNewClusterWithEndpointSnapshotInheritsHealthOnlyWhenHealthCheckEnabled(t *testing.T) {
 	endpoint := testEndpoint("ep-1", "127.0.0.1", 18085)
 	oldRuntime := NewCluster(testCluster("snapshot-constructor-old", endpoint))
@@ -298,6 +494,28 @@ func testSnapshotEndpointWithLLMMeta() *model.Endpoint {
 		},
 	}
 	return endpoint
+}
+
+type countingConsistentHash struct {
+	host string
+}
+
+func (h countingConsistentHash) Hash(string) uint32 {
+	return 0
+}
+
+func (h countingConsistentHash) Get(string) (string, error) {
+	return h.host, nil
+}
+
+func (h countingConsistentHash) GetHash(uint32) (string, error) {
+	return h.host, nil
+}
+
+func (h countingConsistentHash) Add(string) {}
+
+func (h countingConsistentHash) Remove(string) bool {
+	return false
 }
 
 func mutateReturnedEndpoint(endpoint *model.Endpoint) {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -162,13 +162,39 @@ func TestClusterEndpointHealthEventUpdatesSnapshotWithoutMutatingEndpoint(t *tes
 	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
 
 	assert.False(t, endpoint.UnHealthy)
-	assert.False(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
+	assert.True(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
 	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
 	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
 
 	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
 	assert.False(t, endpoint.UnHealthy)
-	assert.Equal(t, []*model.Endpoint{endpoint}, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+	healthyEndpoints := runtimeCluster.EndpointSnapshot().HealthyEndpoints()
+	assert.Equal(t, []*model.Endpoint{endpoint}, healthyEndpoints)
+	if assert.Len(t, healthyEndpoints, 1) {
+		assert.False(t, healthyEndpoints[0].UnHealthy)
+	}
+	assert.False(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
+}
+
+func TestClusterEndpointHealthEventRestoresRuntimeEndpointHealthFlag(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18082)
+	endpoint.UnHealthy = true
+	runtimeCluster := NewCluster(testCluster("snapshot-health-flag", endpoint))
+
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+	assert.True(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+
+	assert.True(t, endpoint.UnHealthy)
+	healthyEndpoint := runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID)
+	if assert.NotNil(t, healthyEndpoint) {
+		assert.False(t, healthyEndpoint.UnHealthy)
+	}
+	allEndpoint := runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID)
+	if assert.NotNil(t, allEndpoint) {
+		assert.False(t, allEndpoint.UnHealthy)
+	}
 }
 
 func TestClusterEndpointHealthEventIgnoresStaleAddress(t *testing.T) {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -39,8 +39,10 @@ func TestClusterEndpointSnapshotSeedsFromEndpointHealth(t *testing.T) {
 
 	assert.Equal(t, []*model.Endpoint{healthy, unhealthy}, snapshot.AllEndpoints())
 	assert.Equal(t, []*model.Endpoint{healthy}, snapshot.HealthyEndpoints())
-	assert.Same(t, healthy, snapshot.EndpointByID(healthy.ID))
-	assert.Same(t, healthy, snapshot.HealthyEndpointByID(healthy.ID))
+	assert.NotSame(t, healthy, snapshot.EndpointByID(healthy.ID))
+	assert.Equal(t, healthy, snapshot.EndpointByID(healthy.ID))
+	assert.NotSame(t, healthy, snapshot.HealthyEndpointByID(healthy.ID))
+	assert.Equal(t, healthy, snapshot.HealthyEndpointByID(healthy.ID))
 	assert.Nil(t, snapshot.HealthyEndpointByID(unhealthy.ID))
 }
 
@@ -59,14 +61,51 @@ func TestClusterEndpointSnapshotReturnsDefensiveEndpointSlices(t *testing.T) {
 	assert.Equal(t, []*model.Endpoint{first, second}, snapshot.AllEndpoints())
 	assert.Equal(t, []*model.Endpoint{first, second}, snapshot.HealthyEndpoints())
 	assert.Equal(t, 2, snapshot.EndpointCount())
-	assert.Same(t, first, snapshot.EndpointByID(first.ID))
-	assert.Same(t, first, snapshot.HealthyEndpointByID(first.ID))
+	assert.NotSame(t, first, snapshot.EndpointByID(first.ID))
+	assert.Equal(t, first, snapshot.EndpointByID(first.ID))
+	assert.Same(t, snapshot.EndpointByID(first.ID), snapshot.HealthyEndpointByID(first.ID))
 }
 
 func TestClusterEndpointSnapshotEndpointCountIsNilSafe(t *testing.T) {
 	var snapshot *EndpointSnapshot
 
 	assert.Zero(t, snapshot.EndpointCount())
+}
+
+func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
+	endpoint.Address.Domains = []string{"api.example.com"}
+	endpoint.Metadata = map[string]string{"weight": "3"}
+	endpoint.LLMMeta = &model.LLMMeta{
+		Provider: "openai",
+		APIKey:   "old-key",
+		RetryPolicy: model.RetryPolicy{
+			Config: map[string]any{"attempts": 1},
+		},
+	}
+
+	runtimeCluster := NewCluster(testCluster("snapshot-clone", endpoint))
+	snapshotEndpoint := runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID)
+	if !assert.NotNil(t, snapshotEndpoint) {
+		return
+	}
+
+	assert.NotSame(t, endpoint, snapshotEndpoint)
+	assert.NotSame(t, endpoint.LLMMeta, snapshotEndpoint.LLMMeta)
+
+	endpoint.Address.Address = "127.0.0.2"
+	endpoint.Address.Domains[0] = "changed.example.com"
+	endpoint.Metadata["weight"] = "9"
+	endpoint.LLMMeta.APIKey = "new-key"
+	endpoint.LLMMeta.RetryPolicy.Config["attempts"] = 2
+	endpoint.UnHealthy = true
+
+	assert.Equal(t, model.SocketAddress{Address: "127.0.0.1", Port: 18080, Domains: []string{"api.example.com"}}, snapshotEndpoint.Address)
+	assert.Equal(t, "api.example.com", snapshotEndpoint.Address.GetAddress())
+	assert.Equal(t, map[string]string{"weight": "3"}, snapshotEndpoint.Metadata)
+	assert.Equal(t, "old-key", snapshotEndpoint.LLMMeta.APIKey)
+	assert.Equal(t, 1, snapshotEndpoint.LLMMeta.RetryPolicy.Config["attempts"])
+	assert.False(t, snapshotEndpoint.UnHealthy)
 }
 
 func TestClusterEndpointHealthEventUpdatesSnapshotWithoutMutatingEndpoint(t *testing.T) {
@@ -76,6 +115,7 @@ func TestClusterEndpointHealthEventUpdatesSnapshotWithoutMutatingEndpoint(t *tes
 	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
 
 	assert.False(t, endpoint.UnHealthy)
+	assert.False(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
 	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
 	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
 
@@ -135,17 +175,13 @@ func TestClusterSnapshotForRuntimeReplacementFreezesHealthEvents(t *testing.T) {
 
 	assert.Nil(t, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
 	assert.True(t, replacementRuntime.UpdateEndpointHealth(replacement.ID, replacement.Address.GetAddress(), true))
-	assert.Same(t, replacement, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+	assert.NotSame(t, replacement, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+	assert.Equal(t, replacement, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
 }
 
 func TestNewClusterWithEndpointSnapshotInheritsHealthOnlyWhenHealthCheckEnabled(t *testing.T) {
 	endpoint := testEndpoint("ep-1", "127.0.0.1", 18085)
 	oldRuntime := NewCluster(testCluster("snapshot-constructor-old", endpoint))
-	state := oldRuntime.EndpointRuntimeState(endpoint.ID, endpoint.Address.GetAddress())
-	if !assert.NotNil(t, state) {
-		return
-	}
-	state.Store("cooldown", "true")
 	assert.True(t, oldRuntime.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
 	previous := oldRuntime.EndpointSnapshot()
 
@@ -156,151 +192,22 @@ func TestNewClusterWithEndpointSnapshotInheritsHealthOnlyWhenHealthCheckEnabled(
 	)
 	t.Cleanup(replacementRuntime.Stop)
 	assert.Nil(t, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
-	if carriedState := replacementRuntime.EndpointRuntimeState(replacement.ID, replacement.Address.GetAddress()); assert.Same(t, state, carriedState) {
-		value, ok := carriedState.Load("cooldown")
-		assert.True(t, ok)
-		assert.Equal(t, "true", value)
-	}
 
 	noHealthCheckReplacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
 	noHealthCheckRuntime := NewClusterWithEndpointSnapshot(
 		testCluster("snapshot-constructor-no-healthcheck", noHealthCheckReplacement),
 		previous,
 	)
-	assert.Same(t, noHealthCheckReplacement, noHealthCheckRuntime.EndpointSnapshot().HealthyEndpointByID(noHealthCheckReplacement.ID))
-	if carriedState := noHealthCheckRuntime.EndpointRuntimeState(noHealthCheckReplacement.ID, noHealthCheckReplacement.Address.GetAddress()); assert.Same(t, state, carriedState) {
-		value, ok := carriedState.Load("cooldown")
-		assert.True(t, ok)
-		assert.Equal(t, "true", value)
-	}
+	assert.NotSame(t, noHealthCheckReplacement, noHealthCheckRuntime.EndpointSnapshot().HealthyEndpointByID(noHealthCheckReplacement.ID))
+	assert.Equal(t, noHealthCheckReplacement, noHealthCheckRuntime.EndpointSnapshot().HealthyEndpointByID(noHealthCheckReplacement.ID))
 
 	moved := testEndpoint(endpoint.ID, "127.0.0.2", 18086)
 	movedRuntime := NewClusterWithEndpointSnapshot(
 		testCluster("snapshot-constructor-moved", moved),
 		previous,
 	)
-	assert.Same(t, moved, movedRuntime.EndpointSnapshot().HealthyEndpointByID(moved.ID))
-	movedState := movedRuntime.EndpointRuntimeState(moved.ID, moved.Address.GetAddress())
-	if assert.NotNil(t, movedState) {
-		_, ok := movedState.Load("cooldown")
-		assert.False(t, ok)
-	}
-}
-
-func TestClusterEndpointRuntimeStateFollowsSameAddressOnly(t *testing.T) {
-	endpoint := testEndpoint("ep-1", "127.0.0.1", 18085)
-	config := testCluster("runtime-state", endpoint)
-	runtimeCluster := NewCluster(config)
-	address := endpoint.Address.GetAddress()
-
-	state := runtimeCluster.EndpointRuntimeState(endpoint.ID, address)
-	if !assert.NotNil(t, state) {
-		return
-	}
-	state.Store("cooldown", "true")
-
-	replacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
-	config.Endpoints[0] = replacement
-	runtimeCluster.RefreshEndpoints()
-
-	carriedState := runtimeCluster.EndpointRuntimeState(replacement.ID, replacement.Address.GetAddress())
-	if assert.Same(t, state, carriedState) {
-		value, ok := carriedState.Load("cooldown")
-		assert.True(t, ok)
-		assert.Equal(t, "true", value)
-	}
-
-	moved := testEndpoint(endpoint.ID, "127.0.0.2", 18086)
-	config.Endpoints[0] = moved
-	runtimeCluster.RefreshEndpoints()
-
-	assert.Nil(t, runtimeCluster.EndpointRuntimeState(endpoint.ID, address))
-	movedState := runtimeCluster.EndpointRuntimeState(moved.ID, moved.Address.GetAddress())
-	if assert.NotNil(t, movedState) {
-		_, ok := movedState.Load("cooldown")
-		assert.False(t, ok)
-	}
-
-	config.Endpoints = nil
-	runtimeCluster.RefreshEndpoints()
-	assert.Nil(t, runtimeCluster.EndpointRuntimeState(moved.ID, moved.Address.GetAddress()))
-}
-
-func TestEndpointRuntimeStateLoadManyReturnsCopy(t *testing.T) {
-	state := newEndpointRuntimeState()
-	state.StoreMany(map[string]string{
-		"cooldown": "true",
-		"checked":  "now",
-	})
-
-	values := state.LoadMany("cooldown", "checked", "missing")
-	assert.Equal(t, map[string]string{
-		"cooldown": "true",
-		"checked":  "now",
-	}, values)
-
-	values["cooldown"] = "false"
-	value, ok := state.Load("cooldown")
-	assert.True(t, ok)
-	assert.Equal(t, "true", value)
-}
-
-func TestEndpointRuntimeStateStoreManyStoresPair(t *testing.T) {
-	state := newEndpointRuntimeState()
-
-	state.StoreMany(map[string]string{
-		"unhealthy": "true",
-		"checked":   "now",
-	})
-
-	values := state.LoadMany("unhealthy", "checked")
-	assert.Equal(t, "true", values["unhealthy"])
-	assert.Equal(t, "now", values["checked"])
-}
-
-func TestEndpointRuntimeStateDeleteIfMatchesDeletesMatchingValues(t *testing.T) {
-	state := newEndpointRuntimeState()
-	state.StoreMany(map[string]string{
-		"unhealthy": "true",
-		"checked":   "old",
-		"stable":    "keep",
-	})
-
-	assert.True(t, state.DeleteIfMatches(
-		map[string]string{
-			"unhealthy": "true",
-			"checked":   "old",
-		},
-		"unhealthy",
-		"checked",
-	))
-
-	_, ok := state.Load("unhealthy")
-	assert.False(t, ok)
-	_, ok = state.Load("checked")
-	assert.False(t, ok)
-	stable, ok := state.Load("stable")
-	assert.True(t, ok)
-	assert.Equal(t, "keep", stable)
-}
-
-func TestEndpointRuntimeStateDeleteIfMatchesPreservesRefreshedValues(t *testing.T) {
-	state := newEndpointRuntimeState()
-	state.StoreMany(map[string]string{
-		"unhealthy": "true",
-		"checked":   "old",
-	})
-	expected := state.LoadMany("unhealthy", "checked")
-
-	state.Store("checked", "new")
-
-	assert.False(t, state.DeleteIfMatches(expected, "unhealthy", "checked"))
-	unhealthy, ok := state.Load("unhealthy")
-	assert.True(t, ok)
-	assert.Equal(t, "true", unhealthy)
-	checked, ok := state.Load("checked")
-	assert.True(t, ok)
-	assert.Equal(t, "new", checked)
+	assert.NotSame(t, moved, movedRuntime.EndpointSnapshot().HealthyEndpointByID(moved.ID))
+	assert.Equal(t, moved, movedRuntime.EndpointSnapshot().HealthyEndpointByID(moved.ID))
 }
 
 func testCluster(name string, endpoints ...*model.Endpoint) *model.ClusterConfig {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -76,22 +76,7 @@ func TestClusterEndpointSnapshotEndpointCountIsNilSafe(t *testing.T) {
 }
 
 func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
-	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
-	endpoint.Address.Domains = []string{"api.example.com"}
-	endpoint.Metadata = map[string]string{"weight": "3"}
-	endpoint.LLMMeta = &model.LLMMeta{
-		Provider: "openai",
-		APIKey:   "old-key",
-		RetryPolicy: model.RetryPolicy{
-			Config: map[string]any{
-				"attempts": 1,
-				"nested": map[string]any{
-					"delays": []any{"100ms"},
-				},
-			},
-		},
-	}
-
+	endpoint := testSnapshotEndpointWithLLMMeta()
 	runtimeCluster := NewCluster(testCluster("snapshot-clone", endpoint))
 	snapshotEndpoint := runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID)
 	if !assert.NotNil(t, snapshotEndpoint) {
@@ -113,22 +98,7 @@ func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
 }
 
 func TestClusterEndpointSnapshotReturnsDefensiveEndpointObjects(t *testing.T) {
-	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
-	endpoint.Address.Domains = []string{"api.example.com"}
-	endpoint.Metadata = map[string]string{"weight": "3"}
-	endpoint.LLMMeta = &model.LLMMeta{
-		Provider: "openai",
-		APIKey:   "old-key",
-		RetryPolicy: model.RetryPolicy{
-			Config: map[string]any{
-				"attempts": 1,
-				"nested": map[string]any{
-					"delays": []any{"100ms"},
-				},
-			},
-		},
-	}
-
+	endpoint := testSnapshotEndpointWithLLMMeta()
 	runtimeCluster := NewCluster(testCluster("snapshot-defensive-endpoint", endpoint))
 	snapshot := runtimeCluster.EndpointSnapshot()
 
@@ -309,6 +279,25 @@ func testEndpoint(id string, host string, port int) *model.Endpoint {
 			Port:    port,
 		},
 	}
+}
+
+func testSnapshotEndpointWithLLMMeta() *model.Endpoint {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
+	endpoint.Address.Domains = []string{"api.example.com"}
+	endpoint.Metadata = map[string]string{"weight": "3"}
+	endpoint.LLMMeta = &model.LLMMeta{
+		Provider: "openai",
+		APIKey:   "old-key",
+		RetryPolicy: model.RetryPolicy{
+			Config: map[string]any{
+				"attempts": 1,
+				"nested": map[string]any{
+					"delays": []any{"100ms"},
+				},
+			},
+		},
+	}
+	return endpoint
 }
 
 func mutateReturnedEndpoint(endpoint *model.Endpoint) {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -80,6 +80,30 @@ func TestClusterEndpointSnapshotEndpointCountIsNilSafe(t *testing.T) {
 	assert.Zero(t, snapshot.EndpointCount())
 }
 
+func TestClusterEndpointSnapshotForPickAccessorsAliasInternalStorage(t *testing.T) {
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+
+	runtimeCluster := NewCluster(testCluster("snapshot-for-pick-alias", first, second))
+	snapshot := runtimeCluster.EndpointSnapshot()
+
+	healthy1 := snapshot.HealthyEndpointsForPick()
+	healthy2 := snapshot.HealthyEndpointsForPick()
+	if assert.Len(t, healthy1, 2) && assert.Len(t, healthy2, 2) {
+		assert.Same(t, &healthy1[0], &healthy2[0])
+	}
+
+	all1 := snapshot.AllEndpointsForPick()
+	all2 := snapshot.AllEndpointsForPick()
+	if assert.Len(t, all1, 2) && assert.Len(t, all2, 2) {
+		assert.Same(t, &all1[0], &all2[0])
+	}
+
+	var nilSnapshot *EndpointSnapshot
+	assert.Nil(t, nilSnapshot.HealthyEndpointsForPick())
+	assert.Nil(t, nilSnapshot.AllEndpointsForPick())
+}
+
 func TestClusterEndpointSnapshotBuildsConsistentHashFromRuntimeHealthyEndpoints(t *testing.T) {
 	tests := []model.LbPolicyType{
 		model.LoadBalancerRingHashing,

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -63,7 +63,10 @@ func TestClusterEndpointSnapshotReturnsDefensiveEndpointSlices(t *testing.T) {
 	assert.Equal(t, 2, snapshot.EndpointCount())
 	assert.NotSame(t, first, snapshot.EndpointByID(first.ID))
 	assert.Equal(t, first, snapshot.EndpointByID(first.ID))
-	assert.Same(t, snapshot.EndpointByID(first.ID), snapshot.HealthyEndpointByID(first.ID))
+	endpointByID := snapshot.EndpointByID(first.ID)
+	healthyByID := snapshot.HealthyEndpointByID(first.ID)
+	assert.NotSame(t, endpointByID, healthyByID)
+	assert.Equal(t, endpointByID, healthyByID)
 }
 
 func TestClusterEndpointSnapshotEndpointCountIsNilSafe(t *testing.T) {
@@ -80,7 +83,12 @@ func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
 		Provider: "openai",
 		APIKey:   "old-key",
 		RetryPolicy: model.RetryPolicy{
-			Config: map[string]any{"attempts": 1},
+			Config: map[string]any{
+				"attempts": 1,
+				"nested": map[string]any{
+					"delays": []any{"100ms"},
+				},
+			},
 		},
 	}
 
@@ -98,14 +106,53 @@ func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
 	endpoint.Metadata["weight"] = "9"
 	endpoint.LLMMeta.APIKey = "new-key"
 	endpoint.LLMMeta.RetryPolicy.Config["attempts"] = 2
+	endpoint.LLMMeta.RetryPolicy.Config["nested"].(map[string]any)["delays"].([]any)[0] = "200ms"
 	endpoint.UnHealthy = true
 
-	assert.Equal(t, model.SocketAddress{Address: "127.0.0.1", Port: 18080, Domains: []string{"api.example.com"}}, snapshotEndpoint.Address)
-	assert.Equal(t, "api.example.com", snapshotEndpoint.Address.GetAddress())
-	assert.Equal(t, map[string]string{"weight": "3"}, snapshotEndpoint.Metadata)
-	assert.Equal(t, "old-key", snapshotEndpoint.LLMMeta.APIKey)
-	assert.Equal(t, 1, snapshotEndpoint.LLMMeta.RetryPolicy.Config["attempts"])
-	assert.False(t, snapshotEndpoint.UnHealthy)
+	assertEndpointMatchesOriginalSnapshot(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID))
+}
+
+func TestClusterEndpointSnapshotReturnsDefensiveEndpointObjects(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
+	endpoint.Address.Domains = []string{"api.example.com"}
+	endpoint.Metadata = map[string]string{"weight": "3"}
+	endpoint.LLMMeta = &model.LLMMeta{
+		Provider: "openai",
+		APIKey:   "old-key",
+		RetryPolicy: model.RetryPolicy{
+			Config: map[string]any{
+				"attempts": 1,
+				"nested": map[string]any{
+					"delays": []any{"100ms"},
+				},
+			},
+		},
+	}
+
+	runtimeCluster := NewCluster(testCluster("snapshot-defensive-endpoint", endpoint))
+	snapshot := runtimeCluster.EndpointSnapshot()
+
+	all := snapshot.AllEndpoints()
+	healthy := snapshot.HealthyEndpoints()
+	byID := snapshot.EndpointByID(endpoint.ID)
+	healthyByID := snapshot.HealthyEndpointByID(endpoint.ID)
+
+	assert.NotSame(t, all[0], healthy[0])
+	assert.NotSame(t, all[0], byID)
+	assert.NotSame(t, byID, healthyByID)
+
+	mutateReturnedEndpoint(all[0])
+	mutateReturnedEndpoint(healthy[0])
+	mutateReturnedEndpoint(byID)
+	mutateReturnedEndpoint(healthyByID)
+
+	assertEndpointMatchesOriginalSnapshot(t, snapshot.EndpointByID(endpoint.ID))
+	assertEndpointMatchesOriginalSnapshot(t, snapshot.HealthyEndpointByID(endpoint.ID))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+	assertEndpointMatchesOriginalSnapshot(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
 }
 
 func TestClusterEndpointHealthEventUpdatesSnapshotWithoutMutatingEndpoint(t *testing.T) {
@@ -236,4 +283,30 @@ func testEndpoint(id string, host string, port int) *model.Endpoint {
 			Port:    port,
 		},
 	}
+}
+
+func mutateReturnedEndpoint(endpoint *model.Endpoint) {
+	endpoint.Name = "mutated"
+	endpoint.Address.Address = "127.0.0.2"
+	endpoint.Address.Domains[0] = "changed.example.com"
+	endpoint.Metadata["weight"] = "9"
+	endpoint.LLMMeta.APIKey = "new-key"
+	endpoint.LLMMeta.RetryPolicy.Config["attempts"] = 2
+	endpoint.LLMMeta.RetryPolicy.Config["nested"].(map[string]any)["delays"].([]any)[0] = "200ms"
+	endpoint.UnHealthy = true
+}
+
+func assertEndpointMatchesOriginalSnapshot(t *testing.T, endpoint *model.Endpoint) {
+	t.Helper()
+
+	if !assert.NotNil(t, endpoint) {
+		return
+	}
+	assert.Equal(t, "endpoint-ep-1", endpoint.Name)
+	assert.Equal(t, model.SocketAddress{Address: "127.0.0.1", Port: 18080, Domains: []string{"api.example.com"}}, endpoint.Address)
+	assert.Equal(t, map[string]string{"weight": "3"}, endpoint.Metadata)
+	assert.Equal(t, "old-key", endpoint.LLMMeta.APIKey)
+	assert.Equal(t, 1, endpoint.LLMMeta.RetryPolicy.Config["attempts"])
+	assert.Equal(t, "100ms", endpoint.LLMMeta.RetryPolicy.Config["nested"].(map[string]any)["delays"].([]any)[0])
+	assert.False(t, endpoint.UnHealthy)
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+func TestClusterEndpointSnapshotSeedsFromEndpointHealth(t *testing.T) {
+	healthy := testEndpoint("ep-1", "127.0.0.1", 18080)
+	unhealthy := testEndpoint("ep-2", "127.0.0.1", 18081)
+	unhealthy.UnHealthy = true
+
+	runtimeCluster := NewCluster(testCluster("snapshot-seed", healthy, unhealthy))
+	snapshot := runtimeCluster.EndpointSnapshot()
+
+	assert.Equal(t, []*model.Endpoint{healthy, unhealthy}, snapshot.AllEndpoints())
+	assert.Equal(t, []*model.Endpoint{healthy}, snapshot.HealthyEndpoints())
+	assert.Same(t, healthy, snapshot.EndpointByID(healthy.ID))
+	assert.Same(t, healthy, snapshot.HealthyEndpointByID(healthy.ID))
+	assert.Nil(t, snapshot.HealthyEndpointByID(unhealthy.ID))
+}
+
+func TestClusterEndpointSnapshotReturnsDefensiveEndpointSlices(t *testing.T) {
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+
+	runtimeCluster := NewCluster(testCluster("snapshot-defensive-copy", first, second))
+	snapshot := runtimeCluster.EndpointSnapshot()
+
+	all := snapshot.AllEndpoints()
+	healthy := snapshot.HealthyEndpoints()
+	all[0] = nil
+	healthy[0] = nil
+
+	assert.Equal(t, []*model.Endpoint{first, second}, snapshot.AllEndpoints())
+	assert.Equal(t, []*model.Endpoint{first, second}, snapshot.HealthyEndpoints())
+	assert.Equal(t, 2, snapshot.EndpointCount())
+	assert.Same(t, first, snapshot.EndpointByID(first.ID))
+	assert.Same(t, first, snapshot.HealthyEndpointByID(first.ID))
+}
+
+func TestClusterEndpointSnapshotEndpointCountIsNilSafe(t *testing.T) {
+	var snapshot *EndpointSnapshot
+
+	assert.Zero(t, snapshot.EndpointCount())
+}
+
+func TestClusterEndpointHealthEventUpdatesSnapshotWithoutMutatingEndpoint(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18082)
+	runtimeCluster := NewCluster(testCluster("snapshot-health", endpoint))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+
+	assert.False(t, endpoint.UnHealthy)
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+	assert.False(t, endpoint.UnHealthy)
+	assert.Equal(t, []*model.Endpoint{endpoint}, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+}
+
+func TestClusterEndpointHealthEventIgnoresStaleAddress(t *testing.T) {
+	oldEndpoint := testEndpoint("ep-1", "127.0.0.1", 18083)
+	oldAddress := oldEndpoint.Address.GetAddress()
+	config := testCluster("snapshot-stale-address", oldEndpoint)
+	runtimeCluster := NewCluster(config)
+
+	newEndpoint := testEndpoint("ep-1", "127.0.0.2", 18084)
+	config.Endpoints[0] = newEndpoint
+	runtimeCluster.RefreshEndpoints()
+
+	assert.False(t, runtimeCluster.UpdateEndpointHealth(newEndpoint.ID, oldAddress, false))
+	assert.Equal(t, []*model.Endpoint{newEndpoint}, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(newEndpoint.ID, newEndpoint.Address.GetAddress(), false))
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+}
+
+func TestClusterRefreshEndpointsFromDoesNotOverwriteNewerHealthUpdate(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18084)
+	runtimeCluster := NewCluster(testClusterWithHealthCheck("snapshot-refresh-cas", endpoint))
+	t.Cleanup(runtimeCluster.Stop)
+	staleSnapshot := runtimeCluster.EndpointSnapshot()
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	runtimeCluster.RefreshEndpointsFrom(staleSnapshot)
+
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+}
+
+func TestClusterSnapshotForRuntimeReplacementFreezesHealthEvents(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18085)
+	runtimeCluster := NewCluster(testClusterWithHealthCheck("snapshot-freeze", endpoint))
+	t.Cleanup(runtimeCluster.Stop)
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	frozen := runtimeCluster.SnapshotForRuntimeReplacement()
+
+	assert.Nil(t, frozen.HealthyEndpointByID(endpoint.ID))
+	assert.False(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+
+	replacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
+	replacementRuntime := NewClusterWithEndpointSnapshot(
+		testClusterWithHealthCheck("snapshot-freeze-replacement", replacement),
+		frozen,
+	)
+	t.Cleanup(replacementRuntime.Stop)
+
+	assert.Nil(t, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+	assert.True(t, replacementRuntime.UpdateEndpointHealth(replacement.ID, replacement.Address.GetAddress(), true))
+	assert.Same(t, replacement, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+}
+
+func TestNewClusterWithEndpointSnapshotInheritsHealthOnlyWhenHealthCheckEnabled(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18085)
+	oldRuntime := NewCluster(testCluster("snapshot-constructor-old", endpoint))
+	state := oldRuntime.EndpointRuntimeState(endpoint.ID, endpoint.Address.GetAddress())
+	if !assert.NotNil(t, state) {
+		return
+	}
+	state.Store("cooldown", "true")
+	assert.True(t, oldRuntime.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	previous := oldRuntime.EndpointSnapshot()
+
+	replacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
+	replacementRuntime := NewClusterWithEndpointSnapshot(
+		testClusterWithHealthCheck("snapshot-constructor-same", replacement),
+		previous,
+	)
+	t.Cleanup(replacementRuntime.Stop)
+	assert.Nil(t, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+	if carriedState := replacementRuntime.EndpointRuntimeState(replacement.ID, replacement.Address.GetAddress()); assert.Same(t, state, carriedState) {
+		value, ok := carriedState.Load("cooldown")
+		assert.True(t, ok)
+		assert.Equal(t, "true", value)
+	}
+
+	noHealthCheckReplacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
+	noHealthCheckRuntime := NewClusterWithEndpointSnapshot(
+		testCluster("snapshot-constructor-no-healthcheck", noHealthCheckReplacement),
+		previous,
+	)
+	assert.Same(t, noHealthCheckReplacement, noHealthCheckRuntime.EndpointSnapshot().HealthyEndpointByID(noHealthCheckReplacement.ID))
+	if carriedState := noHealthCheckRuntime.EndpointRuntimeState(noHealthCheckReplacement.ID, noHealthCheckReplacement.Address.GetAddress()); assert.Same(t, state, carriedState) {
+		value, ok := carriedState.Load("cooldown")
+		assert.True(t, ok)
+		assert.Equal(t, "true", value)
+	}
+
+	moved := testEndpoint(endpoint.ID, "127.0.0.2", 18086)
+	movedRuntime := NewClusterWithEndpointSnapshot(
+		testCluster("snapshot-constructor-moved", moved),
+		previous,
+	)
+	assert.Same(t, moved, movedRuntime.EndpointSnapshot().HealthyEndpointByID(moved.ID))
+	movedState := movedRuntime.EndpointRuntimeState(moved.ID, moved.Address.GetAddress())
+	if assert.NotNil(t, movedState) {
+		_, ok := movedState.Load("cooldown")
+		assert.False(t, ok)
+	}
+}
+
+func TestClusterEndpointRuntimeStateFollowsSameAddressOnly(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18085)
+	config := testCluster("runtime-state", endpoint)
+	runtimeCluster := NewCluster(config)
+	address := endpoint.Address.GetAddress()
+
+	state := runtimeCluster.EndpointRuntimeState(endpoint.ID, address)
+	if !assert.NotNil(t, state) {
+		return
+	}
+	state.Store("cooldown", "true")
+
+	replacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
+	config.Endpoints[0] = replacement
+	runtimeCluster.RefreshEndpoints()
+
+	carriedState := runtimeCluster.EndpointRuntimeState(replacement.ID, replacement.Address.GetAddress())
+	if assert.Same(t, state, carriedState) {
+		value, ok := carriedState.Load("cooldown")
+		assert.True(t, ok)
+		assert.Equal(t, "true", value)
+	}
+
+	moved := testEndpoint(endpoint.ID, "127.0.0.2", 18086)
+	config.Endpoints[0] = moved
+	runtimeCluster.RefreshEndpoints()
+
+	assert.Nil(t, runtimeCluster.EndpointRuntimeState(endpoint.ID, address))
+	movedState := runtimeCluster.EndpointRuntimeState(moved.ID, moved.Address.GetAddress())
+	if assert.NotNil(t, movedState) {
+		_, ok := movedState.Load("cooldown")
+		assert.False(t, ok)
+	}
+
+	config.Endpoints = nil
+	runtimeCluster.RefreshEndpoints()
+	assert.Nil(t, runtimeCluster.EndpointRuntimeState(moved.ID, moved.Address.GetAddress()))
+}
+
+func TestEndpointRuntimeStateLoadManyReturnsCopy(t *testing.T) {
+	state := newEndpointRuntimeState()
+	state.StoreMany(map[string]string{
+		"cooldown": "true",
+		"checked":  "now",
+	})
+
+	values := state.LoadMany("cooldown", "checked", "missing")
+	assert.Equal(t, map[string]string{
+		"cooldown": "true",
+		"checked":  "now",
+	}, values)
+
+	values["cooldown"] = "false"
+	value, ok := state.Load("cooldown")
+	assert.True(t, ok)
+	assert.Equal(t, "true", value)
+}
+
+func TestEndpointRuntimeStateStoreManyStoresPair(t *testing.T) {
+	state := newEndpointRuntimeState()
+
+	state.StoreMany(map[string]string{
+		"unhealthy": "true",
+		"checked":   "now",
+	})
+
+	values := state.LoadMany("unhealthy", "checked")
+	assert.Equal(t, "true", values["unhealthy"])
+	assert.Equal(t, "now", values["checked"])
+}
+
+func TestEndpointRuntimeStateDeleteIfMatchesDeletesMatchingValues(t *testing.T) {
+	state := newEndpointRuntimeState()
+	state.StoreMany(map[string]string{
+		"unhealthy": "true",
+		"checked":   "old",
+		"stable":    "keep",
+	})
+
+	assert.True(t, state.DeleteIfMatches(
+		map[string]string{
+			"unhealthy": "true",
+			"checked":   "old",
+		},
+		"unhealthy",
+		"checked",
+	))
+
+	_, ok := state.Load("unhealthy")
+	assert.False(t, ok)
+	_, ok = state.Load("checked")
+	assert.False(t, ok)
+	stable, ok := state.Load("stable")
+	assert.True(t, ok)
+	assert.Equal(t, "keep", stable)
+}
+
+func TestEndpointRuntimeStateDeleteIfMatchesPreservesRefreshedValues(t *testing.T) {
+	state := newEndpointRuntimeState()
+	state.StoreMany(map[string]string{
+		"unhealthy": "true",
+		"checked":   "old",
+	})
+	expected := state.LoadMany("unhealthy", "checked")
+
+	state.Store("checked", "new")
+
+	assert.False(t, state.DeleteIfMatches(expected, "unhealthy", "checked"))
+	unhealthy, ok := state.Load("unhealthy")
+	assert.True(t, ok)
+	assert.Equal(t, "true", unhealthy)
+	checked, ok := state.Load("checked")
+	assert.True(t, ok)
+	assert.Equal(t, "new", checked)
+}
+
+func testCluster(name string, endpoints ...*model.Endpoint) *model.ClusterConfig {
+	return &model.ClusterConfig{
+		Name:      name,
+		Endpoints: endpoints,
+	}
+}
+
+func testClusterWithHealthCheck(name string, endpoints ...*model.Endpoint) *model.ClusterConfig {
+	config := testCluster(name, endpoints...)
+	config.HealthChecks = []model.HealthCheckConfig{{
+		Protocol:       "tcp",
+		TimeoutConfig:  "1h",
+		IntervalConfig: "1h",
+	}}
+	return config
+}
+
+func testEndpoint(id string, host string, port int) *model.Endpoint {
+	return &model.Endpoint{
+		ID:   id,
+		Name: "endpoint-" + id,
+		Address: model.SocketAddress{
+			Address: host,
+			Port:    port,
+		},
+	}
+}

--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -157,8 +157,10 @@ func (hc *HealthChecker) Start() {
 }
 
 func (hc *HealthChecker) Stop() {
-	for _, h := range hc.cluster.Endpoints {
-		hc.stopCheck(h)
+	for addr, h := range hc.checkers {
+		h.Stop()
+		delete(hc.checkers, addr)
+		logger.Infof("[health check] stop a health check session for %s", addr)
 	}
 }
 
@@ -171,6 +173,9 @@ func (hc *HealthChecker) StartOne(endpoint *model.Endpoint) {
 }
 
 func (hc *HealthChecker) startCheck(endpoint *model.Endpoint) {
+	if endpoint == nil {
+		return
+	}
 	addr := endpoint.Address.GetAddress()
 	if _, ok := hc.checkers[addr]; !ok {
 		c := newChecker(endpoint, hc)
@@ -181,12 +186,36 @@ func (hc *HealthChecker) startCheck(endpoint *model.Endpoint) {
 }
 
 func (hc *HealthChecker) stopCheck(endpoint *model.Endpoint) {
+	if endpoint == nil {
+		return
+	}
 	addr := endpoint.Address.GetAddress()
+	if hc.hasOtherEndpointWithAddress(endpoint, addr) {
+		return
+	}
 	if c, ok := hc.checkers[addr]; ok {
 		c.Stop()
 		delete(hc.checkers, addr)
-		logger.Infof("[health check] create a health check session for %s", addr)
+		logger.Infof("[health check] stop a health check session for %s", addr)
 	}
+}
+
+func (hc *HealthChecker) hasOtherEndpointWithAddress(endpoint *model.Endpoint, addr string) bool {
+	if hc.cluster == nil {
+		return false
+	}
+	for _, candidate := range hc.cluster.Endpoints {
+		if candidate == nil || candidate == endpoint {
+			continue
+		}
+		if endpoint.ID != "" && candidate.ID == endpoint.ID {
+			continue
+		}
+		if candidate.Address.GetAddress() == addr {
+			return true
+		}
+	}
+	return false
 }
 
 func newChecker(endpoint *model.Endpoint, hc *HealthChecker) *EndpointChecker {
@@ -337,7 +366,9 @@ func (c *EndpointChecker) emitHealth(healthy bool) {
 	if c.HealthChecker.onEndpointHealth == nil {
 		// Direct CreateHealthCheck callers still observe health through
 		// Endpoint.UnHealthy; runtime clusters install a snapshot callback.
-		c.endpoint.UnHealthy = !healthy
+		if !c.HealthChecker.setEndpointAddressHealth(c.endpointAddr, healthy) {
+			c.endpoint.UnHealthy = !healthy
+		}
 		return
 	}
 	c.HealthChecker.onEndpointHealth(EndpointHealthEvent{
@@ -345,6 +376,21 @@ func (c *EndpointChecker) emitHealth(healthy bool) {
 		EndpointAddress: c.endpointAddr,
 		Healthy:         healthy,
 	})
+}
+
+func (hc *HealthChecker) setEndpointAddressHealth(addr string, healthy bool) bool {
+	if hc.cluster == nil {
+		return false
+	}
+	updated := false
+	for _, endpoint := range hc.cluster.Endpoints {
+		if endpoint == nil || endpoint.Address.GetAddress() != addr {
+			continue
+		}
+		endpoint.UnHealthy = !healthy
+		updated = true
+	}
+	return updated
 }
 
 func (c *EndpointChecker) OnCheck() {

--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -54,11 +54,14 @@ type HealthChecker struct {
 	cluster            *model.ClusterConfig
 	unhealthyThreshold uint32
 	protocol           string
+	onEndpointHealth   EndpointHealthListener
 }
 
 // EndpointChecker is a wrapper of types.HealthCheckSession for health check
 type EndpointChecker struct {
 	endpoint      *model.Endpoint
+	endpointID    string
+	endpointAddr  string
 	HealthChecker *HealthChecker
 	// checker, todo can extend to TCP, http, grpc, dubbo or other protocol checker
 	checker       Checker
@@ -80,12 +83,28 @@ type Checker interface {
 	OnTimeout()
 }
 
+type EndpointHealthEvent struct {
+	EndpointID      string
+	EndpointAddress string
+	Healthy         bool
+}
+
+type EndpointHealthListener func(EndpointHealthEvent)
+
 type checkResponse struct {
 	ID      uint64
 	Healthy bool
 }
 
 func CreateHealthCheck(cluster *model.ClusterConfig, cfg model.HealthCheckConfig) *HealthChecker {
+	return CreateHealthCheckWithCallback(cluster, cfg, nil)
+}
+
+func CreateHealthCheckWithCallback(
+	cluster *model.ClusterConfig,
+	cfg model.HealthCheckConfig,
+	onEndpointHealth EndpointHealthListener,
+) *HealthChecker {
 
 	timeout, err := time.ParseDuration(cfg.TimeoutConfig)
 	if err != nil {
@@ -124,6 +143,7 @@ func CreateHealthCheck(cluster *model.ClusterConfig, cfg model.HealthCheckConfig
 		unhealthyThreshold: unhealthyThreshold,
 		initialDelay:       initialDelay,
 		checkers:           make(map[string]*EndpointChecker),
+		onEndpointHealth:   onEndpointHealth,
 	}
 
 	return hc
@@ -197,8 +217,12 @@ func newChecker(endpoint *model.Endpoint, hc *HealthChecker) *EndpointChecker {
 	}
 
 	c := &EndpointChecker{
-		checker:       checker,
-		endpoint:      endpoint,
+		checker:  checker,
+		endpoint: endpoint,
+		// Capture stable event identity when the checker starts; endpoint
+		// objects can be replaced while old checker events are still in flight.
+		endpointID:    endpoint.ID,
+		endpointAddr:  endpoint.Address.GetAddress(),
 		HealthChecker: hc,
 		resp:          make(chan checkResponse),
 		timeout:       make(chan bool),
@@ -300,13 +324,27 @@ func (c *EndpointChecker) HandleTimeout() {
 func (c *EndpointChecker) handleHealth() {
 	c.healthCount = 0
 	c.unHealthCount = 0
-	c.endpoint.UnHealthy = false
+	c.emitHealth(true)
 }
 
 func (c *EndpointChecker) handleUnHealth() {
 	c.healthCount = 0
 	c.unHealthCount = 0
-	c.endpoint.UnHealthy = true
+	c.emitHealth(false)
+}
+
+func (c *EndpointChecker) emitHealth(healthy bool) {
+	if c.HealthChecker.onEndpointHealth == nil {
+		// Direct CreateHealthCheck callers still observe health through
+		// Endpoint.UnHealthy; runtime clusters install a snapshot callback.
+		c.endpoint.UnHealthy = !healthy
+		return
+	}
+	c.HealthChecker.onEndpointHealth(EndpointHealthEvent{
+		EndpointID:      c.endpointID,
+		EndpointAddress: c.endpointAddr,
+		Healthy:         healthy,
+	})
 }
 
 func (c *EndpointChecker) OnCheck() {

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -27,6 +27,32 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
+type normalizeAddressCase struct {
+	name        string
+	address     string
+	port        string
+	wantAddress string
+	wantErr     bool
+}
+
+func normalizeOK(name, address, port, wantAddress string) normalizeAddressCase {
+	return normalizeAddressCase{
+		name:        name,
+		address:     address,
+		port:        port,
+		wantAddress: wantAddress,
+	}
+}
+
+func normalizeErr(name, address, port string) normalizeAddressCase {
+	return normalizeAddressCase{
+		name:    name,
+		address: address,
+		port:    port,
+		wantErr: true,
+	}
+}
+
 func TestEndpointCheckerHealthHandlersEmitEventsWithoutMutatingEndpoint(t *testing.T) {
 	endpoint := &model.Endpoint{
 		ID:        "ep-1",
@@ -90,76 +116,16 @@ func TestEndpointCheckerHealthHandlersMutateEndpointWithoutListener(t *testing.T
 }
 
 func TestNormalizeAddress(t *testing.T) {
-	tests := []struct {
-		name        string
-		address     string
-		port        string
-		wantAddress string
-		wantErr     bool
-	}{
-		{
-			name:        "port is empty, address has port",
-			address:     "localhost:8080",
-			port:        "",
-			wantAddress: "localhost:8080",
-			wantErr:     false,
-		},
-		{
-			name:        "port is empty, address has no port",
-			address:     "localhost",
-			port:        "",
-			wantAddress: "",
-			wantErr:     true,
-		},
-		{
-			name:        "port is not empty, address has no port",
-			address:     "localhost",
-			port:        "80",
-			wantAddress: "localhost:80",
-			wantErr:     false,
-		},
-		{
-			name:        "port is not empty, address has same port",
-			address:     "localhost:80",
-			port:        "80",
-			wantAddress: "localhost:80",
-			wantErr:     false,
-		},
-		{
-			name:        "port is not empty, address has different port",
-			address:     "localhost:8080",
-			port:        "80",
-			wantAddress: "localhost:80",
-			wantErr:     false,
-		},
-		{
-			name:        "invalid address format for empty port",
-			address:     "[::1]", // IPv6 without port
-			port:        "",
-			wantAddress: "",
-			wantErr:     true,
-		},
-		{
-			name:        "valid IPv6 address with port",
-			address:     "[::1]:8080",
-			port:        "",
-			wantAddress: "[::1]:8080",
-			wantErr:     false,
-		},
-		{
-			name:        "port is not empty, valid IPv6 address without port",
-			address:     "[::1]",
-			port:        "80",
-			wantAddress: "[::1]:80",
-			wantErr:     false,
-		},
-		{
-			name:        "port is not empty, valid IPv6 address with different port",
-			address:     "[::1]:8080",
-			port:        "80",
-			wantAddress: "[::1]:80",
-			wantErr:     false,
-		},
+	tests := []normalizeAddressCase{
+		normalizeOK("port is empty, address has port", "localhost:8080", "", "localhost:8080"),
+		normalizeErr("port is empty, address has no port", "localhost", ""),
+		normalizeOK("port is not empty, address has no port", "localhost", "80", "localhost:80"),
+		normalizeOK("port is not empty, address has same port", "localhost:80", "80", "localhost:80"),
+		normalizeOK("port is not empty, address has different port", "localhost:8080", "80", "localhost:80"),
+		normalizeErr("invalid IPv6 address format for empty port", "[::1]", ""),
+		normalizeOK("valid IPv6 address with port", "[::1]:8080", "", "[::1]:8080"),
+		normalizeOK("port is not empty, valid IPv6 address without port", "[::1]", "80", "[::1]:80"),
+		normalizeOK("port is not empty, valid IPv6 address with different port", "[::1]:8080", "80", "[::1]:80"),
 	}
 
 	for _, tt := range tests {
@@ -176,6 +142,25 @@ func TestNormalizeAddress(t *testing.T) {
 	}
 }
 
+func acceptOneTCPConnection(listener net.Listener) {
+	go func() {
+		conn, _ := listener.Accept()
+		if conn != nil {
+			conn.Close()
+		}
+	}()
+}
+
+func assertCheckTcpConn(t *testing.T, name, host, port string, want bool) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		success := CheckTcpConn(host, port, 100*time.Millisecond)
+		if success != want {
+			t.Errorf("CheckTcpConn(%q, %q, ...) = %t, want %t", host, port, success, want)
+		}
+	})
+}
+
 func TestCheckTcpConn(t *testing.T) {
 	// We need a way to simulate a successful and a failed TCP connection.
 	// We can achieve this by setting up a temporary listener for the success case
@@ -190,55 +175,19 @@ func TestCheckTcpConn(t *testing.T) {
 	addr := listener.Addr().String()
 	host, portStr, _ := net.SplitHostPort(addr)
 
-	t.Run("successful connection", func(t *testing.T) {
-		go func() {
-			conn, _ := listener.Accept() // Accept the incoming connection
-			if conn != nil {
-				conn.Close()
-			}
-		}()
-		success := CheckTcpConn(host, portStr, 100*time.Millisecond)
-		if !success {
-			t.Errorf("CheckTcpConn(%q, %q, ...) should return true for a successful connection", host, portStr)
-		}
-	})
+	acceptOneTCPConnection(listener)
+	assertCheckTcpConn(t, "successful connection", host, portStr, true)
 
 	// Failure case 1: Invalid address format
-	t.Run("failed connection due to invalid address format", func(t *testing.T) {
-		success := CheckTcpConn("127.0.0.1:80:90", "80", 100*time.Millisecond)
-		if success {
-			t.Errorf("CheckTcpConn(%q, %q, ...) should return false for an invalid address format", "127.0.0.1:80:90", "80")
-		}
-	})
+	assertCheckTcpConn(t, "failed connection due to invalid address format", "127.0.0.1:80:90", "80", false)
 
 	// Failure case 2: Connection timeout
-	t.Run("failed connection due to timeout", func(t *testing.T) {
-		// Use a non-routable local address to ensure a timeout
-		success := CheckTcpConn("127.0.0.1", "80", 100*time.Millisecond)
-		if success {
-			t.Errorf("CheckTcpConn(%q, %q, ...) should return false due to timeout", "127.0.0.1", "80")
-		}
-	})
+	assertCheckTcpConn(t, "failed connection due to timeout", "127.0.0.1", "80", false)
 
 	// Test with empty port (should fail due to normalizeAddress)
-	t.Run("failed with empty port and no port in address", func(t *testing.T) {
-		success := CheckTcpConn("localhost", "", 100*time.Millisecond)
-		if success {
-			t.Errorf("CheckTcpConn(%q, %q, ...) should return false when port is empty and address has no port", "localhost", "")
-		}
-	})
+	assertCheckTcpConn(t, "failed with empty port and no port in address", "localhost", "", false)
 
 	// Test with empty port and address has port (should succeed)
-	t.Run("successful with empty port and port in address", func(t *testing.T) {
-		go func() {
-			conn, _ := listener.Accept()
-			if conn != nil {
-				conn.Close()
-			}
-		}()
-		success := CheckTcpConn(addr, "", 100*time.Millisecond)
-		if !success {
-			t.Errorf("CheckTcpConn(%q, %q, ...) should return true when port is empty and address has port", addr, "")
-		}
-	})
+	acceptOneTCPConnection(listener)
+	assertCheckTcpConn(t, "successful with empty port and port in address", addr, "", true)
 }

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -115,6 +115,101 @@ func TestEndpointCheckerHealthHandlersMutateEndpointWithoutListener(t *testing.T
 	}
 }
 
+func TestEndpointCheckerHealthHandlersMutateSameAddressEndpointsWithoutListener(t *testing.T) {
+	first := &model.Endpoint{
+		ID: "ep-1",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    18082,
+		},
+	}
+	second := &model.Endpoint{
+		ID: "ep-2",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    18082,
+		},
+	}
+	otherAddress := &model.Endpoint{
+		ID: "ep-3",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    18083,
+		},
+	}
+	checker := newChecker(first, &HealthChecker{
+		cluster: &model.ClusterConfig{
+			Endpoints: []*model.Endpoint{first, second, otherAddress},
+		},
+	})
+
+	checker.handleUnHealth()
+
+	if !first.UnHealthy {
+		t.Fatalf("first endpoint UnHealthy = false after shared-address unhealth event, want true")
+	}
+	if !second.UnHealthy {
+		t.Fatalf("second endpoint UnHealthy = false after shared-address unhealth event, want true")
+	}
+	if otherAddress.UnHealthy {
+		t.Fatalf("other-address endpoint UnHealthy = true after shared-address unhealth event, want false")
+	}
+
+	checker.handleHealth()
+
+	if first.UnHealthy {
+		t.Fatalf("first endpoint UnHealthy = true after shared-address health event, want false")
+	}
+	if second.UnHealthy {
+		t.Fatalf("second endpoint UnHealthy = true after shared-address health event, want false")
+	}
+}
+
+func TestHealthCheckerStopOneKeepsSharedAddressChecker(t *testing.T) {
+	first := &model.Endpoint{
+		ID: "ep-1",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    18084,
+		},
+	}
+	second := &model.Endpoint{
+		ID: "ep-2",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    18084,
+		},
+	}
+	addr := first.Address.GetAddress()
+	checker := &EndpointChecker{
+		stop: make(chan struct{}),
+	}
+	hc := &HealthChecker{
+		cluster: &model.ClusterConfig{
+			Endpoints: []*model.Endpoint{first, second},
+		},
+		checkers: map[string]*EndpointChecker{
+			addr: checker,
+		},
+	}
+
+	hc.stopCheck(first)
+	if _, ok := hc.checkers[addr]; !ok {
+		t.Fatalf("shared-address checker was stopped while another endpoint still used the address")
+	}
+
+	hc.cluster.Endpoints = []*model.Endpoint{first}
+	hc.stopCheck(first)
+	if _, ok := hc.checkers[addr]; ok {
+		t.Fatalf("checker was kept after the last endpoint using the address was removed")
+	}
+	select {
+	case <-checker.stop:
+	default:
+		t.Fatalf("checker stop channel was not closed")
+	}
+}
+
 func TestNormalizeAddress(t *testing.T) {
 	tests := []normalizeAddressCase{
 		normalizeOK("port is empty, address has port", "localhost:8080", "", "localhost:8080"),

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -23,6 +23,72 @@ import (
 	"time"
 )
 
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+func TestEndpointCheckerHealthHandlersEmitEventsWithoutMutatingEndpoint(t *testing.T) {
+	endpoint := &model.Endpoint{
+		ID:        "ep-1",
+		UnHealthy: true,
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    18080,
+		},
+	}
+
+	events := make([]EndpointHealthEvent, 0, 2)
+	hc := &HealthChecker{
+		onEndpointHealth: func(event EndpointHealthEvent) {
+			events = append(events, event)
+		},
+	}
+	checker := newChecker(endpoint, hc)
+
+	checker.handleHealth()
+	checker.handleUnHealth()
+
+	if !endpoint.UnHealthy {
+		t.Fatalf("endpoint.UnHealthy was mutated by health handlers")
+	}
+	if len(events) != 2 {
+		t.Fatalf("events length = %d, want 2", len(events))
+	}
+	if !events[0].Healthy {
+		t.Fatalf("first event healthy = false, want true")
+	}
+	if events[0].EndpointID != endpoint.ID {
+		t.Fatalf("first event endpoint ID = %q, want %q", events[0].EndpointID, endpoint.ID)
+	}
+	if events[0].EndpointAddress != endpoint.Address.GetAddress() {
+		t.Fatalf("first event endpoint address = %q, want %q", events[0].EndpointAddress, endpoint.Address.GetAddress())
+	}
+	if events[1].Healthy {
+		t.Fatalf("second event healthy = true, want false")
+	}
+}
+
+func TestEndpointCheckerHealthHandlersMutateEndpointWithoutListener(t *testing.T) {
+	endpoint := &model.Endpoint{
+		ID: "ep-1",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    18081,
+		},
+	}
+	checker := newChecker(endpoint, &HealthChecker{})
+
+	checker.handleUnHealth()
+	if !endpoint.UnHealthy {
+		t.Fatalf("endpoint.UnHealthy = false after unhealth event, want true")
+	}
+
+	checker.handleHealth()
+	if endpoint.UnHealthy {
+		t.Fatalf("endpoint.UnHealthy = true after health event, want false")
+	}
+}
+
 func TestNormalizeAddress(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -139,9 +205,9 @@ func TestCheckTcpConn(t *testing.T) {
 
 	// Failure case 1: Invalid address format
 	t.Run("failed connection due to invalid address format", func(t *testing.T) {
-		success := CheckTcpConn("invalid address", "80", 100*time.Millisecond)
+		success := CheckTcpConn("127.0.0.1:80:90", "80", 100*time.Millisecond)
 		if success {
-			t.Errorf("CheckTcpConn(%q, %q, ...) should return false for an invalid address format", "invalid address", "80")
+			t.Errorf("CheckTcpConn(%q, %q, ...) should return false for an invalid address format", "127.0.0.1:80:90", "80")
 		}
 	})
 

--- a/pkg/cluster/loadbalancer/internal/lbtest/consistenthash.go
+++ b/pkg/cluster/loadbalancer/internal/lbtest/consistenthash.go
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package lbtest holds load-balancer test helpers shared between
+// pkg/cluster/loadbalancer sub-packages.
+package lbtest
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+// StaticHashPolicy returns a fixed hash key, satisfying model.LbPolicy.
+type StaticHashPolicy string
+
+func (p StaticHashPolicy) GenerateHash() string {
+	return string(p)
+}
+
+// FixedConsistentHash always resolves to Host, satisfying both
+// model.LbConsistentHash and model.LbConsistentHashView for tests.
+type FixedConsistentHash struct {
+	Host string
+}
+
+func (h FixedConsistentHash) Hash(string) uint32             { return 0 }
+func (h FixedConsistentHash) Add(string)                     {}
+func (h FixedConsistentHash) Get(string) (string, error)     { return h.Host, nil }
+func (h FixedConsistentHash) GetHash(uint32) (string, error) { return h.Host, nil }
+func (h FixedConsistentHash) Remove(string) bool             { return false }
+
+// ConsistentHashBalancer is the union of legacy and snapshot pick entry points
+// that consistent-hash balancers (Maglev, RingHash, ...) implement.
+type ConsistentHashBalancer interface {
+	loadbalancer.LoadBalancer
+	loadbalancer.SnapshotLoadBalancer
+}
+
+// RunConsistentHashHandlerSuite exercises the configured-hash, unhealthy
+// fallback, and snapshot-aware paths for a consistent-hash balancer.
+// namePrefix labels the cluster configs so failure output stays readable.
+func RunConsistentHashHandlerSuite(t *testing.T, balancer ConsistentHashBalancer, namePrefix string) {
+	t.Helper()
+
+	t.Run("HandlerUsesConfiguredHashWithoutClusterLBPolicy", func(t *testing.T) {
+		first := &model.Endpoint{
+			ID:      "first",
+			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+		}
+		second := &model.Endpoint{
+			ID:      "second",
+			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+		}
+		cluster := &model.ClusterConfig{
+			Name:      namePrefix + "-direct",
+			Endpoints: []*model.Endpoint{first, second},
+			ConsistentHash: model.ConsistentHash{
+				Hash: FixedConsistentHash{Host: second.GetHost()},
+			},
+		}
+
+		got := balancer.Handler(cluster, StaticHashPolicy("request-key"))
+		if got == nil {
+			t.Fatal("expected endpoint, got nil")
+		}
+		if got.ID != second.ID {
+			t.Fatalf("picked %q, want %q", got.ID, second.ID)
+		}
+	})
+
+	t.Run("HandlerFallsBackWhenConfiguredHashHitsUnhealthyEndpoint", func(t *testing.T) {
+		healthy := &model.Endpoint{
+			ID:      "healthy",
+			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+		}
+		unhealthy := &model.Endpoint{
+			ID:        "unhealthy",
+			Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+			UnHealthy: true,
+		}
+		cluster := &model.ClusterConfig{
+			Name:      namePrefix + "-direct-unhealthy-hit",
+			Endpoints: []*model.Endpoint{healthy, unhealthy},
+			ConsistentHash: model.ConsistentHash{
+				Hash: FixedConsistentHash{Host: unhealthy.GetHost()},
+			},
+		}
+
+		got := balancer.Handler(cluster, StaticHashPolicy("request-key"))
+		if got == nil {
+			t.Fatal("expected fallback endpoint, got nil")
+		}
+		if got.ID != healthy.ID {
+			t.Fatalf("picked %q, want %q", got.ID, healthy.ID)
+		}
+	})
+
+	t.Run("UsesHealthyConsistentHashSnapshot", func(t *testing.T) {
+		first := &model.Endpoint{
+			ID:      "first",
+			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+		}
+		unhealthy := &model.Endpoint{
+			ID:        "unhealthy",
+			Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+			UnHealthy: true,
+		}
+		second := &model.Endpoint{
+			ID:      "second",
+			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18082},
+		}
+		cluster := &model.ClusterConfig{
+			Name: namePrefix + "-healthy-snapshot",
+			ConsistentHash: model.ConsistentHash{
+				Hash: FixedConsistentHash{Host: unhealthy.GetHost()},
+			},
+		}
+
+		got := balancer.HandlerWithSnapshot(loadbalancer.PickContext{
+			Config:                cluster,
+			HealthyConsistentHash: FixedConsistentHash{Host: second.GetHost()},
+			HealthyEndpoints:      []*model.Endpoint{first, second},
+		}, StaticHashPolicy("key-for-unhealthy-slot"))
+
+		if got == nil {
+			t.Fatal("expected healthy endpoint, got nil")
+		}
+		if got.ID != second.ID {
+			t.Fatalf("picked %q, want %q", got.ID, second.ID)
+		}
+	})
+}

--- a/pkg/cluster/loadbalancer/internal/lbtest/consistenthash.go
+++ b/pkg/cluster/loadbalancer/internal/lbtest/consistenthash.go
@@ -28,6 +28,11 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
+const (
+	testLoopbackAddress = "127.0.0.1"
+	pickedWantMsgFormat = "picked %q, want %q"
+)
+
 // StaticHashPolicy returns a fixed hash key, satisfying model.LbPolicy.
 type StaticHashPolicy string
 
@@ -41,8 +46,12 @@ type FixedConsistentHash struct {
 	Host string
 }
 
-func (h FixedConsistentHash) Hash(string) uint32             { return 0 }
-func (h FixedConsistentHash) Add(string)                     {}
+func (h FixedConsistentHash) Hash(string) uint32 { return 0 }
+
+// Add intentionally does nothing: the fixture exposes a frozen single-host
+// view and rejects runtime membership changes by design.
+func (h FixedConsistentHash) Add(string) {}
+
 func (h FixedConsistentHash) Get(string) (string, error)     { return h.Host, nil }
 func (h FixedConsistentHash) GetHash(uint32) (string, error) { return h.Host, nil }
 func (h FixedConsistentHash) Remove(string) bool             { return false }
@@ -63,11 +72,11 @@ func RunConsistentHashHandlerSuite(t *testing.T, balancer ConsistentHashBalancer
 	t.Run("HandlerUsesConfiguredHashWithoutClusterLBPolicy", func(t *testing.T) {
 		first := &model.Endpoint{
 			ID:      "first",
-			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18080},
 		}
 		second := &model.Endpoint{
 			ID:      "second",
-			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18081},
 		}
 		cluster := &model.ClusterConfig{
 			Name:      namePrefix + "-direct",
@@ -82,18 +91,18 @@ func RunConsistentHashHandlerSuite(t *testing.T, balancer ConsistentHashBalancer
 			t.Fatal("expected endpoint, got nil")
 		}
 		if got.ID != second.ID {
-			t.Fatalf("picked %q, want %q", got.ID, second.ID)
+			t.Fatalf(pickedWantMsgFormat, got.ID, second.ID)
 		}
 	})
 
 	t.Run("HandlerFallsBackWhenConfiguredHashHitsUnhealthyEndpoint", func(t *testing.T) {
 		healthy := &model.Endpoint{
 			ID:      "healthy",
-			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18080},
 		}
 		unhealthy := &model.Endpoint{
 			ID:        "unhealthy",
-			Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+			Address:   model.SocketAddress{Address: testLoopbackAddress, Port: 18081},
 			UnHealthy: true,
 		}
 		cluster := &model.ClusterConfig{
@@ -109,23 +118,23 @@ func RunConsistentHashHandlerSuite(t *testing.T, balancer ConsistentHashBalancer
 			t.Fatal("expected fallback endpoint, got nil")
 		}
 		if got.ID != healthy.ID {
-			t.Fatalf("picked %q, want %q", got.ID, healthy.ID)
+			t.Fatalf(pickedWantMsgFormat, got.ID, healthy.ID)
 		}
 	})
 
 	t.Run("UsesHealthyConsistentHashSnapshot", func(t *testing.T) {
 		first := &model.Endpoint{
 			ID:      "first",
-			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18080},
 		}
 		unhealthy := &model.Endpoint{
 			ID:        "unhealthy",
-			Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+			Address:   model.SocketAddress{Address: testLoopbackAddress, Port: 18081},
 			UnHealthy: true,
 		}
 		second := &model.Endpoint{
 			ID:      "second",
-			Address: model.SocketAddress{Address: "127.0.0.1", Port: 18082},
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18082},
 		}
 		cluster := &model.ClusterConfig{
 			Name: namePrefix + "-healthy-snapshot",
@@ -144,7 +153,7 @@ func RunConsistentHashHandlerSuite(t *testing.T, balancer ConsistentHashBalancer
 			t.Fatal("expected healthy endpoint, got nil")
 		}
 		if got.ID != second.ID {
-			t.Fatalf("picked %q, want %q", got.ID, second.ID)
+			t.Fatalf(pickedWantMsgFormat, got.ID, second.ID)
 		}
 	})
 }

--- a/pkg/cluster/loadbalancer/internal/lbtest/consistenthash.go
+++ b/pkg/cluster/loadbalancer/internal/lbtest/consistenthash.go
@@ -50,7 +50,9 @@ func (h FixedConsistentHash) Hash(string) uint32 { return 0 }
 
 // Add intentionally does nothing: the fixture exposes a frozen single-host
 // view and rejects runtime membership changes by design.
-func (h FixedConsistentHash) Add(string) {}
+func (h FixedConsistentHash) Add(string) {
+	// no-op: see method doc above.
+}
 
 func (h FixedConsistentHash) Get(string) (string, error)     { return h.Host, nil }
 func (h FixedConsistentHash) GetHash(uint32) (string, error) { return h.Host, nil }

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -18,21 +18,80 @@
 package loadbalancer
 
 import (
+	"sync"
+	"sync/atomic"
+)
+
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
+
+type PickContext struct {
+	// Config carries cluster-level load-balancer configuration and runtime
+	// cursor state. Snapshot-aware balancers should not reread Config.Endpoints
+	// for health filtering.
+	Config *model.ClusterConfig
+	// HealthyEndpoints is already filtered from the current runtime snapshot.
+	HealthyEndpoints []*model.Endpoint
+}
 
 type LoadBalancer interface {
 	Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint
 }
 
+// SnapshotLoadBalancer is optional for balancers that consume the current
+// runtime snapshot. Implementations should pick only from
+// PickContext.HealthyEndpoints; Config.Endpoints may include unhealthy or stale
+// config entries.
+type SnapshotLoadBalancer interface {
+	HandlerWithSnapshot(c PickContext, policy model.LbPolicy) *model.Endpoint
+}
+
 // LoadBalancerStrategy load balancer strategy mode
 var LoadBalancerStrategy = map[model.LbPolicyType]LoadBalancer{}
+
+var legacyPickMu sync.Mutex
 
 func RegisterLoadBalancer(name model.LbPolicyType, balancer LoadBalancer) {
 	if _, ok := LoadBalancerStrategy[name]; ok {
 		panic("load balancer register fail " + name)
 	}
 	LoadBalancerStrategy[name] = balancer
+}
+
+func PickEndpoint(balancer LoadBalancer, context PickContext, policy model.LbPolicy) *model.Endpoint {
+	if balancer == nil || context.Config == nil {
+		return nil
+	}
+	if snapshotBalancer, ok := balancer.(SnapshotLoadBalancer); ok {
+		return snapshotBalancer.HandlerWithSnapshot(context, policy)
+	}
+
+	// Legacy balancers only understand ClusterConfig. Serialize this
+	// compatibility path so cursor-style state reconciles predictably; custom
+	// mutable state should move to SnapshotLoadBalancer instead.
+	legacyPickMu.Lock()
+	defer legacyPickMu.Unlock()
+
+	config := *context.Config
+	config.Endpoints = cloneEndpoints(context.HealthyEndpoints)
+	cursorBefore := atomic.LoadUint32(&context.Config.PrePickEndpointIndex)
+	atomic.StoreUint32(&config.PrePickEndpointIndex, cursorBefore)
+	endpoint := balancer.Handler(&config, policy)
+	cursorAfter := atomic.LoadUint32(&config.PrePickEndpointIndex)
+	if cursorAfter != cursorBefore {
+		atomic.AddUint32(&context.Config.PrePickEndpointIndex, cursorAfter-cursorBefore)
+	}
+	return endpoint
+}
+
+func cloneEndpoints(endpoints []*model.Endpoint) []*model.Endpoint {
+	if endpoints == nil {
+		return nil
+	}
+	cloned := make([]*model.Endpoint, len(endpoints))
+	copy(cloned, endpoints)
+	return cloned
 }
 
 func RegisterConsistentHashInit(name model.LbPolicyType, function model.ConsistentHashInitFunc) {

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -47,6 +47,15 @@ type SnapshotLoadBalancer interface {
 	HandlerWithSnapshot(c PickContext, policy model.LbPolicy) *model.Endpoint
 }
 
+// ClusterScopedLegacyLoadBalancer lets a legacy load balancer opt in to
+// runtime-cluster scoped serialization. Legacy balancers that do not implement
+// this interface keep the package-level compatibility lock because strategy
+// instances are shared globally. Implementations must ensure the same balancer
+// instance can run Handler concurrently across different clusters.
+type ClusterScopedLegacyLoadBalancer interface {
+	UseClusterScopedLegacyLock() bool
+}
+
 // LoadBalancerStrategy load balancer strategy mode
 var LoadBalancerStrategy = map[model.LbPolicyType]LoadBalancer{}
 
@@ -60,6 +69,18 @@ func RegisterLoadBalancer(name model.LbPolicyType, balancer LoadBalancer) {
 }
 
 func PickEndpoint(balancer LoadBalancer, context PickContext, policy model.LbPolicy) *model.Endpoint {
+	return pickEndpointWithLegacyLock(balancer, nil, context, policy)
+}
+
+// PickEndpointWithLegacyLock serializes legacy balancers. The caller-provided
+// runtime lock is used only when the balancer explicitly opts in to scoped
+// serialization; other legacy balancers keep the package-level compatibility
+// lock.
+func PickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locker, context PickContext, policy model.LbPolicy) *model.Endpoint {
+	return pickEndpointWithLegacyLock(balancer, legacyPickLock, context, policy)
+}
+
+func pickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locker, context PickContext, policy model.LbPolicy) *model.Endpoint {
 	if balancer == nil || context.Config == nil {
 		return nil
 	}
@@ -70,8 +91,9 @@ func PickEndpoint(balancer LoadBalancer, context PickContext, policy model.LbPol
 	// Legacy balancers only understand ClusterConfig. Serialize this
 	// compatibility path so cursor-style state reconciles predictably; custom
 	// mutable state should move to SnapshotLoadBalancer instead.
-	legacyPickMu.Lock()
-	defer legacyPickMu.Unlock()
+	lock := legacyPickLockFor(balancer, legacyPickLock)
+	lock.Lock()
+	defer lock.Unlock()
 
 	config := *context.Config
 	config.Endpoints = cloneEndpoints(context.HealthyEndpoints)
@@ -83,6 +105,13 @@ func PickEndpoint(balancer LoadBalancer, context PickContext, policy model.LbPol
 		atomic.AddUint32(&context.Config.PrePickEndpointIndex, cursorAfter-cursorBefore)
 	}
 	return endpoint
+}
+
+func legacyPickLockFor(balancer LoadBalancer, legacyPickLock sync.Locker) sync.Locker {
+	if scoped, ok := balancer.(ClusterScopedLegacyLoadBalancer); ok && scoped.UseClusterScopedLegacyLock() && legacyPickLock != nil {
+		return legacyPickLock
+	}
+	return &legacyPickMu
 }
 
 func cloneEndpoints(endpoints []*model.Endpoint) []*model.Endpoint {

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -198,10 +198,14 @@ func sameEndpointIdentity(candidate, endpoint *model.Endpoint) bool {
 		if candidate.ID != endpoint.ID {
 			return false
 		}
-		endpointAddress := endpoint.Address.GetAddress()
-		return endpointAddress == "" || candidate.Address.GetAddress() == endpointAddress
+		// Preserve historical behavior: a snapshot endpoint declaring a single
+		// blank domain (GetAddress() == "") accepts any candidate by ID.
+		if len(endpoint.Address.Domains) > 0 && endpoint.Address.Domains[0] == "" {
+			return true
+		}
+		return candidate.Address.Equal(endpoint.Address)
 	}
-	return candidate.Address.GetAddress() == endpoint.Address.GetAddress()
+	return candidate.Address.Equal(endpoint.Address)
 }
 
 func RegisterConsistentHashInit(name model.LbPolicyType, function model.ConsistentHashInitFunc) {

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -32,6 +32,8 @@ type PickContext struct {
 	// for health filtering.
 	Config *model.ClusterConfig
 	// HealthyEndpoints is already filtered from the current runtime snapshot.
+	// Snapshot-aware balancers must treat endpoints as read-only and return the
+	// chosen endpoint without mutating or retaining it.
 	HealthyEndpoints []*model.Endpoint
 }
 

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -31,6 +31,15 @@ type PickContext struct {
 	// cursor state. Snapshot-aware balancers should not reread Config.Endpoints
 	// for health filtering.
 	Config *model.ClusterConfig
+	// HealthyConsistentHash is built from HealthyEndpoints for the same
+	// immutable runtime snapshot and intentionally exposes lookup methods only.
+	// Consistent-hash balancers should prefer this view over
+	// Config.ConsistentHash.Hash, which is mutable and can include
+	// runtime-unhealthy endpoints.
+	HealthyConsistentHash model.LbConsistentHashView
+	// AllEndpoints is the current runtime snapshot, including endpoints marked
+	// unhealthy by runtime health checks.
+	AllEndpoints []*model.Endpoint
 	// HealthyEndpoints is already filtered from the current runtime snapshot.
 	// Snapshot-aware balancers must treat endpoints as read-only and return the
 	// chosen endpoint without mutating or retaining it.
@@ -47,6 +56,19 @@ type LoadBalancer interface {
 // config entries.
 type SnapshotLoadBalancer interface {
 	HandlerWithSnapshot(c PickContext, policy model.LbPolicy) *model.Endpoint
+}
+
+// HealthyOnlySnapshotLoadBalancer marks snapshot-aware balancers that do not
+// need PickContext.AllEndpoints. Unmarked snapshot balancers keep receiving the
+// full snapshot for compatibility with custom implementations.
+type HealthyOnlySnapshotLoadBalancer interface {
+	UseHealthyEndpointsOnly() bool
+}
+
+// ZeroCopySnapshotLoadBalancer marks trusted balancers that never mutate or
+// retain snapshot endpoints. Other snapshot balancers receive defensive copies.
+type ZeroCopySnapshotLoadBalancer interface {
+	UseZeroCopySnapshot() bool
 }
 
 // ClusterScopedLegacyLoadBalancer lets a legacy load balancer opt in to
@@ -82,12 +104,41 @@ func PickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locke
 	return pickEndpointWithLegacyLock(balancer, legacyPickLock, context, policy)
 }
 
+// NeedsAllEndpoints reports whether a snapshot-aware balancer should receive
+// PickContext.AllEndpoints on the request path.
+func NeedsAllEndpoints(balancer LoadBalancer) bool {
+	healthyOnly, ok := balancer.(HealthyOnlySnapshotLoadBalancer)
+	return !ok || !healthyOnly.UseHealthyEndpointsOnly()
+}
+
+// ConsistentHashForHealthyEndpoints returns a consistent hash view that only
+// contains the healthy endpoints visible to this pick.
+func ConsistentHashForHealthyEndpoints(context PickContext) model.LbConsistentHashView {
+	if context.HealthyConsistentHash != nil {
+		return context.HealthyConsistentHash
+	}
+	if context.Config == nil || len(context.HealthyEndpoints) == 0 {
+		return nil
+	}
+	newConsistentHash, ok := model.ConsistentHashInitMap[context.Config.LbStr]
+	if ok {
+		return model.ReadOnlyConsistentHash(newConsistentHash(context.Config.ConsistentHash, context.HealthyEndpoints))
+	}
+	return model.ReadOnlyConsistentHash(context.Config.ConsistentHash.Hash)
+}
+
 func pickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locker, context PickContext, policy model.LbPolicy) *model.Endpoint {
 	if balancer == nil || context.Config == nil {
 		return nil
 	}
 	if snapshotBalancer, ok := balancer.(SnapshotLoadBalancer); ok {
-		return snapshotBalancer.HandlerWithSnapshot(context, policy)
+		snapshotContext := context
+		zeroCopy, ok := balancer.(ZeroCopySnapshotLoadBalancer)
+		if !ok || !zeroCopy.UseZeroCopySnapshot() {
+			snapshotContext = defensiveSnapshotPickContext(context)
+		}
+		endpoint := snapshotBalancer.HandlerWithSnapshot(snapshotContext, policy)
+		return healthyEndpointFromSnapshot(endpoint, context.HealthyEndpoints)
 	}
 
 	// Legacy balancers only understand ClusterConfig. Serialize this
@@ -97,8 +148,12 @@ func pickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locke
 	lock.Lock()
 	defer lock.Unlock()
 
+	allEndpoints := context.AllEndpoints
+	if allEndpoints == nil {
+		allEndpoints = context.HealthyEndpoints
+	}
 	config := *context.Config
-	config.Endpoints = cloneEndpoints(context.HealthyEndpoints)
+	config.Endpoints = model.CloneEndpoints(allEndpoints)
 	cursorBefore := atomic.LoadUint32(&context.Config.PrePickEndpointIndex)
 	atomic.StoreUint32(&config.PrePickEndpointIndex, cursorBefore)
 	endpoint := balancer.Handler(&config, policy)
@@ -106,7 +161,14 @@ func pickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locke
 	if cursorAfter != cursorBefore {
 		atomic.AddUint32(&context.Config.PrePickEndpointIndex, cursorAfter-cursorBefore)
 	}
-	return endpoint
+	return healthyEndpointFromSnapshot(endpoint, context.HealthyEndpoints)
+}
+
+func defensiveSnapshotPickContext(context PickContext) PickContext {
+	defensive := context
+	defensive.AllEndpoints = model.CloneEndpoints(context.AllEndpoints)
+	defensive.HealthyEndpoints = model.CloneEndpoints(context.HealthyEndpoints)
+	return defensive
 }
 
 func legacyPickLockFor(balancer LoadBalancer, legacyPickLock sync.Locker) sync.Locker {
@@ -116,13 +178,30 @@ func legacyPickLockFor(balancer LoadBalancer, legacyPickLock sync.Locker) sync.L
 	return &legacyPickMu
 }
 
-func cloneEndpoints(endpoints []*model.Endpoint) []*model.Endpoint {
-	if endpoints == nil {
+func healthyEndpointFromSnapshot(endpoint *model.Endpoint, healthyEndpoints []*model.Endpoint) *model.Endpoint {
+	if endpoint == nil {
 		return nil
 	}
-	cloned := make([]*model.Endpoint, len(endpoints))
-	copy(cloned, endpoints)
-	return cloned
+	for _, candidate := range healthyEndpoints {
+		if sameEndpointIdentity(candidate, endpoint) {
+			return model.CloneEndpoint(candidate)
+		}
+	}
+	return nil
+}
+
+func sameEndpointIdentity(candidate, endpoint *model.Endpoint) bool {
+	if candidate == nil || endpoint == nil {
+		return false
+	}
+	if endpoint.ID != "" || candidate.ID != "" {
+		if candidate.ID != endpoint.ID {
+			return false
+		}
+		endpointAddress := endpoint.Address.GetAddress()
+		return endpointAddress == "" || candidate.Address.GetAddress() == endpointAddress
+	}
+	return candidate.Address.GetAddress() == endpoint.Address.GetAddress()
 }
 
 func RegisterConsistentHashInit(name model.LbPolicyType, function model.ConsistentHashInitFunc) {

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalancer
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+type legacyLoadBalancer struct {
+	seenEndpoints []*model.Endpoint
+}
+
+type legacyCursorLoadBalancer struct{}
+
+var _ LoadBalancer = (*legacyLoadBalancer)(nil)
+
+type blockingLegacyLoadBalancer struct {
+	entered chan int
+	release chan struct{}
+	calls   int32
+}
+
+func (l *legacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	l.seenEndpoints = c.Endpoints
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	return c.Endpoints[0]
+}
+
+func (legacyCursorLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	index := atomic.AddUint32(&c.PrePickEndpointIndex, 1) - 1
+	return c.Endpoints[int(index%uint32(len(c.Endpoints)))]
+}
+
+func (b *blockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	call := atomic.AddInt32(&b.calls, 1)
+	b.entered <- int(call)
+	<-b.release
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	return c.Endpoints[0]
+}
+
+func TestPickEndpointAdaptsLegacyLoadBalancer(t *testing.T) {
+	healthy := &model.Endpoint{ID: "healthy"}
+	unhealthy := &model.Endpoint{ID: "unhealthy"}
+	cluster := &model.ClusterConfig{
+		Name:      "legacy-load-balancer",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+	}
+	balancer := &legacyLoadBalancer{}
+
+	got := PickEndpoint(balancer, PickContext{
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	assert.Same(t, healthy, got)
+	assert.Equal(t, []*model.Endpoint{healthy}, balancer.seenEndpoints)
+	assert.Equal(t, []*model.Endpoint{healthy, unhealthy}, cluster.Endpoints)
+}
+
+func TestPickEndpointReconcilesLegacyCursorState(t *testing.T) {
+	first := &model.Endpoint{ID: "first"}
+	second := &model.Endpoint{ID: "second"}
+	cluster := &model.ClusterConfig{
+		Name:                 "legacy-cursor-load-balancer",
+		Endpoints:            []*model.Endpoint{first, second},
+		PrePickEndpointIndex: 3,
+	}
+
+	got := PickEndpoint(legacyCursorLoadBalancer{}, PickContext{
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{first, second},
+	}, nil)
+
+	assert.Same(t, second, got)
+	assert.Equal(t, uint32(4), atomic.LoadUint32(&cluster.PrePickEndpointIndex))
+}
+
+func TestPickEndpointSerializesLegacyLoadBalancerHandlers(t *testing.T) {
+	first := &model.Endpoint{ID: "first"}
+	cluster := &model.ClusterConfig{
+		Name:      "blocking-legacy-load-balancer",
+		Endpoints: []*model.Endpoint{first},
+	}
+	balancer := &blockingLegacyLoadBalancer{
+		entered: make(chan int, 2),
+		release: make(chan struct{}),
+	}
+	pickContext := PickContext{
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{first},
+	}
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_ = PickEndpoint(balancer, pickContext, nil)
+	}()
+	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = PickEndpoint(balancer, pickContext, nil)
+	}()
+
+	select {
+	case call := <-balancer.entered:
+		t.Fatalf("legacy handler call %d entered before the first call returned", call)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(balancer.release)
+	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func waitLegacyHandlerEntry(t *testing.T, entered <-chan int) int {
+	t.Helper()
+	select {
+	case call := <-entered:
+		return call
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for legacy handler entry")
+		return 0
+	}
+}
+
+func waitClosed(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for legacy pick to finish")
+	}
+}

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -37,6 +37,11 @@ type legacyLoadBalancer struct {
 }
 
 type legacyCursorLoadBalancer struct{}
+type mutatingLegacyLoadBalancer struct{}
+type unhealthyLegacyLoadBalancer struct{}
+type mutatingSnapshotLoadBalancer struct{}
+type unhealthySnapshotLoadBalancer struct{}
+type healthyOnlySnapshotLoadBalancer struct{}
 
 var _ LoadBalancer = (*legacyLoadBalancer)(nil)
 
@@ -75,6 +80,61 @@ func (l *legacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *
 func (legacyCursorLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
 	index := atomic.AddUint32(&c.PrePickEndpointIndex, 1) - 1
 	return c.Endpoints[int(index%uint32(len(c.Endpoints)))]
+}
+
+func (mutatingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	c.Endpoints[0].Metadata["weight"] = "99"
+	c.Endpoints[0].LLMMeta.APIKey = "mutated-key"
+	return c.Endpoints[0]
+}
+
+func (unhealthyLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	if len(c.Endpoints) < 2 {
+		return nil
+	}
+	return c.Endpoints[1]
+}
+
+func (mutatingSnapshotLoadBalancer) Handler(_ *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (mutatingSnapshotLoadBalancer) HandlerWithSnapshot(c PickContext, _ model.LbPolicy) *model.Endpoint {
+	if len(c.HealthyEndpoints) == 0 {
+		return nil
+	}
+	c.HealthyEndpoints[0].Metadata["weight"] = "99"
+	c.HealthyEndpoints[0].LLMMeta.APIKey = "mutated-key"
+	if len(c.AllEndpoints) > 1 {
+		c.AllEndpoints[1].Metadata["weight"] = "42"
+	}
+	return c.HealthyEndpoints[0]
+}
+
+func (unhealthySnapshotLoadBalancer) Handler(_ *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (unhealthySnapshotLoadBalancer) HandlerWithSnapshot(c PickContext, _ model.LbPolicy) *model.Endpoint {
+	if len(c.AllEndpoints) < 2 {
+		return nil
+	}
+	return c.AllEndpoints[1]
+}
+
+func (healthyOnlySnapshotLoadBalancer) Handler(_ *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (healthyOnlySnapshotLoadBalancer) HandlerWithSnapshot(_ PickContext, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (healthyOnlySnapshotLoadBalancer) UseHealthyEndpointsOnly() bool {
+	return true
 }
 
 func (b *blockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
@@ -194,7 +254,7 @@ func (h *legacyPickHarness) assertNoEntry() {
 
 func TestPickEndpointAdaptsLegacyLoadBalancer(t *testing.T) {
 	healthy := &model.Endpoint{ID: "healthy"}
-	unhealthy := &model.Endpoint{ID: "unhealthy"}
+	unhealthy := &model.Endpoint{ID: "unhealthy", UnHealthy: true}
 	cluster := &model.ClusterConfig{
 		Name:      "legacy-load-balancer",
 		Endpoints: []*model.Endpoint{healthy, unhealthy},
@@ -202,12 +262,16 @@ func TestPickEndpointAdaptsLegacyLoadBalancer(t *testing.T) {
 	balancer := &legacyLoadBalancer{}
 
 	got := PickEndpoint(balancer, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy, unhealthy},
 		Config:           cluster,
 		HealthyEndpoints: []*model.Endpoint{healthy},
 	}, nil)
 
-	assert.Same(t, healthy, got)
-	assert.Equal(t, []*model.Endpoint{healthy}, balancer.seenEndpoints)
+	assert.NotSame(t, healthy, got)
+	assert.Equal(t, healthy, got)
+	assert.Equal(t, []*model.Endpoint{healthy, unhealthy}, balancer.seenEndpoints)
+	assert.NotSame(t, healthy, balancer.seenEndpoints[0])
+	assert.NotSame(t, unhealthy, balancer.seenEndpoints[1])
 	assert.Equal(t, []*model.Endpoint{healthy, unhealthy}, cluster.Endpoints)
 }
 
@@ -225,8 +289,105 @@ func TestPickEndpointReconcilesLegacyCursorState(t *testing.T) {
 		HealthyEndpoints: []*model.Endpoint{first, second},
 	}, nil)
 
-	assert.Same(t, second, got)
+	assert.NotSame(t, second, got)
+	assert.Equal(t, second, got)
 	assert.Equal(t, uint32(4), atomic.LoadUint32(&cluster.PrePickEndpointIndex))
+}
+
+func TestPickEndpointLegacyMutationsDoNotEscape(t *testing.T) {
+	healthy := &model.Endpoint{
+		ID:       "healthy",
+		Metadata: map[string]string{"weight": "1"},
+		LLMMeta:  &model.LLMMeta{APIKey: "original-key"},
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "legacy-mutation",
+		Endpoints: []*model.Endpoint{healthy},
+	}
+
+	got := PickEndpoint(mutatingLegacyLoadBalancer{}, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	if assert.NotNil(t, got) {
+		assert.Equal(t, map[string]string{"weight": "1"}, got.Metadata)
+		assert.Equal(t, "original-key", got.LLMMeta.APIKey)
+	}
+	assert.Equal(t, map[string]string{"weight": "1"}, healthy.Metadata)
+	assert.Equal(t, "original-key", healthy.LLMMeta.APIKey)
+}
+
+func TestPickEndpointRejectsUnhealthyLegacyReturn(t *testing.T) {
+	healthy := &model.Endpoint{ID: "healthy"}
+	unhealthy := &model.Endpoint{ID: "unhealthy", UnHealthy: true}
+	cluster := &model.ClusterConfig{
+		Name:      "legacy-health-guard",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+	}
+
+	got := PickEndpoint(unhealthyLegacyLoadBalancer{}, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy, unhealthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	assert.Nil(t, got)
+}
+
+func TestPickEndpointSnapshotMutationsDoNotEscape(t *testing.T) {
+	healthy := &model.Endpoint{
+		ID:       "healthy",
+		Metadata: map[string]string{"weight": "1"},
+		LLMMeta:  &model.LLMMeta{APIKey: "original-key"},
+	}
+	unhealthy := &model.Endpoint{
+		ID:        "unhealthy",
+		Metadata:  map[string]string{"weight": "2"},
+		UnHealthy: true,
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "snapshot-mutation",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+	}
+
+	got := PickEndpoint(mutatingSnapshotLoadBalancer{}, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy, unhealthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	if assert.NotNil(t, got) {
+		assert.NotSame(t, healthy, got)
+		assert.Equal(t, map[string]string{"weight": "1"}, got.Metadata)
+		assert.Equal(t, "original-key", got.LLMMeta.APIKey)
+	}
+	assert.Equal(t, map[string]string{"weight": "1"}, healthy.Metadata)
+	assert.Equal(t, "original-key", healthy.LLMMeta.APIKey)
+	assert.Equal(t, map[string]string{"weight": "2"}, unhealthy.Metadata)
+}
+
+func TestPickEndpointRejectsUnhealthySnapshotReturn(t *testing.T) {
+	healthy := &model.Endpoint{ID: "healthy"}
+	unhealthy := &model.Endpoint{ID: "unhealthy", UnHealthy: true}
+	cluster := &model.ClusterConfig{
+		Name:      "snapshot-health-guard",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+	}
+
+	got := PickEndpoint(unhealthySnapshotLoadBalancer{}, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy, unhealthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	assert.Nil(t, got)
+}
+
+func TestNeedsAllEndpointsKeepsCompatibilityForUnmarkedSnapshotLoadBalancer(t *testing.T) {
+	assert.True(t, NeedsAllEndpoints(mutatingSnapshotLoadBalancer{}))
+	assert.False(t, NeedsAllEndpoints(healthyOnlySnapshotLoadBalancer{}))
 }
 
 func TestPickEndpointSerializesLegacyLoadBalancerHandlers(t *testing.T) {

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -57,6 +57,13 @@ type observableLocker struct {
 	blocked chan struct{}
 }
 
+type legacyPickHarness struct {
+	t           *testing.T
+	balancer    LoadBalancer
+	blocking    *blockingLegacyLoadBalancer
+	releaseOnce sync.Once
+}
+
 func (l *legacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
 	l.seenEndpoints = c.Endpoints
 	if len(c.Endpoints) == 0 {
@@ -118,6 +125,73 @@ func (l *observableLocker) Unlock() {
 	l.mu.Unlock()
 }
 
+func newLegacyPickHarness(t *testing.T, scoped bool) *legacyPickHarness {
+	t.Helper()
+	blocking := &blockingLegacyLoadBalancer{
+		entered: make(chan int, 2),
+		release: make(chan struct{}),
+	}
+	harness := &legacyPickHarness{
+		t:        t,
+		balancer: blocking,
+		blocking: blocking,
+	}
+	if scoped {
+		harness.balancer = &clusterScopedBlockingLegacyLoadBalancer{
+			blockingLegacyLoadBalancer: blocking,
+		}
+	}
+	t.Cleanup(harness.release)
+	return harness
+}
+
+func newLegacyPickContext(clusterName, endpointID string) PickContext {
+	endpoint := &model.Endpoint{ID: endpointID}
+	return PickContext{
+		Config: &model.ClusterConfig{
+			Name:      clusterName,
+			Endpoints: []*model.Endpoint{endpoint},
+		},
+		HealthyEndpoints: []*model.Endpoint{endpoint},
+	}
+}
+
+func (h *legacyPickHarness) startDirectPick(context PickContext) <-chan struct{} {
+	h.t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = PickEndpoint(h.balancer, context, nil)
+	}()
+	return done
+}
+
+func (h *legacyPickHarness) startLockedPick(lock sync.Locker, context PickContext) <-chan struct{} {
+	h.t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = PickEndpointWithLegacyLock(h.balancer, lock, context, nil)
+	}()
+	return done
+}
+
+func (h *legacyPickHarness) release() {
+	h.releaseOnce.Do(func() {
+		close(h.blocking.release)
+	})
+}
+
+func (h *legacyPickHarness) waitEntry() int {
+	h.t.Helper()
+	return waitLegacyHandlerEntry(h.t, h.blocking.entered)
+}
+
+func (h *legacyPickHarness) assertNoEntry() {
+	h.t.Helper()
+	assertNoLegacyHandlerEntry(h.t, h.blocking.entered)
+}
+
 func TestPickEndpointAdaptsLegacyLoadBalancer(t *testing.T) {
 	healthy := &model.Endpoint{ID: "healthy"}
 	unhealthy := &model.Endpoint{ID: "unhealthy"}
@@ -156,242 +230,88 @@ func TestPickEndpointReconcilesLegacyCursorState(t *testing.T) {
 }
 
 func TestPickEndpointSerializesLegacyLoadBalancerHandlers(t *testing.T) {
-	first := &model.Endpoint{ID: "first"}
-	cluster := &model.ClusterConfig{
-		Name:      "blocking-legacy-load-balancer",
-		Endpoints: []*model.Endpoint{first},
-	}
-	balancer := &blockingLegacyLoadBalancer{
-		entered: make(chan int, 2),
-		release: make(chan struct{}),
-	}
-	pickContext := PickContext{
-		Config:           cluster,
-		HealthyEndpoints: []*model.Endpoint{first},
-	}
+	harness := newLegacyPickHarness(t, false)
+	pickContext := newLegacyPickContext("blocking-legacy-load-balancer", "first")
 
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		_ = PickEndpoint(balancer, pickContext, nil)
-	}()
-	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+	firstDone := harness.startDirectPick(pickContext)
+	assert.Equal(t, 1, harness.waitEntry())
 
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = PickEndpoint(balancer, pickContext, nil)
-	}()
+	secondDone := harness.startDirectPick(pickContext)
+	harness.assertNoEntry()
 
-	assertNoLegacyHandlerEntry(t, balancer.entered)
-
-	close(balancer.release)
-	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	harness.release()
+	assert.Equal(t, 2, harness.waitEntry())
 	waitClosed(t, firstDone)
 	waitClosed(t, secondDone)
 }
 
 func TestPickEndpointKeepsCompatibilityLockForOptInLegacyLoadBalancer(t *testing.T) {
-	firstEndpoint := &model.Endpoint{ID: "first"}
-	firstCluster := &model.ClusterConfig{
-		Name:      "blocking-legacy-load-balancer-first-direct-pick",
-		Endpoints: []*model.Endpoint{firstEndpoint},
-	}
-	secondEndpoint := &model.Endpoint{ID: "second"}
-	secondCluster := &model.ClusterConfig{
-		Name:      "blocking-legacy-load-balancer-second-direct-pick",
-		Endpoints: []*model.Endpoint{secondEndpoint},
-	}
-	balancer := &clusterScopedBlockingLegacyLoadBalancer{
-		blockingLegacyLoadBalancer: &blockingLegacyLoadBalancer{
-			entered: make(chan int, 2),
-			release: make(chan struct{}),
-		},
-	}
-	var releaseOnce sync.Once
-	t.Cleanup(func() {
-		releaseOnce.Do(func() {
-			close(balancer.release)
-		})
-	})
+	harness := newLegacyPickHarness(t, true)
+	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-direct-pick", "first")
+	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-direct-pick", "second")
 
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		_ = PickEndpoint(balancer, PickContext{
-			Config:           firstCluster,
-			HealthyEndpoints: []*model.Endpoint{firstEndpoint},
-		}, nil)
-	}()
-	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+	firstDone := harness.startDirectPick(firstContext)
+	assert.Equal(t, 1, harness.waitEntry())
 
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = PickEndpoint(balancer, PickContext{
-			Config:           secondCluster,
-			HealthyEndpoints: []*model.Endpoint{secondEndpoint},
-		}, nil)
-	}()
+	secondDone := harness.startDirectPick(secondContext)
+	harness.assertNoEntry()
 
-	assertNoLegacyHandlerEntry(t, balancer.entered)
-
-	releaseOnce.Do(func() {
-		close(balancer.release)
-	})
-	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	harness.release()
+	assert.Equal(t, 2, harness.waitEntry())
 	waitClosed(t, firstDone)
 	waitClosed(t, secondDone)
 }
 
 func TestPickEndpointWithLegacyLockSerializesOptInLegacyLoadBalancerHandlersWithSameLock(t *testing.T) {
-	first := &model.Endpoint{ID: "first"}
-	cluster := &model.ClusterConfig{
-		Name:      "blocking-legacy-load-balancer-same-lock",
-		Endpoints: []*model.Endpoint{first},
-	}
-	balancer := &clusterScopedBlockingLegacyLoadBalancer{
-		blockingLegacyLoadBalancer: &blockingLegacyLoadBalancer{
-			entered: make(chan int, 2),
-			release: make(chan struct{}),
-		},
-	}
+	harness := newLegacyPickHarness(t, true)
 	legacyPickLock := newObservableLocker()
-	var releaseOnce sync.Once
-	t.Cleanup(func() {
-		releaseOnce.Do(func() {
-			close(balancer.release)
-		})
-	})
-	pickContext := PickContext{
-		Config:           cluster,
-		HealthyEndpoints: []*model.Endpoint{first},
-	}
+	pickContext := newLegacyPickContext("blocking-legacy-load-balancer-same-lock", "first")
 
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		_ = PickEndpointWithLegacyLock(balancer, legacyPickLock, pickContext, nil)
-	}()
-	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+	firstDone := harness.startLockedPick(legacyPickLock, pickContext)
+	assert.Equal(t, 1, harness.waitEntry())
 
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = PickEndpointWithLegacyLock(balancer, legacyPickLock, pickContext, nil)
-	}()
+	secondDone := harness.startLockedPick(legacyPickLock, pickContext)
 	waitLegacyLockBlocked(t, legacyPickLock.blocked)
 
-	releaseOnce.Do(func() {
-		close(balancer.release)
-	})
-	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	harness.release()
+	assert.Equal(t, 2, harness.waitEntry())
 	waitClosed(t, firstDone)
 	waitClosed(t, secondDone)
 }
 
 func TestPickEndpointWithLegacyLockSerializesNonOptInLegacyLoadBalancerHandlersAcrossDifferentLocks(t *testing.T) {
-	firstEndpoint := &model.Endpoint{ID: "first"}
-	firstCluster := &model.ClusterConfig{
-		Name:      "blocking-legacy-load-balancer-first-lock",
-		Endpoints: []*model.Endpoint{firstEndpoint},
-	}
-	secondEndpoint := &model.Endpoint{ID: "second"}
-	secondCluster := &model.ClusterConfig{
-		Name:      "blocking-legacy-load-balancer-second-lock",
-		Endpoints: []*model.Endpoint{secondEndpoint},
-	}
-	balancer := &blockingLegacyLoadBalancer{
-		entered: make(chan int, 2),
-		release: make(chan struct{}),
-	}
+	harness := newLegacyPickHarness(t, false)
+	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-lock", "first")
+	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-lock", "second")
 	var firstLock sync.Mutex
 	var secondLock sync.Mutex
-	var releaseOnce sync.Once
-	t.Cleanup(func() {
-		releaseOnce.Do(func() {
-			close(balancer.release)
-		})
-	})
 
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		_ = PickEndpointWithLegacyLock(balancer, &firstLock, PickContext{
-			Config:           firstCluster,
-			HealthyEndpoints: []*model.Endpoint{firstEndpoint},
-		}, nil)
-	}()
-	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+	firstDone := harness.startLockedPick(&firstLock, firstContext)
+	assert.Equal(t, 1, harness.waitEntry())
 
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = PickEndpointWithLegacyLock(balancer, &secondLock, PickContext{
-			Config:           secondCluster,
-			HealthyEndpoints: []*model.Endpoint{secondEndpoint},
-		}, nil)
-	}()
+	secondDone := harness.startLockedPick(&secondLock, secondContext)
+	harness.assertNoEntry()
 
-	assertNoLegacyHandlerEntry(t, balancer.entered)
-
-	releaseOnce.Do(func() {
-		close(balancer.release)
-	})
-	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	harness.release()
+	assert.Equal(t, 2, harness.waitEntry())
 	waitClosed(t, firstDone)
 	waitClosed(t, secondDone)
 }
 
 func TestPickEndpointWithLegacyLockAllowsOptInLegacyLoadBalancerHandlersWithDifferentLocksToRunConcurrently(t *testing.T) {
-	firstEndpoint := &model.Endpoint{ID: "first"}
-	firstCluster := &model.ClusterConfig{
-		Name:      "blocking-legacy-load-balancer-first-lock",
-		Endpoints: []*model.Endpoint{firstEndpoint},
-	}
-	secondEndpoint := &model.Endpoint{ID: "second"}
-	secondCluster := &model.ClusterConfig{
-		Name:      "blocking-legacy-load-balancer-second-lock",
-		Endpoints: []*model.Endpoint{secondEndpoint},
-	}
-	balancer := &clusterScopedBlockingLegacyLoadBalancer{
-		blockingLegacyLoadBalancer: &blockingLegacyLoadBalancer{
-			entered: make(chan int, 2),
-			release: make(chan struct{}),
-		},
-	}
+	harness := newLegacyPickHarness(t, true)
+	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-lock", "first")
+	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-lock", "second")
 	var firstLock sync.Mutex
 	var secondLock sync.Mutex
-	var releaseOnce sync.Once
-	t.Cleanup(func() {
-		releaseOnce.Do(func() {
-			close(balancer.release)
-		})
-	})
 
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		_ = PickEndpointWithLegacyLock(balancer, &firstLock, PickContext{
-			Config:           firstCluster,
-			HealthyEndpoints: []*model.Endpoint{firstEndpoint},
-		}, nil)
-	}()
-	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+	firstDone := harness.startLockedPick(&firstLock, firstContext)
+	assert.Equal(t, 1, harness.waitEntry())
 
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = PickEndpointWithLegacyLock(balancer, &secondLock, PickContext{
-			Config:           secondCluster,
-			HealthyEndpoints: []*model.Endpoint{secondEndpoint},
-		}, nil)
-	}()
-	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	secondDone := harness.startLockedPick(&secondLock, secondContext)
+	assert.Equal(t, 2, harness.waitEntry())
 
-	releaseOnce.Do(func() {
-		close(balancer.release)
-	})
+	harness.release()
 	waitClosed(t, firstDone)
 	waitClosed(t, secondDone)
 }

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -18,6 +18,7 @@
 package loadbalancer
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -45,6 +46,17 @@ type blockingLegacyLoadBalancer struct {
 	calls   int32
 }
 
+type clusterScopedBlockingLegacyLoadBalancer struct {
+	*blockingLegacyLoadBalancer
+}
+
+type observableLocker struct {
+	mu      sync.Mutex
+	waiter  chan struct{}
+	locked  bool
+	blocked chan struct{}
+}
+
 func (l *legacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
 	l.seenEndpoints = c.Endpoints
 	if len(c.Endpoints) == 0 {
@@ -66,6 +78,44 @@ func (b *blockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbP
 		return nil
 	}
 	return c.Endpoints[0]
+}
+
+func (b *clusterScopedBlockingLegacyLoadBalancer) UseClusterScopedLegacyLock() bool {
+	return true
+}
+
+func newObservableLocker() *observableLocker {
+	return &observableLocker{
+		blocked: make(chan struct{}, 1),
+	}
+}
+
+func (l *observableLocker) Lock() {
+	l.mu.Lock()
+	if !l.locked {
+		l.locked = true
+		l.mu.Unlock()
+		return
+	}
+	waiter := make(chan struct{})
+	l.waiter = waiter
+	l.blocked <- struct{}{}
+	l.mu.Unlock()
+	<-waiter
+
+	l.mu.Lock()
+	l.locked = true
+	l.mu.Unlock()
+}
+
+func (l *observableLocker) Unlock() {
+	l.mu.Lock()
+	l.locked = false
+	if l.waiter != nil {
+		close(l.waiter)
+		l.waiter = nil
+	}
+	l.mu.Unlock()
 }
 
 func TestPickEndpointAdaptsLegacyLoadBalancer(t *testing.T) {
@@ -133,14 +183,215 @@ func TestPickEndpointSerializesLegacyLoadBalancerHandlers(t *testing.T) {
 		_ = PickEndpoint(balancer, pickContext, nil)
 	}()
 
-	select {
-	case call := <-balancer.entered:
-		t.Fatalf("legacy handler call %d entered before the first call returned", call)
-	case <-time.After(50 * time.Millisecond):
-	}
+	assertNoLegacyHandlerEntry(t, balancer.entered)
 
 	close(balancer.release)
 	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func TestPickEndpointKeepsCompatibilityLockForOptInLegacyLoadBalancer(t *testing.T) {
+	firstEndpoint := &model.Endpoint{ID: "first"}
+	firstCluster := &model.ClusterConfig{
+		Name:      "blocking-legacy-load-balancer-first-direct-pick",
+		Endpoints: []*model.Endpoint{firstEndpoint},
+	}
+	secondEndpoint := &model.Endpoint{ID: "second"}
+	secondCluster := &model.ClusterConfig{
+		Name:      "blocking-legacy-load-balancer-second-direct-pick",
+		Endpoints: []*model.Endpoint{secondEndpoint},
+	}
+	balancer := &clusterScopedBlockingLegacyLoadBalancer{
+		blockingLegacyLoadBalancer: &blockingLegacyLoadBalancer{
+			entered: make(chan int, 2),
+			release: make(chan struct{}),
+		},
+	}
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() {
+			close(balancer.release)
+		})
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_ = PickEndpoint(balancer, PickContext{
+			Config:           firstCluster,
+			HealthyEndpoints: []*model.Endpoint{firstEndpoint},
+		}, nil)
+	}()
+	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = PickEndpoint(balancer, PickContext{
+			Config:           secondCluster,
+			HealthyEndpoints: []*model.Endpoint{secondEndpoint},
+		}, nil)
+	}()
+
+	assertNoLegacyHandlerEntry(t, balancer.entered)
+
+	releaseOnce.Do(func() {
+		close(balancer.release)
+	})
+	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func TestPickEndpointWithLegacyLockSerializesOptInLegacyLoadBalancerHandlersWithSameLock(t *testing.T) {
+	first := &model.Endpoint{ID: "first"}
+	cluster := &model.ClusterConfig{
+		Name:      "blocking-legacy-load-balancer-same-lock",
+		Endpoints: []*model.Endpoint{first},
+	}
+	balancer := &clusterScopedBlockingLegacyLoadBalancer{
+		blockingLegacyLoadBalancer: &blockingLegacyLoadBalancer{
+			entered: make(chan int, 2),
+			release: make(chan struct{}),
+		},
+	}
+	legacyPickLock := newObservableLocker()
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() {
+			close(balancer.release)
+		})
+	})
+	pickContext := PickContext{
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{first},
+	}
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_ = PickEndpointWithLegacyLock(balancer, legacyPickLock, pickContext, nil)
+	}()
+	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = PickEndpointWithLegacyLock(balancer, legacyPickLock, pickContext, nil)
+	}()
+	waitLegacyLockBlocked(t, legacyPickLock.blocked)
+
+	releaseOnce.Do(func() {
+		close(balancer.release)
+	})
+	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func TestPickEndpointWithLegacyLockSerializesNonOptInLegacyLoadBalancerHandlersAcrossDifferentLocks(t *testing.T) {
+	firstEndpoint := &model.Endpoint{ID: "first"}
+	firstCluster := &model.ClusterConfig{
+		Name:      "blocking-legacy-load-balancer-first-lock",
+		Endpoints: []*model.Endpoint{firstEndpoint},
+	}
+	secondEndpoint := &model.Endpoint{ID: "second"}
+	secondCluster := &model.ClusterConfig{
+		Name:      "blocking-legacy-load-balancer-second-lock",
+		Endpoints: []*model.Endpoint{secondEndpoint},
+	}
+	balancer := &blockingLegacyLoadBalancer{
+		entered: make(chan int, 2),
+		release: make(chan struct{}),
+	}
+	var firstLock sync.Mutex
+	var secondLock sync.Mutex
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() {
+			close(balancer.release)
+		})
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_ = PickEndpointWithLegacyLock(balancer, &firstLock, PickContext{
+			Config:           firstCluster,
+			HealthyEndpoints: []*model.Endpoint{firstEndpoint},
+		}, nil)
+	}()
+	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = PickEndpointWithLegacyLock(balancer, &secondLock, PickContext{
+			Config:           secondCluster,
+			HealthyEndpoints: []*model.Endpoint{secondEndpoint},
+		}, nil)
+	}()
+
+	assertNoLegacyHandlerEntry(t, balancer.entered)
+
+	releaseOnce.Do(func() {
+		close(balancer.release)
+	})
+	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func TestPickEndpointWithLegacyLockAllowsOptInLegacyLoadBalancerHandlersWithDifferentLocksToRunConcurrently(t *testing.T) {
+	firstEndpoint := &model.Endpoint{ID: "first"}
+	firstCluster := &model.ClusterConfig{
+		Name:      "blocking-legacy-load-balancer-first-lock",
+		Endpoints: []*model.Endpoint{firstEndpoint},
+	}
+	secondEndpoint := &model.Endpoint{ID: "second"}
+	secondCluster := &model.ClusterConfig{
+		Name:      "blocking-legacy-load-balancer-second-lock",
+		Endpoints: []*model.Endpoint{secondEndpoint},
+	}
+	balancer := &clusterScopedBlockingLegacyLoadBalancer{
+		blockingLegacyLoadBalancer: &blockingLegacyLoadBalancer{
+			entered: make(chan int, 2),
+			release: make(chan struct{}),
+		},
+	}
+	var firstLock sync.Mutex
+	var secondLock sync.Mutex
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() {
+			close(balancer.release)
+		})
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_ = PickEndpointWithLegacyLock(balancer, &firstLock, PickContext{
+			Config:           firstCluster,
+			HealthyEndpoints: []*model.Endpoint{firstEndpoint},
+		}, nil)
+	}()
+	assert.Equal(t, 1, waitLegacyHandlerEntry(t, balancer.entered))
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = PickEndpointWithLegacyLock(balancer, &secondLock, PickContext{
+			Config:           secondCluster,
+			HealthyEndpoints: []*model.Endpoint{secondEndpoint},
+		}, nil)
+	}()
+	assert.Equal(t, 2, waitLegacyHandlerEntry(t, balancer.entered))
+
+	releaseOnce.Do(func() {
+		close(balancer.release)
+	})
 	waitClosed(t, firstDone)
 	waitClosed(t, secondDone)
 }
@@ -153,6 +404,24 @@ func waitLegacyHandlerEntry(t *testing.T, entered <-chan int) int {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for legacy handler entry")
 		return 0
+	}
+}
+
+func assertNoLegacyHandlerEntry(t *testing.T, entered <-chan int) {
+	t.Helper()
+	select {
+	case call := <-entered:
+		t.Fatalf("legacy handler call %d entered before the first call returned", call)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func waitLegacyLockBlocked(t *testing.T, blocked <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for legacy pick to block on the runtime lock")
 	}
 }
 

--- a/pkg/cluster/loadbalancer/maglev/maglev_hash.go
+++ b/pkg/cluster/loadbalancer/maglev/maglev_hash.go
@@ -50,31 +50,47 @@ func NewMaglevHash(config model.ConsistentHash, endpoints []*model.Endpoint) mod
 
 type MaglevHash struct{}
 
+func (MaglevHash) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (MaglevHash) UseZeroCopySnapshot() bool {
+	return true
+}
+
 func (m MaglevHash) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
+	if c == nil {
+		return nil
+	}
+	endpoints := c.GetEndpoint(true)
+	hashView := model.ReadOnlyConsistentHash(c.ConsistentHash.Hash)
+	if hashView == nil && len(endpoints) > 0 {
+		hashView = model.ReadOnlyConsistentHash(NewMaglevHash(c.ConsistentHash, endpoints))
+	}
 	return m.HandlerWithSnapshot(loadbalancer.PickContext{
-		Config:           c,
-		HealthyEndpoints: c.GetEndpoint(true),
+		Config:                c,
+		HealthyConsistentHash: hashView,
+		HealthyEndpoints:      endpoints,
 	}, policy)
 }
 
 func (m MaglevHash) HandlerWithSnapshot(c loadbalancer.PickContext, policy model.LbPolicy) *model.Endpoint {
-	dst, err := c.Config.ConsistentHash.Hash.Get(policy.GenerateHash())
+	endpoints := c.HealthyEndpoints
+	hashView := loadbalancer.ConsistentHashForHealthyEndpoints(c)
+	if len(endpoints) == 0 || hashView == nil || policy == nil {
+		return nil
+	}
+
+	dst, err := hashView.Get(policy.GenerateHash())
 	if err != nil {
 		logger.Warnf("[dubbo-go-pixiu] error of getting from maglev hash: %v", err)
 		return nil
 	}
-
-	endpoints := c.HealthyEndpoints
 
 	for _, endpoint := range endpoints {
 		if endpoint.GetHost() == dst {
 			return endpoint
 		}
 	}
-
-	if len(endpoints) == 0 {
-		return nil
-	}
-
 	return endpoints[0]
 }

--- a/pkg/cluster/loadbalancer/maglev/maglev_hash.go
+++ b/pkg/cluster/loadbalancer/maglev/maglev_hash.go
@@ -51,13 +51,20 @@ func NewMaglevHash(config model.ConsistentHash, endpoints []*model.Endpoint) mod
 type MaglevHash struct{}
 
 func (m MaglevHash) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
-	dst, err := c.ConsistentHash.Hash.Get(policy.GenerateHash())
+	return m.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: c.GetEndpoint(true),
+	}, policy)
+}
+
+func (m MaglevHash) HandlerWithSnapshot(c loadbalancer.PickContext, policy model.LbPolicy) *model.Endpoint {
+	dst, err := c.Config.ConsistentHash.Hash.Get(policy.GenerateHash())
 	if err != nil {
 		logger.Warnf("[dubbo-go-pixiu] error of getting from maglev hash: %v", err)
 		return nil
 	}
 
-	endpoints := c.GetEndpoint(true)
+	endpoints := c.HealthyEndpoints
 
 	for _, endpoint := range endpoints {
 		if endpoint.GetHost() == dst {

--- a/pkg/cluster/loadbalancer/maglev/maglev_hash_test.go
+++ b/pkg/cluster/loadbalancer/maglev/maglev_hash_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
@@ -56,7 +57,10 @@ func TestMaglevHash(t *testing.T) {
 
 	for i := 1; i <= 20; i++ {
 		path = fmt.Sprintf("/pixiu?total=%d", i)
-		t.Log(hashing.Handler(cluster, &http.HttpContext{Request: &stdHttp.Request{Method: stdHttp.MethodGet, RequestURI: path}}))
+		t.Log(hashing.HandlerWithSnapshot(loadbalancer.PickContext{
+			Config:           cluster,
+			HealthyEndpoints: cluster.GetEndpoint(true),
+		}, &http.HttpContext{Request: &stdHttp.Request{Method: stdHttp.MethodGet, RequestURI: path}}))
 	}
 
 }

--- a/pkg/cluster/loadbalancer/maglev/maglev_hash_test.go
+++ b/pkg/cluster/loadbalancer/maglev/maglev_hash_test.go
@@ -30,6 +30,87 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
+type staticHashPolicy string
+
+func (p staticHashPolicy) GenerateHash() string {
+	return string(p)
+}
+
+type fixedConsistentHash struct {
+	host string
+}
+
+func (h fixedConsistentHash) Hash(string) uint32 {
+	return 0
+}
+
+func (h fixedConsistentHash) Add(string) {}
+
+func (h fixedConsistentHash) Get(string) (string, error) {
+	return h.host, nil
+}
+
+func (h fixedConsistentHash) GetHash(uint32) (string, error) {
+	return h.host, nil
+}
+
+func (h fixedConsistentHash) Remove(string) bool {
+	return false
+}
+
+func TestMaglevHashHandlerUsesConfiguredHashWithoutClusterLBPolicy(t *testing.T) {
+	first := &model.Endpoint{
+		ID:      "first",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+	}
+	second := &model.Endpoint{
+		ID:      "second",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "maglev-direct",
+		Endpoints: []*model.Endpoint{first, second},
+		ConsistentHash: model.ConsistentHash{
+			Hash: fixedConsistentHash{host: second.GetHost()},
+		},
+	}
+
+	got := MaglevHash{}.Handler(cluster, staticHashPolicy("request-key"))
+	if got == nil {
+		t.Fatal("expected endpoint, got nil")
+	}
+	if got.ID != second.ID {
+		t.Fatalf("MaglevHash picked %q, want %q", got.ID, second.ID)
+	}
+}
+
+func TestMaglevHashHandlerFallsBackWhenConfiguredHashHitsUnhealthyEndpoint(t *testing.T) {
+	healthy := &model.Endpoint{
+		ID:      "healthy",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+	}
+	unhealthy := &model.Endpoint{
+		ID:        "unhealthy",
+		Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+		UnHealthy: true,
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "maglev-direct-unhealthy-hit",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+		ConsistentHash: model.ConsistentHash{
+			Hash: fixedConsistentHash{host: unhealthy.GetHost()},
+		},
+	}
+
+	got := MaglevHash{}.Handler(cluster, staticHashPolicy("request-key"))
+	if got == nil {
+		t.Fatal("expected fallback endpoint, got nil")
+	}
+	if got.ID != healthy.ID {
+		t.Fatalf("MaglevHash picked %q, want %q", got.ID, healthy.ID)
+	}
+}
+
 func TestMaglevHash(t *testing.T) {
 
 	nodeCount := 5
@@ -63,4 +144,53 @@ func TestMaglevHash(t *testing.T) {
 		}, &http.HttpContext{Request: &stdHttp.Request{Method: stdHttp.MethodGet, RequestURI: path}}))
 	}
 
+}
+
+func TestLookUpTableHashIsStableForSameKey(t *testing.T) {
+	table, err := NewLookUpTable(521, []string{"127.0.0.1:18080", "127.0.0.1:18081"})
+	if err != nil {
+		t.Fatalf("NewLookUpTable() error = %v", err)
+	}
+
+	first := table.Hash("same-request-key")
+	for i := 0; i < 20; i++ {
+		if got := table.Hash("same-request-key"); got != first {
+			t.Fatalf("Hash() = %d, want stable %d", got, first)
+		}
+	}
+}
+
+func TestMaglevHashUsesHealthyConsistentHashSnapshot(t *testing.T) {
+	first := &model.Endpoint{
+		ID:      "first",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+	}
+	unhealthy := &model.Endpoint{
+		ID:        "unhealthy",
+		Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+		UnHealthy: true,
+	}
+	second := &model.Endpoint{
+		ID:      "second",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18082},
+	}
+	cluster := &model.ClusterConfig{
+		Name: "maglev-healthy-snapshot",
+		ConsistentHash: model.ConsistentHash{
+			Hash: fixedConsistentHash{host: unhealthy.GetHost()},
+		},
+	}
+
+	got := MaglevHash{}.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:                cluster,
+		HealthyConsistentHash: fixedConsistentHash{host: second.GetHost()},
+		HealthyEndpoints:      []*model.Endpoint{first, second},
+	}, staticHashPolicy("key-for-unhealthy-slot"))
+
+	if got == nil {
+		t.Fatal("expected healthy endpoint, got nil")
+	}
+	if got.ID != second.ID {
+		t.Fatalf("MaglevHash picked %q, want %q", got.ID, second.ID)
+	}
 }

--- a/pkg/cluster/loadbalancer/maglev/maglev_hash_test.go
+++ b/pkg/cluster/loadbalancer/maglev/maglev_hash_test.go
@@ -26,89 +26,13 @@ import (
 
 import (
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/internal/lbtest"
 	"github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
-type staticHashPolicy string
-
-func (p staticHashPolicy) GenerateHash() string {
-	return string(p)
-}
-
-type fixedConsistentHash struct {
-	host string
-}
-
-func (h fixedConsistentHash) Hash(string) uint32 {
-	return 0
-}
-
-func (h fixedConsistentHash) Add(string) {}
-
-func (h fixedConsistentHash) Get(string) (string, error) {
-	return h.host, nil
-}
-
-func (h fixedConsistentHash) GetHash(uint32) (string, error) {
-	return h.host, nil
-}
-
-func (h fixedConsistentHash) Remove(string) bool {
-	return false
-}
-
-func TestMaglevHashHandlerUsesConfiguredHashWithoutClusterLBPolicy(t *testing.T) {
-	first := &model.Endpoint{
-		ID:      "first",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
-	}
-	second := &model.Endpoint{
-		ID:      "second",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18081},
-	}
-	cluster := &model.ClusterConfig{
-		Name:      "maglev-direct",
-		Endpoints: []*model.Endpoint{first, second},
-		ConsistentHash: model.ConsistentHash{
-			Hash: fixedConsistentHash{host: second.GetHost()},
-		},
-	}
-
-	got := MaglevHash{}.Handler(cluster, staticHashPolicy("request-key"))
-	if got == nil {
-		t.Fatal("expected endpoint, got nil")
-	}
-	if got.ID != second.ID {
-		t.Fatalf("MaglevHash picked %q, want %q", got.ID, second.ID)
-	}
-}
-
-func TestMaglevHashHandlerFallsBackWhenConfiguredHashHitsUnhealthyEndpoint(t *testing.T) {
-	healthy := &model.Endpoint{
-		ID:      "healthy",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
-	}
-	unhealthy := &model.Endpoint{
-		ID:        "unhealthy",
-		Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
-		UnHealthy: true,
-	}
-	cluster := &model.ClusterConfig{
-		Name:      "maglev-direct-unhealthy-hit",
-		Endpoints: []*model.Endpoint{healthy, unhealthy},
-		ConsistentHash: model.ConsistentHash{
-			Hash: fixedConsistentHash{host: unhealthy.GetHost()},
-		},
-	}
-
-	got := MaglevHash{}.Handler(cluster, staticHashPolicy("request-key"))
-	if got == nil {
-		t.Fatal("expected fallback endpoint, got nil")
-	}
-	if got.ID != healthy.ID {
-		t.Fatalf("MaglevHash picked %q, want %q", got.ID, healthy.ID)
-	}
+func TestMaglevHashHandlerSuite(t *testing.T) {
+	lbtest.RunConsistentHashHandlerSuite(t, MaglevHash{}, "maglev")
 }
 
 func TestMaglevHash(t *testing.T) {
@@ -157,40 +81,5 @@ func TestLookUpTableHashIsStableForSameKey(t *testing.T) {
 		if got := table.Hash("same-request-key"); got != first {
 			t.Fatalf("Hash() = %d, want stable %d", got, first)
 		}
-	}
-}
-
-func TestMaglevHashUsesHealthyConsistentHashSnapshot(t *testing.T) {
-	first := &model.Endpoint{
-		ID:      "first",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
-	}
-	unhealthy := &model.Endpoint{
-		ID:        "unhealthy",
-		Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
-		UnHealthy: true,
-	}
-	second := &model.Endpoint{
-		ID:      "second",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18082},
-	}
-	cluster := &model.ClusterConfig{
-		Name: "maglev-healthy-snapshot",
-		ConsistentHash: model.ConsistentHash{
-			Hash: fixedConsistentHash{host: unhealthy.GetHost()},
-		},
-	}
-
-	got := MaglevHash{}.HandlerWithSnapshot(loadbalancer.PickContext{
-		Config:                cluster,
-		HealthyConsistentHash: fixedConsistentHash{host: second.GetHost()},
-		HealthyEndpoints:      []*model.Endpoint{first, second},
-	}, staticHashPolicy("key-for-unhealthy-slot"))
-
-	if got == nil {
-		t.Fatal("expected healthy endpoint, got nil")
-	}
-	if got.ID != second.ID {
-		t.Fatalf("MaglevHash picked %q, want %q", got.ID, second.ID)
 	}
 }

--- a/pkg/cluster/loadbalancer/maglev/permutation.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation.go
@@ -19,7 +19,6 @@ package maglev
 
 import (
 	"encoding/binary"
-	"hash/maphash"
 	"math"
 	"math/big"
 	"sync"
@@ -187,10 +186,7 @@ func (t *LookUpTable) removePerm(dst int) {
 
 // Hash the input key.
 func (t *LookUpTable) Hash(key string) uint32 {
-	var h maphash.Hash
-	h.SetSeed(maphash.MakeSeed())
-	h.WriteString(key)
-	return uint32(h.Sum64())
+	return _hash1(key)
 }
 
 // Get a slot by hashing the input key.

--- a/pkg/cluster/loadbalancer/rand/load_balancer_rand.go
+++ b/pkg/cluster/loadbalancer/rand/load_balancer_rand.go
@@ -35,8 +35,15 @@ type Rand struct{}
 // randIntn lets tests replace randomness with deterministic choices.
 var randIntn = rand.Intn
 
-func (Rand) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
-	endpoints := c.GetEndpoint(true)
+func (r Rand) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
+	return r.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: c.GetEndpoint(true),
+	}, policy)
+}
+
+func (Rand) HandlerWithSnapshot(c loadbalancer.PickContext, _ model.LbPolicy) *model.Endpoint {
+	endpoints := c.HealthyEndpoints
 	if len(endpoints) == 0 {
 		return nil
 	}

--- a/pkg/cluster/loadbalancer/rand/load_balancer_rand.go
+++ b/pkg/cluster/loadbalancer/rand/load_balancer_rand.go
@@ -32,6 +32,14 @@ func init() {
 
 type Rand struct{}
 
+func (Rand) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (Rand) UseZeroCopySnapshot() bool {
+	return true
+}
+
 // randIntn lets tests replace randomness with deterministic choices.
 var randIntn = rand.Intn
 

--- a/pkg/cluster/loadbalancer/rand/load_balancer_rand_test.go
+++ b/pkg/cluster/loadbalancer/rand/load_balancer_rand_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
@@ -49,7 +50,7 @@ func TestRand_TwoHealthyEndpoints_CanSelectSecondEndpoint(t *testing.T) {
 
 	var got *model.Endpoint
 	assert.NotPanics(t, func() {
-		got = Rand{}.Handler(cluster, nil)
+		got = Rand{}.HandlerWithSnapshot(testPickContext(cluster), nil)
 	})
 	if assert.NotNil(t, got) {
 		assert.Equal(t, "ep-2", got.ID)
@@ -77,7 +78,7 @@ func TestRand_PartiallyUnhealthyEndpoints_DoesNotIndexPastHealthySlice(t *testin
 
 	var got *model.Endpoint
 	assert.NotPanics(t, func() {
-		got = Rand{}.Handler(cluster, nil)
+		got = Rand{}.HandlerWithSnapshot(testPickContext(cluster), nil)
 	})
 	if assert.NotNil(t, got) {
 		assert.Equal(t, "ep-2", got.ID)
@@ -104,7 +105,14 @@ func TestRand_AllEndpointsUnhealthy_ReturnsNilWithoutPanic(t *testing.T) {
 
 	var got *model.Endpoint
 	assert.NotPanics(t, func() {
-		got = Rand{}.Handler(cluster, nil)
+		got = Rand{}.HandlerWithSnapshot(testPickContext(cluster), nil)
 	})
 	assert.Nil(t, got)
+}
+
+func testPickContext(cluster *model.ClusterConfig) loadbalancer.PickContext {
+	return loadbalancer.PickContext{
+		Config:           cluster,
+		HealthyEndpoints: cluster.GetEndpoint(true),
+	}
 }

--- a/pkg/cluster/loadbalancer/ringhash/ring_hash.go
+++ b/pkg/cluster/loadbalancer/ringhash/ring_hash.go
@@ -59,14 +59,21 @@ func NewRingHash(config model.ConsistentHash, endpoints []*model.Endpoint) model
 type RingHashing struct{}
 
 func (r RingHashing) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
-	u := c.ConsistentHash.Hash.Hash(policy.GenerateHash())
-	hash, err := c.ConsistentHash.Hash.GetHash(u)
+	return r.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: c.GetEndpoint(true),
+	}, policy)
+}
+
+func (r RingHashing) HandlerWithSnapshot(c loadbalancer.PickContext, policy model.LbPolicy) *model.Endpoint {
+	u := c.Config.ConsistentHash.Hash.Hash(policy.GenerateHash())
+	hash, err := c.Config.ConsistentHash.Hash.GetHash(u)
 	if err != nil {
 		logger.Warnf("[dubbo-go-pixiu] error of getting from ring hash: %v", err)
 		return nil
 	}
 
-	endpoints := c.GetEndpoint(true)
+	endpoints := c.HealthyEndpoints
 
 	for _, endpoint := range endpoints {
 		if endpoint.GetHost() == hash {

--- a/pkg/cluster/loadbalancer/ringhash/ring_hash.go
+++ b/pkg/cluster/loadbalancer/ringhash/ring_hash.go
@@ -58,32 +58,48 @@ func NewRingHash(config model.ConsistentHash, endpoints []*model.Endpoint) model
 
 type RingHashing struct{}
 
+func (RingHashing) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (RingHashing) UseZeroCopySnapshot() bool {
+	return true
+}
+
 func (r RingHashing) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
+	if c == nil {
+		return nil
+	}
+	endpoints := c.GetEndpoint(true)
+	hashView := model.ReadOnlyConsistentHash(c.ConsistentHash.Hash)
+	if hashView == nil && len(endpoints) > 0 {
+		hashView = model.ReadOnlyConsistentHash(NewRingHash(c.ConsistentHash, endpoints))
+	}
 	return r.HandlerWithSnapshot(loadbalancer.PickContext{
-		Config:           c,
-		HealthyEndpoints: c.GetEndpoint(true),
+		Config:                c,
+		HealthyConsistentHash: hashView,
+		HealthyEndpoints:      endpoints,
 	}, policy)
 }
 
 func (r RingHashing) HandlerWithSnapshot(c loadbalancer.PickContext, policy model.LbPolicy) *model.Endpoint {
-	u := c.Config.ConsistentHash.Hash.Hash(policy.GenerateHash())
-	hash, err := c.Config.ConsistentHash.Hash.GetHash(u)
+	endpoints := c.HealthyEndpoints
+	hashView := loadbalancer.ConsistentHashForHealthyEndpoints(c)
+	if len(endpoints) == 0 || hashView == nil || policy == nil {
+		return nil
+	}
+
+	u := hashView.Hash(policy.GenerateHash())
+	host, err := hashView.GetHash(u)
 	if err != nil {
 		logger.Warnf("[dubbo-go-pixiu] error of getting from ring hash: %v", err)
 		return nil
 	}
 
-	endpoints := c.HealthyEndpoints
-
 	for _, endpoint := range endpoints {
-		if endpoint.GetHost() == hash {
+		if endpoint.GetHost() == host {
 			return endpoint
 		}
 	}
-
-	if len(endpoints) == 0 {
-		return nil
-	}
-
 	return endpoints[0]
 }

--- a/pkg/cluster/loadbalancer/ringhash/ring_hash_test.go
+++ b/pkg/cluster/loadbalancer/ringhash/ring_hash_test.go
@@ -30,6 +30,87 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
+type staticHashPolicy string
+
+func (p staticHashPolicy) GenerateHash() string {
+	return string(p)
+}
+
+type fixedConsistentHash struct {
+	host string
+}
+
+func (h fixedConsistentHash) Hash(string) uint32 {
+	return 0
+}
+
+func (h fixedConsistentHash) Add(string) {}
+
+func (h fixedConsistentHash) Get(string) (string, error) {
+	return h.host, nil
+}
+
+func (h fixedConsistentHash) GetHash(uint32) (string, error) {
+	return h.host, nil
+}
+
+func (h fixedConsistentHash) Remove(string) bool {
+	return false
+}
+
+func TestRingHashHandlerUsesConfiguredHashWithoutClusterLBPolicy(t *testing.T) {
+	first := &model.Endpoint{
+		ID:      "first",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+	}
+	second := &model.Endpoint{
+		ID:      "second",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "ring-direct",
+		Endpoints: []*model.Endpoint{first, second},
+		ConsistentHash: model.ConsistentHash{
+			Hash: fixedConsistentHash{host: second.GetHost()},
+		},
+	}
+
+	got := RingHashing{}.Handler(cluster, staticHashPolicy("request-key"))
+	if got == nil {
+		t.Fatal("expected endpoint, got nil")
+	}
+	if got.ID != second.ID {
+		t.Fatalf("RingHashing picked %q, want %q", got.ID, second.ID)
+	}
+}
+
+func TestRingHashHandlerFallsBackWhenConfiguredHashHitsUnhealthyEndpoint(t *testing.T) {
+	healthy := &model.Endpoint{
+		ID:      "healthy",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+	}
+	unhealthy := &model.Endpoint{
+		ID:        "unhealthy",
+		Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+		UnHealthy: true,
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "ring-direct-unhealthy-hit",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+		ConsistentHash: model.ConsistentHash{
+			Hash: fixedConsistentHash{host: unhealthy.GetHost()},
+		},
+	}
+
+	got := RingHashing{}.Handler(cluster, staticHashPolicy("request-key"))
+	if got == nil {
+		t.Fatal("expected fallback endpoint, got nil")
+	}
+	if got.ID != healthy.ID {
+		t.Fatalf("RingHashing picked %q, want %q", got.ID, healthy.ID)
+	}
+}
+
 func TestHashRing(t *testing.T) {
 
 	nodeCount := 5
@@ -63,4 +144,39 @@ func TestHashRing(t *testing.T) {
 		}, &http.HttpContext{Request: &stdHttp.Request{Method: stdHttp.MethodGet, RequestURI: path}}))
 	}
 
+}
+
+func TestRingHashUsesHealthyConsistentHashSnapshot(t *testing.T) {
+	first := &model.Endpoint{
+		ID:      "first",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
+	}
+	unhealthy := &model.Endpoint{
+		ID:        "unhealthy",
+		Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
+		UnHealthy: true,
+	}
+	second := &model.Endpoint{
+		ID:      "second",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18082},
+	}
+	cluster := &model.ClusterConfig{
+		Name: "ring-healthy-snapshot",
+		ConsistentHash: model.ConsistentHash{
+			Hash: fixedConsistentHash{host: unhealthy.GetHost()},
+		},
+	}
+
+	got := RingHashing{}.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:                cluster,
+		HealthyConsistentHash: fixedConsistentHash{host: second.GetHost()},
+		HealthyEndpoints:      []*model.Endpoint{first, second},
+	}, staticHashPolicy("key-for-unhealthy-slot"))
+
+	if got == nil {
+		t.Fatal("expected healthy endpoint, got nil")
+	}
+	if got.ID != second.ID {
+		t.Fatalf("RingHashing picked %q, want %q", got.ID, second.ID)
+	}
 }

--- a/pkg/cluster/loadbalancer/ringhash/ring_hash_test.go
+++ b/pkg/cluster/loadbalancer/ringhash/ring_hash_test.go
@@ -26,89 +26,13 @@ import (
 
 import (
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/internal/lbtest"
 	"github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
-type staticHashPolicy string
-
-func (p staticHashPolicy) GenerateHash() string {
-	return string(p)
-}
-
-type fixedConsistentHash struct {
-	host string
-}
-
-func (h fixedConsistentHash) Hash(string) uint32 {
-	return 0
-}
-
-func (h fixedConsistentHash) Add(string) {}
-
-func (h fixedConsistentHash) Get(string) (string, error) {
-	return h.host, nil
-}
-
-func (h fixedConsistentHash) GetHash(uint32) (string, error) {
-	return h.host, nil
-}
-
-func (h fixedConsistentHash) Remove(string) bool {
-	return false
-}
-
-func TestRingHashHandlerUsesConfiguredHashWithoutClusterLBPolicy(t *testing.T) {
-	first := &model.Endpoint{
-		ID:      "first",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
-	}
-	second := &model.Endpoint{
-		ID:      "second",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18081},
-	}
-	cluster := &model.ClusterConfig{
-		Name:      "ring-direct",
-		Endpoints: []*model.Endpoint{first, second},
-		ConsistentHash: model.ConsistentHash{
-			Hash: fixedConsistentHash{host: second.GetHost()},
-		},
-	}
-
-	got := RingHashing{}.Handler(cluster, staticHashPolicy("request-key"))
-	if got == nil {
-		t.Fatal("expected endpoint, got nil")
-	}
-	if got.ID != second.ID {
-		t.Fatalf("RingHashing picked %q, want %q", got.ID, second.ID)
-	}
-}
-
-func TestRingHashHandlerFallsBackWhenConfiguredHashHitsUnhealthyEndpoint(t *testing.T) {
-	healthy := &model.Endpoint{
-		ID:      "healthy",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
-	}
-	unhealthy := &model.Endpoint{
-		ID:        "unhealthy",
-		Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
-		UnHealthy: true,
-	}
-	cluster := &model.ClusterConfig{
-		Name:      "ring-direct-unhealthy-hit",
-		Endpoints: []*model.Endpoint{healthy, unhealthy},
-		ConsistentHash: model.ConsistentHash{
-			Hash: fixedConsistentHash{host: unhealthy.GetHost()},
-		},
-	}
-
-	got := RingHashing{}.Handler(cluster, staticHashPolicy("request-key"))
-	if got == nil {
-		t.Fatal("expected fallback endpoint, got nil")
-	}
-	if got.ID != healthy.ID {
-		t.Fatalf("RingHashing picked %q, want %q", got.ID, healthy.ID)
-	}
+func TestRingHashHandlerSuite(t *testing.T) {
+	lbtest.RunConsistentHashHandlerSuite(t, RingHashing{}, "ring")
 }
 
 func TestHashRing(t *testing.T) {
@@ -144,39 +68,4 @@ func TestHashRing(t *testing.T) {
 		}, &http.HttpContext{Request: &stdHttp.Request{Method: stdHttp.MethodGet, RequestURI: path}}))
 	}
 
-}
-
-func TestRingHashUsesHealthyConsistentHashSnapshot(t *testing.T) {
-	first := &model.Endpoint{
-		ID:      "first",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18080},
-	}
-	unhealthy := &model.Endpoint{
-		ID:        "unhealthy",
-		Address:   model.SocketAddress{Address: "127.0.0.1", Port: 18081},
-		UnHealthy: true,
-	}
-	second := &model.Endpoint{
-		ID:      "second",
-		Address: model.SocketAddress{Address: "127.0.0.1", Port: 18082},
-	}
-	cluster := &model.ClusterConfig{
-		Name: "ring-healthy-snapshot",
-		ConsistentHash: model.ConsistentHash{
-			Hash: fixedConsistentHash{host: unhealthy.GetHost()},
-		},
-	}
-
-	got := RingHashing{}.HandlerWithSnapshot(loadbalancer.PickContext{
-		Config:                cluster,
-		HealthyConsistentHash: fixedConsistentHash{host: second.GetHost()},
-		HealthyEndpoints:      []*model.Endpoint{first, second},
-	}, staticHashPolicy("key-for-unhealthy-slot"))
-
-	if got == nil {
-		t.Fatal("expected healthy endpoint, got nil")
-	}
-	if got.ID != second.ID {
-		t.Fatalf("RingHashing picked %q, want %q", got.ID, second.ID)
-	}
 }

--- a/pkg/cluster/loadbalancer/ringhash/ring_hash_test.go
+++ b/pkg/cluster/loadbalancer/ringhash/ring_hash_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
@@ -56,7 +57,10 @@ func TestHashRing(t *testing.T) {
 
 	for i := 1; i <= 20; i++ {
 		path = fmt.Sprintf("/pixiu?total=%d", i)
-		t.Log(hashing.Handler(cluster, &http.HttpContext{Request: &stdHttp.Request{Method: stdHttp.MethodGet, RequestURI: path}}))
+		t.Log(hashing.HandlerWithSnapshot(loadbalancer.PickContext{
+			Config:           cluster,
+			HealthyEndpoints: cluster.GetEndpoint(true),
+		}, &http.HttpContext{Request: &stdHttp.Request{Method: stdHttp.MethodGet, RequestURI: path}}))
 	}
 
 }

--- a/pkg/cluster/loadbalancer/roundrobin/round_robin.go
+++ b/pkg/cluster/loadbalancer/roundrobin/round_robin.go
@@ -32,6 +32,14 @@ func init() {
 
 type RoundRobin struct{}
 
+func (RoundRobin) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (RoundRobin) UseZeroCopySnapshot() bool {
+	return true
+}
+
 func (r RoundRobin) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
 	return r.HandlerWithSnapshot(loadbalancer.PickContext{
 		Config:           c,

--- a/pkg/cluster/loadbalancer/roundrobin/round_robin.go
+++ b/pkg/cluster/loadbalancer/roundrobin/round_robin.go
@@ -32,12 +32,19 @@ func init() {
 
 type RoundRobin struct{}
 
-func (RoundRobin) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
-	endpoints := c.GetEndpoint(true)
+func (r RoundRobin) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
+	return r.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: c.GetEndpoint(true),
+	}, policy)
+}
+
+func (RoundRobin) HandlerWithSnapshot(c loadbalancer.PickContext, _ model.LbPolicy) *model.Endpoint {
+	endpoints := c.HealthyEndpoints
 	if len(endpoints) == 0 {
 		return nil
 	}
 	// AddUint32 returns the incremented value, so subtract 1 for a zero-based index.
-	index := atomic.AddUint32(&c.PrePickEndpointIndex, 1) - 1
+	index := atomic.AddUint32(&c.Config.PrePickEndpointIndex, 1) - 1
 	return endpoints[int(index%uint32(len(endpoints)))]
 }

--- a/pkg/cluster/loadbalancer/roundrobin/round_robin_test.go
+++ b/pkg/cluster/loadbalancer/roundrobin/round_robin_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
@@ -40,7 +41,7 @@ func TestRoundRobin_AllEndpointsUnhealthy_ReturnsNilWithoutPanic(t *testing.T) {
 
 	var got *model.Endpoint
 	assert.NotPanics(t, func() {
-		got = RoundRobin{}.Handler(cluster, nil)
+		got = RoundRobin{}.HandlerWithSnapshot(testPickContext(cluster), nil)
 	})
 	assert.Nil(t, got)
 }
@@ -56,10 +57,10 @@ func TestRoundRobin_RepeatedPicksFollowHealthyOrder(t *testing.T) {
 
 	rr := RoundRobin{}
 	got := []string{
-		rr.Handler(cluster, nil).ID,
-		rr.Handler(cluster, nil).ID,
-		rr.Handler(cluster, nil).ID,
-		rr.Handler(cluster, nil).ID,
+		rr.HandlerWithSnapshot(testPickContext(cluster), nil).ID,
+		rr.HandlerWithSnapshot(testPickContext(cluster), nil).ID,
+		rr.HandlerWithSnapshot(testPickContext(cluster), nil).ID,
+		rr.HandlerWithSnapshot(testPickContext(cluster), nil).ID,
 	}
 
 	assert.Equal(t, []string{"ep-1", "ep-2", "ep-3", "ep-1"}, got)
@@ -77,13 +78,20 @@ func TestRoundRobin_MixedHealthyEndpointsHonorNonZeroCursor(t *testing.T) {
 	}
 
 	rr := RoundRobin{}
-	first := rr.Handler(cluster, nil)
-	second := rr.Handler(cluster, nil)
+	first := rr.HandlerWithSnapshot(testPickContext(cluster), nil)
+	second := rr.HandlerWithSnapshot(testPickContext(cluster), nil)
 
 	if assert.NotNil(t, first) {
 		assert.Equal(t, "ep-4", first.ID)
 	}
 	if assert.NotNil(t, second) {
 		assert.Equal(t, "ep-2", second.ID)
+	}
+}
+
+func testPickContext(cluster *model.ClusterConfig) loadbalancer.PickContext {
+	return loadbalancer.PickContext{
+		Config:           cluster,
+		HealthyEndpoints: cluster.GetEndpoint(true),
 	}
 }

--- a/pkg/cluster/loadbalancer/weightrandom/weight_random.go
+++ b/pkg/cluster/loadbalancer/weightrandom/weight_random.go
@@ -40,8 +40,15 @@ type weightedEndpoint struct {
 // It assigns weights to endpoints and uses these weights to influence the probability of selection.
 type WeightRandom struct{}
 
-func (WeightRandom) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
-	endpoints := c.GetEndpoint(true)
+func (w WeightRandom) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
+	return w.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: c.GetEndpoint(true),
+	}, policy)
+}
+
+func (WeightRandom) HandlerWithSnapshot(c loadbalancer.PickContext, _ model.LbPolicy) *model.Endpoint {
+	endpoints := c.HealthyEndpoints
 
 	if len(endpoints) == 0 {
 		return nil

--- a/pkg/cluster/loadbalancer/weightrandom/weight_random.go
+++ b/pkg/cluster/loadbalancer/weightrandom/weight_random.go
@@ -40,6 +40,14 @@ type weightedEndpoint struct {
 // It assigns weights to endpoints and uses these weights to influence the probability of selection.
 type WeightRandom struct{}
 
+func (WeightRandom) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (WeightRandom) UseZeroCopySnapshot() bool {
+	return true
+}
+
 func (w WeightRandom) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
 	return w.HandlerWithSnapshot(loadbalancer.PickContext{
 		Config:           c,

--- a/pkg/cluster/loadbalancer/weightrandom/weight_random_test.go
+++ b/pkg/cluster/loadbalancer/weightrandom/weight_random_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
@@ -119,7 +120,7 @@ func TestWeightRandom_Handler(t *testing.T) {
 
 			var (
 				wr  = WeightRandom{}
-				got = wr.Handler(tt.clusterConfig, nil)
+				got = wr.HandlerWithSnapshot(testPickContext(tt.clusterConfig), nil)
 			)
 
 			if tt.want == nil {
@@ -200,7 +201,7 @@ func TestWeightRandom_Handler_Probabilistic(t *testing.T) {
 			)
 
 			for i := 0; i < tt.iterations; i++ {
-				endpoint := wr.Handler(clusterConfig, nil)
+				endpoint := wr.HandlerWithSnapshot(testPickContext(clusterConfig), nil)
 				if endpoint != nil {
 					counts[endpoint.ID]++
 				}
@@ -217,6 +218,13 @@ func TestWeightRandom_Handler_Probabilistic(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func testPickContext(cluster *model.ClusterConfig) loadbalancer.PickContext {
+	return loadbalancer.PickContext{
+		Config:           cluster,
+		HealthyEndpoints: cluster.GetEndpoint(true),
 	}
 }
 

--- a/pkg/cluster/loadbalancer/weightrandom/weight_random_test.go
+++ b/pkg/cluster/loadbalancer/weightrandom/weight_random_test.go
@@ -18,6 +18,7 @@
 package weightrandom
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"testing"
@@ -35,89 +36,51 @@ func TestWeightRandom_Handler(t *testing.T) {
 		want          *model.Endpoint
 	}{
 		{
-			name: "no healthy endpoints",
-			clusterConfig: &model.ClusterConfig{
-				Endpoints: []*model.Endpoint{},
-			},
-			want: nil,
+			name:          "no healthy endpoints",
+			clusterConfig: &model.ClusterConfig{Endpoints: []*model.Endpoint{}},
+			want:          nil,
 		},
 		{
-			name: "single healthy endpoint with default weight",
-			clusterConfig: &model.ClusterConfig{
-				Endpoints: []*model.Endpoint{
-					{ID: "ep1", Name: "ep1"},
-				},
-			},
-			want: &model.Endpoint{ID: "ep1", Name: "ep1"},
+			name:          "single healthy endpoint with default weight",
+			clusterConfig: clusterWithWeightedEndpoints(""),
+			want:          &model.Endpoint{ID: "ep1", Name: "ep1"},
+		},
+		// `want: nil` below means "any healthy endpoint is acceptable"; the helper
+		// in the assertion accepts non-nil picks for non-empty clusters.
+		{
+			name:          "multiple healthy endpoints with default weight, should return one randomly",
+			clusterConfig: clusterWithWeightedEndpoints("", "", ""),
+			want:          nil,
 		},
 		{
-			name: "multiple healthy endpoints with default weight, should return one randomly",
-			clusterConfig: &model.ClusterConfig{
-				Endpoints: []*model.Endpoint{
-					{ID: "ep1", Name: "ep1"},
-					{ID: "ep2", Name: "ep2"},
-					{ID: "ep3", Name: "ep3"},
-				},
-			},
-			want: nil, // We can't predict which one will be picked, so we check for non-nil
+			name:          "multiple healthy endpoints with different weights",
+			clusterConfig: clusterWithWeightedEndpoints("3", "1", "2"),
+			want:          nil,
 		},
 		{
-			name: "multiple healthy endpoints with different weights",
-			clusterConfig: &model.ClusterConfig{
-				Endpoints: []*model.Endpoint{
-					{ID: "ep1", Name: "ep1", Metadata: map[string]string{"weight": "3"}},
-					{ID: "ep2", Name: "ep2", Metadata: map[string]string{"weight": "1"}},
-					{ID: "ep3", Name: "ep3", Metadata: map[string]string{"weight": "2"}},
-				},
-			},
-			want: nil, // Again, random but weighted
+			name:          "endpoint with invalid weight string, should use default weight",
+			clusterConfig: clusterWithWeightedEndpoints("abc", ""),
+			want:          nil,
 		},
 		{
-			name: "endpoint with invalid weight string, should use default weight",
-			clusterConfig: &model.ClusterConfig{
-				Endpoints: []*model.Endpoint{
-					{ID: "ep1", Name: "ep1", Metadata: map[string]string{"weight": "abc"}},
-					{ID: "ep2", Name: "ep2"},
-				},
-			},
-			want: nil,
+			name:          "endpoint with zero weight, should use default weight",
+			clusterConfig: clusterWithWeightedEndpoints("0", ""),
+			want:          nil,
 		},
 		{
-			name: "endpoint with zero weight, should use default weight",
-			clusterConfig: &model.ClusterConfig{
-				Endpoints: []*model.Endpoint{
-					{ID: "ep1", Name: "ep1", Metadata: map[string]string{"weight": "0"}},
-					{ID: "ep2", Name: "ep2"},
-				},
-			},
-			want: nil,
+			name:          "endpoint with negative weight, should use default weight",
+			clusterConfig: clusterWithWeightedEndpoints("-1", ""),
+			want:          nil,
 		},
 		{
-			name: "endpoint with negative weight, should use default weight",
-			clusterConfig: &model.ClusterConfig{
-				Endpoints: []*model.Endpoint{
-					{ID: "ep1", Name: "ep1", Metadata: map[string]string{"weight": "-1"}},
-					{ID: "ep2", Name: "ep2"},
-				},
-			},
-			want: nil,
-		},
-		{
-			name: "all endpoints have invalid weights, should return random",
-			clusterConfig: &model.ClusterConfig{
-				Endpoints: []*model.Endpoint{
-					{ID: "ep1", Name: "ep1", Metadata: map[string]string{"weight": "abc"}},
-					{ID: "ep2", Name: "ep2", Metadata: map[string]string{"weight": "def"}},
-				},
-			},
-			want: nil,
+			name:          "all endpoints have invalid weights, should return random",
+			clusterConfig: clusterWithWeightedEndpoints("abc", "def"),
+			want:          nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mock GetEndpoint method
-
 			var (
 				wr  = WeightRandom{}
 				got = wr.HandlerWithSnapshot(testPickContext(tt.clusterConfig), nil)
@@ -136,6 +99,23 @@ func TestWeightRandom_Handler(t *testing.T) {
 			}
 		})
 	}
+}
+
+// clusterWithWeightedEndpoints builds a ClusterConfig with sequentially-named
+// endpoints (`ep1`, `ep2`, ...). Each entry in weights becomes one endpoint;
+// an empty string leaves Metadata unset, any other value is stored as the
+// raw `weight` metadata.
+func clusterWithWeightedEndpoints(weights ...string) *model.ClusterConfig {
+	endpoints := make([]*model.Endpoint, 0, len(weights))
+	for i, w := range weights {
+		id := fmt.Sprintf("ep%d", i+1)
+		ep := &model.Endpoint{ID: id, Name: id}
+		if w != "" {
+			ep.Metadata = map[string]string{"weight": w}
+		}
+		endpoints = append(endpoints, ep)
+	}
+	return &model.ClusterConfig{Endpoints: endpoints}
 }
 
 // Helper function to create a ClusterConfig with specific endpoints and weights for probabilistic testing

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -25,11 +25,11 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
 import (
-	"github.com/apache/dubbo-go-pixiu/pkg/cluster"
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/retry"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
@@ -41,10 +41,8 @@ import (
 )
 
 const (
-	Kind                = constant.LLMProxyFilter
-	APIKeyPrefix        = "Bearer"
-	LLMUnhealthyKey     = "LLMUnhealthy"
-	HealthyCheckTimeKey = "HealthyCheckTime"
+	Kind         = constant.LLMProxyFilter
+	APIKeyPrefix = "Bearer"
 	// Context key to pass attempt data from proxy to downstream filters
 	LLMUpstreamAttemptsKey    = "llm_upstream_attempts"
 	llmPreferredEndpointIDKey = "llm_preferred_endpoint_id"
@@ -70,8 +68,9 @@ type (
 
 	// FilterFactory creates filter instances.
 	FilterFactory struct {
-		cfg    *Config
-		client http.Client
+		cfg       *Config
+		client    http.Client
+		cooldowns *cooldownStore
 	}
 
 	// Filter is the processing entity for each request.
@@ -80,6 +79,7 @@ type (
 		scheme         string
 		strategy       *Strategy
 		clusterManager *server.ClusterManager
+		cooldowns      *cooldownStore
 	}
 
 	// Config describes the top-level configuration for the filter.
@@ -97,6 +97,23 @@ type (
 		filter         *Filter
 		clusterName    string
 		clusterManager *server.ClusterManager
+		cooldowns      *cooldownStore
+	}
+
+	cooldownKey struct {
+		clusterName     string
+		endpointID      string
+		endpointAddress string
+	}
+
+	cooldownStore struct {
+		mu                    sync.Mutex
+		lastFailureByEndpoint map[cooldownKey]cooldownEntry
+	}
+
+	cooldownEntry struct {
+		lastFailure time.Time
+		ttl         time.Duration
 	}
 )
 
@@ -122,7 +139,7 @@ func (p *Plugin) Kind() string {
 
 // CreateFilterFactory creates a new factory instance for this filter.
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
-	return &FilterFactory{cfg: &Config{}}, nil
+	return &FilterFactory{cfg: &Config{}, cooldowns: newCooldownStore()}, nil
 }
 
 // Config returns the configuration struct for the factory.
@@ -157,6 +174,7 @@ func (factory *FilterFactory) PrepareFilterChain(_ *contexthttp.HttpContext, cha
 		scheme:         factory.cfg.Scheme,
 		strategy:       &Strategy{},
 		clusterManager: server.GetClusterManager(),
+		cooldowns:      factory.cooldownStore(),
 	}
 	chain.AppendDecodeFilters(f)
 	return nil
@@ -186,6 +204,7 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 		filter:         f,
 		clusterName:    rEntry.Cluster,
 		clusterManager: f.clusterManager,
+		cooldowns:      f.cooldowns,
 	}
 
 	// Delegate the complex execution logic to the strategy
@@ -283,7 +302,7 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 	// 1. Pick initial endpoint from the cluster based on load balancing.
 	endpoint := executor.clusterManager.PickEndpoint(executor.clusterName, executor.hc)
 	if preferred := getPreferredEndpointID(executor.hc); preferred != "" {
-		if target := executor.clusterManager.GetEndpointByID(executor.clusterName, preferred); target != nil {
+		if target := executor.clusterManager.GetHealthyEndpointByID(executor.clusterName, preferred); target != nil {
 			endpoint = target
 		}
 	}
@@ -377,55 +396,129 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 	return resp, errors.Join(problems...)
 }
 
-func (executor *RequestExecutor) endpointRuntimeState(endpoint *model.Endpoint) *cluster.EndpointRuntimeState {
-	if executor == nil || executor.clusterManager == nil || endpoint == nil {
-		return nil
-	}
-	// LLM cooldown is runtime state, not endpoint config metadata. The address
-	// guard keeps late fallback attempts from updating a replaced endpoint.
-	return executor.clusterManager.GetEndpointRuntimeState(
-		executor.clusterName,
-		endpoint.ID,
-		endpoint.Address.GetAddress(),
-	)
-}
-
 func (executor *RequestExecutor) endpointInCooldown(endpoint *model.Endpoint) bool {
-	state := executor.endpointRuntimeState(endpoint)
-	if state == nil {
+	store := executor.cooldownStore()
+	if store == nil || endpoint == nil {
 		return false
 	}
 
-	values := state.LoadMany(LLMUnhealthyKey, HealthyCheckTimeKey)
-	unhealthy, ok := values[LLMUnhealthyKey]
-	if !ok || unhealthy != "true" {
-		return false
-	}
-
-	t, ok := values[HealthyCheckTimeKey]
+	lastFailure, ok := store.lastFailure(executor.clusterName, endpoint)
 	if !ok {
 		return false
 	}
-	lastFailure, err := time.Parse(time.RFC3339, t)
-	if err == nil && time.Since(lastFailure) < time.Millisecond*time.Duration(endpoint.LLMMeta.HealthCheckInterval) {
+
+	if time.Since(lastFailure) < endpointCooldownInterval(endpoint) {
 		return true
 	}
 
-	if state.DeleteIfMatches(values, LLMUnhealthyKey, HealthyCheckTimeKey) {
+	if store.deleteLastFailureIfMatches(executor.clusterName, endpoint, lastFailure) {
 		logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] cooldown period passed. Retrying this endpoint.", endpoint.ID, endpoint.Address.GetAddress())
 	}
 	return false
 }
 
 func (executor *RequestExecutor) markEndpointCooldown(endpoint *model.Endpoint) {
-	state := executor.endpointRuntimeState(endpoint)
-	if state == nil {
+	store := executor.cooldownStore()
+	if store == nil || endpoint == nil {
 		return
 	}
-	state.StoreMany(map[string]string{
-		LLMUnhealthyKey:     "true",
-		HealthyCheckTimeKey: time.Now().Format(time.RFC3339),
-	})
+	store.markFailure(executor.clusterName, endpoint, time.Now())
+}
+
+func (executor *RequestExecutor) cooldownStore() *cooldownStore {
+	if executor == nil {
+		return nil
+	}
+	if executor.cooldowns != nil {
+		return executor.cooldowns
+	}
+	if executor.filter != nil {
+		return executor.filter.cooldowns
+	}
+	return nil
+}
+
+func (factory *FilterFactory) cooldownStore() *cooldownStore {
+	if factory.cooldowns == nil {
+		factory.cooldowns = newCooldownStore()
+	}
+	return factory.cooldowns
+}
+
+func newCooldownStore() *cooldownStore {
+	return &cooldownStore{
+		lastFailureByEndpoint: map[cooldownKey]cooldownEntry{},
+	}
+}
+
+func (s *cooldownStore) lastFailure(clusterName string, endpoint *model.Endpoint) (time.Time, bool) {
+	if s == nil || endpoint == nil {
+		return time.Time{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := newCooldownKey(clusterName, endpoint)
+	s.sweepExpiredExceptLocked(time.Now(), key)
+	entry, ok := s.lastFailureByEndpoint[key]
+	return entry.lastFailure, ok
+}
+
+func (s *cooldownStore) markFailure(clusterName string, endpoint *model.Endpoint, lastFailure time.Time) {
+	if s == nil || endpoint == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := newCooldownKey(clusterName, endpoint)
+	s.sweepExpiredExceptLocked(time.Now(), key)
+	s.lastFailureByEndpoint[key] = cooldownEntry{
+		lastFailure: lastFailure,
+		ttl:         endpointCooldownInterval(endpoint),
+	}
+}
+
+func (s *cooldownStore) deleteLastFailureIfMatches(clusterName string, endpoint *model.Endpoint, expected time.Time) bool {
+	if s == nil || endpoint == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := newCooldownKey(clusterName, endpoint)
+	current, ok := s.lastFailureByEndpoint[key]
+	if !ok || current.lastFailure != expected {
+		return false
+	}
+	delete(s.lastFailureByEndpoint, key)
+	return true
+}
+
+func (s *cooldownStore) sweepExpiredExceptLocked(now time.Time, current cooldownKey) {
+	for key, entry := range s.lastFailureByEndpoint {
+		if key == current {
+			continue
+		}
+		if now.Sub(entry.lastFailure) >= entry.ttl {
+			delete(s.lastFailureByEndpoint, key)
+		}
+	}
+}
+
+func newCooldownKey(clusterName string, endpoint *model.Endpoint) cooldownKey {
+	if endpoint == nil {
+		return cooldownKey{clusterName: clusterName}
+	}
+	return cooldownKey{
+		clusterName:     clusterName,
+		endpointID:      endpoint.ID,
+		endpointAddress: endpoint.Address.GetAddress(),
+	}
+}
+
+func endpointCooldownInterval(endpoint *model.Endpoint) time.Duration {
+	if endpoint == nil || endpoint.LLMMeta == nil {
+		return 0
+	}
+	return time.Millisecond * time.Duration(endpoint.LLMMeta.HealthCheckInterval)
 }
 
 // getNextFallbackEndpoint checks if fallback is enabled and returns the next endpoint.

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -19,6 +19,7 @@ package proxy
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -43,6 +44,18 @@ import (
 const (
 	Kind         = constant.LLMProxyFilter
 	APIKeyPrefix = "Bearer"
+	// maxCooldownStoreEntries bounds process-wide cooldown state under registry churn.
+	maxCooldownStoreEntries = 1024
+	cooldownStoreSweepAfter = time.Second
+	cooldownStoreSweepAt    = maxCooldownStoreEntries * 9 / 10
+	// LLMUnhealthyKey is kept for downstream compatibility.
+	//
+	// Deprecated: runtime LLM health is now tracked outside endpoint metadata.
+	LLMUnhealthyKey = "LLMUnhealthy"
+	// HealthyCheckTimeKey is kept for downstream compatibility.
+	//
+	// Deprecated: runtime LLM health is now tracked outside endpoint metadata.
+	HealthyCheckTimeKey = "HealthyCheckTime"
 	// Context key to pass attempt data from proxy to downstream filters
 	LLMUpstreamAttemptsKey    = "llm_upstream_attempts"
 	llmPreferredEndpointIDKey = "llm_preferred_endpoint_id"
@@ -104,11 +117,13 @@ type (
 		clusterName     string
 		endpointID      string
 		endpointAddress string
+		credentialHash  string
 	}
 
 	cooldownStore struct {
 		mu                    sync.Mutex
 		lastFailureByEndpoint map[cooldownKey]cooldownEntry
+		lastSweep             time.Time
 	}
 
 	cooldownEntry struct {
@@ -406,12 +421,12 @@ func (executor *RequestExecutor) endpointInCooldown(endpoint *model.Endpoint) bo
 		return false
 	}
 
-	lastFailure, ok := store.lastFailure(executor.clusterName, endpoint)
+	lastFailure, ttl, ok := store.lastFailureWithCurrentTTL(executor.clusterName, endpoint)
 	if !ok {
 		return false
 	}
 
-	if time.Since(lastFailure) < endpointCooldownInterval(endpoint) {
+	if time.Since(lastFailure) < ttl {
 		return true
 	}
 
@@ -456,15 +471,29 @@ func newCooldownStore() *cooldownStore {
 }
 
 func (s *cooldownStore) lastFailure(clusterName string, endpoint *model.Endpoint) (time.Time, bool) {
+	lastFailure, _, ok := s.lastFailureWithCurrentTTL(clusterName, endpoint)
+	return lastFailure, ok
+}
+
+func (s *cooldownStore) lastFailureWithCurrentTTL(clusterName string, endpoint *model.Endpoint) (time.Time, time.Duration, bool) {
 	if s == nil || endpoint == nil {
-		return time.Time{}, false
+		return time.Time{}, 0, false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	key := newCooldownKey(clusterName, endpoint)
-	s.sweepExpiredExceptLocked(time.Now(), key)
+	now := time.Now()
+	s.sweepExpiredIfNeededLocked(now, key)
 	entry, ok := s.lastFailureByEndpoint[key]
-	return entry.lastFailure, ok
+	if !ok {
+		return time.Time{}, 0, false
+	}
+	currentTTL := endpointCooldownInterval(endpoint)
+	if entry.ttl != currentTTL {
+		entry.ttl = currentTTL
+		s.lastFailureByEndpoint[key] = entry
+	}
+	return entry.lastFailure, entry.ttl, true
 }
 
 func (s *cooldownStore) markFailure(clusterName string, endpoint *model.Endpoint, lastFailure time.Time) {
@@ -474,7 +503,10 @@ func (s *cooldownStore) markFailure(clusterName string, endpoint *model.Endpoint
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	key := newCooldownKey(clusterName, endpoint)
-	s.sweepExpiredExceptLocked(time.Now(), key)
+	s.sweepExpiredIfNeededLocked(time.Now(), key)
+	if _, ok := s.lastFailureByEndpoint[key]; !ok {
+		s.evictOldestIfFullLocked(key)
+	}
 	s.lastFailureByEndpoint[key] = cooldownEntry{
 		lastFailure: lastFailure,
 		ttl:         endpointCooldownInterval(endpoint),
@@ -496,6 +528,16 @@ func (s *cooldownStore) deleteLastFailureIfMatches(clusterName string, endpoint 
 	return true
 }
 
+func (s *cooldownStore) sweepExpiredIfNeededLocked(now time.Time, current cooldownKey) {
+	if len(s.lastFailureByEndpoint) < cooldownStoreSweepAt &&
+		!s.lastSweep.IsZero() &&
+		now.Sub(s.lastSweep) < cooldownStoreSweepAfter {
+		return
+	}
+	s.lastSweep = now
+	s.sweepExpiredExceptLocked(now, current)
+}
+
 func (s *cooldownStore) sweepExpiredExceptLocked(now time.Time, current cooldownKey) {
 	for key, entry := range s.lastFailureByEndpoint {
 		if key == current {
@@ -507,6 +549,31 @@ func (s *cooldownStore) sweepExpiredExceptLocked(now time.Time, current cooldown
 	}
 }
 
+func (s *cooldownStore) evictOldestIfFullLocked(current cooldownKey) {
+	if len(s.lastFailureByEndpoint) < maxCooldownStoreEntries {
+		return
+	}
+
+	var (
+		oldestKey   cooldownKey
+		oldestEntry cooldownEntry
+		found       bool
+	)
+	for key, entry := range s.lastFailureByEndpoint {
+		if key == current {
+			continue
+		}
+		if !found || entry.lastFailure.Before(oldestEntry.lastFailure) {
+			oldestKey = key
+			oldestEntry = entry
+			found = true
+		}
+	}
+	if found {
+		delete(s.lastFailureByEndpoint, oldestKey)
+	}
+}
+
 func newCooldownKey(clusterName string, endpoint *model.Endpoint) cooldownKey {
 	if endpoint == nil {
 		return cooldownKey{clusterName: clusterName}
@@ -515,7 +582,16 @@ func newCooldownKey(clusterName string, endpoint *model.Endpoint) cooldownKey {
 		clusterName:     clusterName,
 		endpointID:      endpoint.ID,
 		endpointAddress: endpoint.Address.GetAddress(),
+		credentialHash:  endpointCredentialHash(endpoint),
 	}
+}
+
+func endpointCredentialHash(endpoint *model.Endpoint) string {
+	if endpoint == nil || endpoint.LLMMeta == nil || endpoint.LLMMeta.APIKey == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(endpoint.LLMMeta.APIKey))
+	return fmt.Sprintf("%x", sum)
 }
 
 func endpointCooldownInterval(endpoint *model.Endpoint) time.Duration {

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -29,6 +29,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster"
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/retry"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
@@ -289,30 +290,17 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 
 	// 2. The main fallback loop. It continues as long as we have a valid endpoint to try.
 	for endpoint != nil {
-		if endpoint.Metadata == nil {
-			endpoint.Metadata = make(map[string]string)
-		}
 		if executor.hc.Params == nil {
 			executor.hc.Params = make(map[string]any)
 		}
 
 		logger.Debugf("[dubbo-go-pixiu] client attempting endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())
 
-		// 3. Check the health of current endpoint,
-		if unhealthy, ok := endpoint.Metadata[LLMUnhealthyKey]; ok && unhealthy == "true" {
-			// check the health cooldown time
-			if t, ok := endpoint.Metadata[HealthyCheckTimeKey]; ok {
-				lt, err := time.Parse(time.RFC3339, t)
-				if err == nil && time.Since(lt) < time.Millisecond*time.Duration(endpoint.LLMMeta.HealthCheckInterval) {
-					logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] is still in unhealthy cooldown period. Skipping to next endpoint.", endpoint.ID, endpoint.Address.GetAddress())
-					endpoint = getNextFallbackEndpoint(endpoint, executor)
-					continue
-				}
-				// The Cooldown period has passed, ready for a new attempt
-				delete(endpoint.Metadata, LLMUnhealthyKey)
-				delete(endpoint.Metadata, HealthyCheckTimeKey)
-				logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] cooldown period passed. Retrying this endpoint.", endpoint.ID, endpoint.Address.GetAddress())
-			}
+		// 3. Check the runtime health cooldown of current endpoint.
+		if executor.endpointInCooldown(endpoint) {
+			logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] is still in unhealthy cooldown period. Skipping to next endpoint.", endpoint.ID, endpoint.Address.GetAddress())
+			endpoint = getNextFallbackEndpoint(endpoint, executor)
+			continue
 		}
 
 		// 4. Dynamically load the retry policy for the current endpoint
@@ -373,8 +361,7 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 
 		// 6. If we are here, all retries for the current endpoint are exhausted.
 		// Get the next endpoint for fallback. The loop will terminate if it's nil.
-		endpoint.Metadata[LLMUnhealthyKey] = "true"
-		endpoint.Metadata[HealthyCheckTimeKey] = time.Now().Format(time.RFC3339)
+		executor.markEndpointCooldown(endpoint)
 		endpoint = getNextFallbackEndpoint(endpoint, executor)
 	}
 
@@ -388,6 +375,57 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 		problems = append(problems, errors.New("all retries and fallbacks failed without a definitive error or response"))
 	}
 	return resp, errors.Join(problems...)
+}
+
+func (executor *RequestExecutor) endpointRuntimeState(endpoint *model.Endpoint) *cluster.EndpointRuntimeState {
+	if executor == nil || executor.clusterManager == nil || endpoint == nil {
+		return nil
+	}
+	// LLM cooldown is runtime state, not endpoint config metadata. The address
+	// guard keeps late fallback attempts from updating a replaced endpoint.
+	return executor.clusterManager.GetEndpointRuntimeState(
+		executor.clusterName,
+		endpoint.ID,
+		endpoint.Address.GetAddress(),
+	)
+}
+
+func (executor *RequestExecutor) endpointInCooldown(endpoint *model.Endpoint) bool {
+	state := executor.endpointRuntimeState(endpoint)
+	if state == nil {
+		return false
+	}
+
+	values := state.LoadMany(LLMUnhealthyKey, HealthyCheckTimeKey)
+	unhealthy, ok := values[LLMUnhealthyKey]
+	if !ok || unhealthy != "true" {
+		return false
+	}
+
+	t, ok := values[HealthyCheckTimeKey]
+	if !ok {
+		return false
+	}
+	lastFailure, err := time.Parse(time.RFC3339, t)
+	if err == nil && time.Since(lastFailure) < time.Millisecond*time.Duration(endpoint.LLMMeta.HealthCheckInterval) {
+		return true
+	}
+
+	if state.DeleteIfMatches(values, LLMUnhealthyKey, HealthyCheckTimeKey) {
+		logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] cooldown period passed. Retrying this endpoint.", endpoint.ID, endpoint.Address.GetAddress())
+	}
+	return false
+}
+
+func (executor *RequestExecutor) markEndpointCooldown(endpoint *model.Endpoint) {
+	state := executor.endpointRuntimeState(endpoint)
+	if state == nil {
+		return
+	}
+	state.StoreMany(map[string]string{
+		LLMUnhealthyKey:     "true",
+		HealthyCheckTimeKey: time.Now().Format(time.RFC3339),
+	})
 }
 
 // getNextFallbackEndpoint checks if fallback is enabled and returns the next endpoint.

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -117,6 +117,10 @@ type (
 	}
 )
 
+// sharedCooldownStore keeps endpoint cooldowns process-wide so filter reloads
+// and multiple LLM proxy factories do not reset runtime failure state.
+var sharedCooldownStore = newCooldownStore()
+
 func getPreferredEndpointID(hc *contexthttp.HttpContext) string {
 	if hc == nil || hc.Params == nil {
 		return ""
@@ -139,7 +143,7 @@ func (p *Plugin) Kind() string {
 
 // CreateFilterFactory creates a new factory instance for this filter.
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
-	return &FilterFactory{cfg: &Config{}, cooldowns: newCooldownStore()}, nil
+	return &FilterFactory{cfg: &Config{}}, nil
 }
 
 // Config returns the configuration struct for the factory.
@@ -432,15 +436,15 @@ func (executor *RequestExecutor) cooldownStore() *cooldownStore {
 	if executor.cooldowns != nil {
 		return executor.cooldowns
 	}
-	if executor.filter != nil {
+	if executor.filter != nil && executor.filter.cooldowns != nil {
 		return executor.filter.cooldowns
 	}
-	return nil
+	return sharedCooldownStore
 }
 
 func (factory *FilterFactory) cooldownStore() *cooldownStore {
-	if factory.cooldowns == nil {
-		factory.cooldowns = newCooldownStore()
+	if factory == nil || factory.cooldowns == nil {
+		return sharedCooldownStore
 	}
 	return factory.cooldowns
 }

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/retry/noretry"
+	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+	"github.com/apache/dubbo-go-pixiu/pkg/server"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(t *testing.T) {
+	clusterName := "llm-runtime-cooldown"
+	endpoints := []*model.Endpoint{
+		testLLMEndpoint("ep-1", 18080),
+		testLLMEndpoint("ep-2", 18081),
+	}
+	clusterConfig := &model.ClusterConfig{
+		Name:      clusterName,
+		LbStr:     model.LoadBalancerRoundRobin,
+		Endpoints: endpoints,
+	}
+	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: []*model.ClusterConfig{clusterConfig},
+		},
+	})
+	filter := &Filter{
+		client: http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("upstream unavailable")
+			}),
+		},
+		scheme: "http",
+	}
+	strategy := &Strategy{}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 50; j++ {
+				req, err := http.NewRequest(http.MethodPost, "http://example.com/v1/chat/completions", http.NoBody)
+				if err != nil {
+					t.Errorf("new request: %v", err)
+					return
+				}
+				hc := &contexthttp.HttpContext{
+					Request: req,
+					Params:  map[string]any{},
+				}
+				_, _ = strategy.Execute(&RequestExecutor{
+					hc:             hc,
+					filter:         filter,
+					clusterName:    clusterName,
+					clusterManager: clusterManager,
+				})
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	for _, endpoint := range endpoints {
+		assert.Equal(t, map[string]string{"static": "value"}, endpoint.Metadata)
+		state := clusterManager.GetEndpointRuntimeState(clusterName, endpoint.ID, endpoint.Address.GetAddress())
+		if assert.NotNil(t, state) {
+			unhealthy, ok := state.Load(LLMUnhealthyKey)
+			assert.True(t, ok)
+			assert.Equal(t, "true", unhealthy)
+			_, ok = state.Load(HealthyCheckTimeKey)
+			assert.True(t, ok)
+		}
+	}
+}
+
+func TestRequestExecutorEndpointInCooldownClearsExpiredCooldownAtomically(t *testing.T) {
+	clusterName := "llm-expired-cooldown"
+	endpoint := testLLMEndpoint("ep-1", 18082)
+	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: []*model.ClusterConfig{{
+				Name:      clusterName,
+				LbStr:     model.LoadBalancerRoundRobin,
+				Endpoints: []*model.Endpoint{endpoint},
+			}},
+		},
+	})
+	executor := &RequestExecutor{
+		clusterName:    clusterName,
+		clusterManager: clusterManager,
+	}
+	state := clusterManager.GetEndpointRuntimeState(clusterName, endpoint.ID, endpoint.Address.GetAddress())
+	if !assert.NotNil(t, state) {
+		return
+	}
+	state.StoreMany(map[string]string{
+		LLMUnhealthyKey:     "true",
+		HealthyCheckTimeKey: time.Now().Add(-time.Hour).Format(time.RFC3339),
+	})
+
+	assert.False(t, executor.endpointInCooldown(endpoint))
+
+	values := state.LoadMany(LLMUnhealthyKey, HealthyCheckTimeKey)
+	_, unhealthyExists := values[LLMUnhealthyKey]
+	_, timeExists := values[HealthyCheckTimeKey]
+	assert.False(t, unhealthyExists)
+	assert.False(t, timeExists)
+}
+
+func TestRequestExecutorMarkEndpointCooldownStoresCooldownPairAtomically(t *testing.T) {
+	clusterName := "llm-mark-cooldown"
+	endpoint := testLLMEndpoint("ep-1", 18083)
+	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: []*model.ClusterConfig{{
+				Name:      clusterName,
+				LbStr:     model.LoadBalancerRoundRobin,
+				Endpoints: []*model.Endpoint{endpoint},
+			}},
+		},
+	})
+	executor := &RequestExecutor{
+		clusterName:    clusterName,
+		clusterManager: clusterManager,
+	}
+
+	executor.markEndpointCooldown(endpoint)
+
+	state := clusterManager.GetEndpointRuntimeState(clusterName, endpoint.ID, endpoint.Address.GetAddress())
+	if !assert.NotNil(t, state) {
+		return
+	}
+	values := state.LoadMany(LLMUnhealthyKey, HealthyCheckTimeKey)
+	assert.Equal(t, "true", values[LLMUnhealthyKey])
+	assert.NotEmpty(t, values[HealthyCheckTimeKey])
+}
+
+func testLLMEndpoint(id string, port int) *model.Endpoint {
+	return &model.Endpoint{
+		ID:       id,
+		Name:     "endpoint-" + id,
+		Metadata: map[string]string{"static": "value"},
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    port,
+		},
+		LLMMeta: &model.LLMMeta{
+			RetryPolicy: model.RetryPolicy{
+				Name: model.RetryerNoRetry,
+			},
+			Fallback:            true,
+			HealthCheckInterval: 60000,
+		},
+	}
+}

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -43,13 +43,37 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
-func TestFilterFactoryCooldownStoreIsShared(t *testing.T) {
-	factory := &FilterFactory{cfg: &Config{}}
+func TestFilterFactoriesShareRuntimeCooldownStore(t *testing.T) {
+	plugin := &Plugin{}
+	firstFactory, err := plugin.CreateFilterFactory()
+	if !assert.NoError(t, err) {
+		return
+	}
+	secondFactory, err := plugin.CreateFilterFactory()
+	if !assert.NoError(t, err) {
+		return
+	}
 
-	store := factory.cooldownStore()
+	firstStore := firstFactory.(*FilterFactory).cooldownStore()
+	secondStore := secondFactory.(*FilterFactory).cooldownStore()
 
-	assert.NotNil(t, store)
-	assert.Same(t, store, factory.cooldownStore())
+	assert.NotNil(t, firstStore)
+	assert.Same(t, firstStore, secondStore)
+
+	clusterName := "llm-shared-runtime-cooldown"
+	endpoint := testLLMEndpoint("ep-1", 18089)
+	firstExecutor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   firstStore,
+	}
+	secondExecutor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   secondStore,
+	}
+
+	firstExecutor.markEndpointCooldown(endpoint)
+
+	assert.True(t, secondExecutor.endpointInCooldown(endpoint))
 }
 
 func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(t *testing.T) {

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 import (
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin"
-	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/retry/noretry"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin" // Register RoundRobin for LLM proxy cluster tests.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/retry/noretry"           // Register NoRetry for LLM proxy retry tests.
 	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 	"github.com/apache/dubbo-go-pixiu/pkg/server"

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -43,6 +43,15 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
+func TestFilterFactoryCooldownStoreIsShared(t *testing.T) {
+	factory := &FilterFactory{cfg: &Config{}}
+
+	store := factory.cooldownStore()
+
+	assert.NotNil(t, store)
+	assert.Same(t, store, factory.cooldownStore())
+}
+
 func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(t *testing.T) {
 	clusterName := "llm-runtime-cooldown"
 	endpoints := []*model.Endpoint{
@@ -65,7 +74,8 @@ func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(
 				return nil, errors.New("upstream unavailable")
 			}),
 		},
-		scheme: "http",
+		scheme:    "http",
+		cooldowns: newCooldownStore(),
 	}
 	strategy := &Strategy{}
 
@@ -91,6 +101,7 @@ func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(
 					filter:         filter,
 					clusterName:    clusterName,
 					clusterManager: clusterManager,
+					cooldowns:      filter.cooldowns,
 				})
 			}
 		}()
@@ -101,77 +112,158 @@ func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(
 
 	for _, endpoint := range endpoints {
 		assert.Equal(t, map[string]string{"static": "value"}, endpoint.Metadata)
-		state := clusterManager.GetEndpointRuntimeState(clusterName, endpoint.ID, endpoint.Address.GetAddress())
-		if assert.NotNil(t, state) {
-			unhealthy, ok := state.Load(LLMUnhealthyKey)
-			assert.True(t, ok)
-			assert.Equal(t, "true", unhealthy)
-			_, ok = state.Load(HealthyCheckTimeKey)
-			assert.True(t, ok)
-		}
+		lastFailure, ok := filter.cooldowns.lastFailure(clusterName, endpoint)
+		assert.True(t, ok)
+		assert.False(t, lastFailure.IsZero())
 	}
 }
 
-func TestRequestExecutorEndpointInCooldownClearsExpiredCooldownAtomically(t *testing.T) {
+func TestRequestExecutorEndpointInCooldownClearsExpiredCooldownFromProxyStore(t *testing.T) {
 	clusterName := "llm-expired-cooldown"
 	endpoint := testLLMEndpoint("ep-1", 18082)
-	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
-		StaticResources: model.StaticResources{
-			Clusters: []*model.ClusterConfig{{
-				Name:      clusterName,
-				LbStr:     model.LoadBalancerRoundRobin,
-				Endpoints: []*model.Endpoint{endpoint},
-			}},
-		},
-	})
+	store := newCooldownStore()
 	executor := &RequestExecutor{
-		clusterName:    clusterName,
-		clusterManager: clusterManager,
+		clusterName: clusterName,
+		cooldowns:   store,
 	}
-	state := clusterManager.GetEndpointRuntimeState(clusterName, endpoint.ID, endpoint.Address.GetAddress())
-	if !assert.NotNil(t, state) {
-		return
-	}
-	state.StoreMany(map[string]string{
-		LLMUnhealthyKey:     "true",
-		HealthyCheckTimeKey: time.Now().Add(-time.Hour).Format(time.RFC3339),
-	})
+	store.markFailure(clusterName, endpoint, time.Now().Add(-time.Hour))
 
 	assert.False(t, executor.endpointInCooldown(endpoint))
 
-	values := state.LoadMany(LLMUnhealthyKey, HealthyCheckTimeKey)
-	_, unhealthyExists := values[LLMUnhealthyKey]
-	_, timeExists := values[HealthyCheckTimeKey]
-	assert.False(t, unhealthyExists)
-	assert.False(t, timeExists)
+	_, ok := store.lastFailure(clusterName, endpoint)
+	assert.False(t, ok)
 }
 
-func TestRequestExecutorMarkEndpointCooldownStoresCooldownPairAtomically(t *testing.T) {
+func TestRequestExecutorMarkEndpointCooldownStoresCooldownInProxyStore(t *testing.T) {
 	clusterName := "llm-mark-cooldown"
 	endpoint := testLLMEndpoint("ep-1", 18083)
-	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
-		StaticResources: model.StaticResources{
-			Clusters: []*model.ClusterConfig{{
-				Name:      clusterName,
-				LbStr:     model.LoadBalancerRoundRobin,
-				Endpoints: []*model.Endpoint{endpoint},
-			}},
-		},
-	})
+	store := newCooldownStore()
 	executor := &RequestExecutor{
-		clusterName:    clusterName,
-		clusterManager: clusterManager,
+		clusterName: clusterName,
+		cooldowns:   store,
 	}
 
 	executor.markEndpointCooldown(endpoint)
 
-	state := clusterManager.GetEndpointRuntimeState(clusterName, endpoint.ID, endpoint.Address.GetAddress())
-	if !assert.NotNil(t, state) {
+	lastFailure, ok := store.lastFailure(clusterName, endpoint)
+	assert.True(t, ok)
+	assert.False(t, lastFailure.IsZero())
+}
+
+func TestRequestExecutorCooldownIsIsolatedByEndpointAddress(t *testing.T) {
+	clusterName := "llm-address-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18084)
+	movedEndpoint := testLLMEndpoint("ep-1", 18085)
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+
+	executor.markEndpointCooldown(oldEndpoint)
+
+	assert.True(t, executor.endpointInCooldown(oldEndpoint))
+	assert.False(t, executor.endpointInCooldown(movedEndpoint))
+	_, ok := store.lastFailure(clusterName, movedEndpoint)
+	assert.False(t, ok)
+}
+
+func TestRequestExecutorCooldownUsesCurrentEndpointInterval(t *testing.T) {
+	clusterName := "llm-current-interval-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18088)
+	oldEndpoint.LLMMeta.HealthCheckInterval = 10
+	replacement := testLLMEndpoint("ep-1", 18088)
+	replacement.LLMMeta.HealthCheckInterval = 60000
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-50*time.Millisecond))
+
+	assert.True(t, executor.endpointInCooldown(replacement))
+}
+
+func TestCooldownStoreLazySweepRemovesExpiredChurnedEndpointEntry(t *testing.T) {
+	clusterName := "llm-churn-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18084)
+	movedEndpoint := testLLMEndpoint("ep-1", 18085)
+	activeEndpoint := testLLMEndpoint("ep-2", 18086)
+	store := newCooldownStore()
+
+	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-time.Hour))
+	store.markFailure(clusterName, movedEndpoint, time.Now())
+
+	store.mu.Lock()
+	_, oldExistsAfterMove := store.lastFailureByEndpoint[newCooldownKey(clusterName, oldEndpoint)]
+	_, movedExists := store.lastFailureByEndpoint[newCooldownKey(clusterName, movedEndpoint)]
+	store.mu.Unlock()
+	assert.False(t, oldExistsAfterMove)
+	assert.True(t, movedExists)
+
+	store.markFailure(clusterName, movedEndpoint, time.Now().Add(-time.Hour))
+	store.lastFailure(clusterName, activeEndpoint)
+
+	store.mu.Lock()
+	_, movedExistsAfterDeletedStyleSweep := store.lastFailureByEndpoint[newCooldownKey(clusterName, movedEndpoint)]
+	store.mu.Unlock()
+	assert.False(t, movedExistsAfterDeletedStyleSweep)
+}
+
+func TestStrategyExecuteIgnoresUnhealthyPreferredEndpoint(t *testing.T) {
+	clusterName := "llm-preferred-health"
+	healthyEndpoint := testLLMEndpoint("ep-1", 18086)
+	preferredEndpoint := testLLMEndpoint("ep-2", 18087)
+	preferredEndpoint.UnHealthy = true
+	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: []*model.ClusterConfig{{
+				Name:      clusterName,
+				LbStr:     model.LoadBalancerRoundRobin,
+				Endpoints: []*model.Endpoint{healthyEndpoint, preferredEndpoint},
+			}},
+		},
+	})
+
+	var attemptedHost string
+	filter := &Filter{
+		client: http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				attemptedHost = req.URL.Host
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Body:       http.NoBody,
+				}, nil
+			}),
+		},
+		scheme:    "http",
+		cooldowns: newCooldownStore(),
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/v1/chat/completions", http.NoBody)
+	if !assert.NoError(t, err) {
 		return
 	}
-	values := state.LoadMany(LLMUnhealthyKey, HealthyCheckTimeKey)
-	assert.Equal(t, "true", values[LLMUnhealthyKey])
-	assert.NotEmpty(t, values[HealthyCheckTimeKey])
+	hc := &contexthttp.HttpContext{
+		Request: req,
+		Params: map[string]any{
+			llmPreferredEndpointIDKey: preferredEndpoint.ID,
+		},
+	}
+
+	resp, err := (&Strategy{}).Execute(&RequestExecutor{
+		hc:             hc,
+		filter:         filter,
+		clusterName:    clusterName,
+		clusterManager: clusterManager,
+		cooldowns:      filter.cooldowns,
+	})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, resp) {
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	assert.Equal(t, healthyEndpoint.Address.GetAddress(), attemptedHost)
 }
 
 func testLLMEndpoint(id string, port int) *model.Endpoint {

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -19,6 +19,7 @@ package proxy
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -192,12 +193,40 @@ func TestRequestExecutorCooldownIsIsolatedByEndpointAddress(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestRequestExecutorCooldownUsesCurrentEndpointInterval(t *testing.T) {
-	clusterName := "llm-current-interval-cooldown"
+func TestRequestExecutorCooldownIsIsolatedByEndpointCredential(t *testing.T) {
+	clusterName := "llm-credential-cooldown"
 	oldEndpoint := testLLMEndpoint("ep-1", 18088)
-	oldEndpoint.LLMMeta.HealthCheckInterval = 10
 	replacement := testLLMEndpoint("ep-1", 18088)
+	replacement.LLMMeta.APIKey = "fixed-key"
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	executor.markEndpointCooldown(oldEndpoint)
+
+	assert.True(t, executor.endpointInCooldown(oldEndpoint))
+	assert.False(t, executor.endpointInCooldown(replacement))
+	_, ok := store.lastFailure(clusterName, replacement)
+	assert.False(t, ok)
+}
+
+func TestRequestExecutorCooldownSurvivesNonIdentityLLMConfigChanges(t *testing.T) {
+	clusterName := "llm-policy-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18089)
+	oldEndpoint.LLMMeta.APIKey = "same-key"
+	oldEndpoint.LLMMeta.HealthCheckInterval = 10
+	replacement := testLLMEndpoint("ep-1", 18089)
+	replacement.Name = "renamed-endpoint"
+	replacement.Metadata["dynamic"] = "value"
+	replacement.LLMMeta.APIKey = "same-key"
 	replacement.LLMMeta.HealthCheckInterval = 60000
+	replacement.LLMMeta.RetryPolicy = model.RetryPolicy{
+		Name: model.RetryerCountBased,
+		Config: map[string]any{
+			"attempts": 2,
+		},
+	}
 	store := newCooldownStore()
 	executor := &RequestExecutor{
 		clusterName: clusterName,
@@ -206,6 +235,35 @@ func TestRequestExecutorCooldownUsesCurrentEndpointInterval(t *testing.T) {
 	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-50*time.Millisecond))
 
 	assert.True(t, executor.endpointInCooldown(replacement))
+}
+
+func TestCooldownStoreLazySweepKeepsEntryAfterEndpointIntervalExtends(t *testing.T) {
+	clusterName := "llm-extended-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18090)
+	oldEndpoint.LLMMeta.APIKey = "same-key"
+	oldEndpoint.LLMMeta.HealthCheckInterval = 10
+	replacement := testLLMEndpoint("ep-1", 18090)
+	replacement.LLMMeta.APIKey = "same-key"
+	replacement.LLMMeta.HealthCheckInterval = 60000
+	activeEndpoint := testLLMEndpoint("ep-2", 18091)
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-50*time.Millisecond))
+
+	assert.True(t, executor.endpointInCooldown(replacement))
+	_, _ = store.lastFailure(clusterName, activeEndpoint)
+	store.mu.Lock()
+	_, ok := store.lastFailureByEndpoint[newCooldownKey(clusterName, replacement)]
+	store.mu.Unlock()
+	assert.True(t, ok)
+}
+
+func TestLegacyEndpointHealthMetadataKeysRemainExported(t *testing.T) {
+	assert.Equal(t, "LLMUnhealthy", LLMUnhealthyKey)
+	assert.Equal(t, "HealthyCheckTime", HealthyCheckTimeKey)
 }
 
 func TestCooldownStoreLazySweepRemovesExpiredChurnedEndpointEntry(t *testing.T) {
@@ -222,16 +280,62 @@ func TestCooldownStoreLazySweepRemovesExpiredChurnedEndpointEntry(t *testing.T) 
 	_, oldExistsAfterMove := store.lastFailureByEndpoint[newCooldownKey(clusterName, oldEndpoint)]
 	_, movedExists := store.lastFailureByEndpoint[newCooldownKey(clusterName, movedEndpoint)]
 	store.mu.Unlock()
-	assert.False(t, oldExistsAfterMove)
+	assert.True(t, oldExistsAfterMove)
 	assert.True(t, movedExists)
 
-	store.markFailure(clusterName, movedEndpoint, time.Now().Add(-time.Hour))
+	store.mu.Lock()
+	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
+	store.mu.Unlock()
 	store.lastFailure(clusterName, activeEndpoint)
 
 	store.mu.Lock()
-	_, movedExistsAfterDeletedStyleSweep := store.lastFailureByEndpoint[newCooldownKey(clusterName, movedEndpoint)]
+	_, oldExistsAfterUnrelatedSweep := store.lastFailureByEndpoint[newCooldownKey(clusterName, oldEndpoint)]
 	store.mu.Unlock()
-	assert.False(t, movedExistsAfterDeletedStyleSweep)
+	assert.False(t, oldExistsAfterUnrelatedSweep)
+}
+
+func TestCooldownStoreLazySweepRemovesExpiredEndpointFromDifferentCluster(t *testing.T) {
+	expiredEndpoint := testLLMEndpoint("ep-1", 18092)
+	activeEndpoint := testLLMEndpoint("ep-2", 18093)
+	store := newCooldownStore()
+
+	store.markFailure("old-cluster", expiredEndpoint, time.Now().Add(-time.Hour))
+	store.mu.Lock()
+	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
+	store.mu.Unlock()
+	store.lastFailure("active-cluster", activeEndpoint)
+
+	store.mu.Lock()
+	_, expiredExists := store.lastFailureByEndpoint[newCooldownKey("old-cluster", expiredEndpoint)]
+	store.mu.Unlock()
+	assert.False(t, expiredExists)
+}
+
+func TestCooldownStoreEvictsOldestEntryWhenCapacityExceeded(t *testing.T) {
+	store := newCooldownStore()
+	now := time.Now()
+	oldestEndpoint := testLLMEndpoint("ep-0", 19000)
+
+	for i := 0; i < maxCooldownStoreEntries; i++ {
+		endpoint := testLLMEndpoint(fmt.Sprintf("ep-%d", i), 19000+i)
+		if i == 0 {
+			oldestEndpoint = endpoint
+		}
+		store.markFailure("capacity-cluster", endpoint, now.Add(time.Duration(i)*time.Millisecond))
+	}
+
+	newestEndpoint := testLLMEndpoint("ep-new", 21000)
+	store.markFailure("capacity-cluster", newestEndpoint, now.Add(time.Hour))
+
+	store.mu.Lock()
+	_, oldestExists := store.lastFailureByEndpoint[newCooldownKey("capacity-cluster", oldestEndpoint)]
+	_, newestExists := store.lastFailureByEndpoint[newCooldownKey("capacity-cluster", newestEndpoint)]
+	entryCount := len(store.lastFailureByEndpoint)
+	store.mu.Unlock()
+
+	assert.False(t, oldestExists)
+	assert.True(t, newestExists)
+	assert.Equal(t, maxCooldownStoreEntries, entryCount)
 }
 
 func TestStrategyExecuteIgnoresUnhealthyPreferredEndpoint(t *testing.T) {

--- a/pkg/model/base.go
+++ b/pkg/model/base.go
@@ -180,3 +180,20 @@ func (a SocketAddress) GetAddress() string {
 	}
 	return fmt.Sprintf("%s:%v", a.Address, a.Port)
 }
+
+// Equal reports whether two SocketAddresses refer to the same upstream identity
+// without allocating the formatted "address:port" string. Domain-mode addresses
+// compare on Domains[0]; bare-IP addresses compare on Address+Port. Mixed-mode
+// pairs (one domain, one IP+port) are reported unequal because they describe
+// different upstreams even when their formatted forms collide.
+func (a SocketAddress) Equal(b SocketAddress) bool {
+	aHasDomain := len(a.Domains) > 0
+	bHasDomain := len(b.Domains) > 0
+	if aHasDomain != bHasDomain {
+		return false
+	}
+	if aHasDomain {
+		return a.Domains[0] == b.Domains[0]
+	}
+	return a.Address == b.Address && a.Port == b.Port
+}

--- a/pkg/model/base_test.go
+++ b/pkg/model/base_test.go
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSocketAddressEqual(t *testing.T) {
+	tests := []struct {
+		name             string
+		a                SocketAddress
+		b                SocketAddress
+		want             bool
+		matchesGetAddress bool
+	}{
+		{
+			name:              "both zero",
+			a:                 SocketAddress{},
+			b:                 SocketAddress{},
+			want:              true,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "ip and port equal",
+			a:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			b:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			want:              true,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "same ip different port",
+			a:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			b:                 SocketAddress{Address: "127.0.0.1", Port: 8081},
+			want:              false,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "same single domain",
+			a:                 SocketAddress{Domains: []string{"svc.example.com"}},
+			b:                 SocketAddress{Domains: []string{"svc.example.com"}},
+			want:              true,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "different domains",
+			a:                 SocketAddress{Domains: []string{"svc.a.example.com"}},
+			b:                 SocketAddress{Domains: []string{"svc.b.example.com"}},
+			want:              false,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "one has domain other has ip port",
+			a:                 SocketAddress{Domains: []string{"svc.example.com"}},
+			b:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			want:              false,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "both have single empty domain",
+			a:                 SocketAddress{Domains: []string{""}},
+			b:                 SocketAddress{Domains: []string{""}},
+			want:              true,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "ipv4 vs ipv6 formatting",
+			a:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			b:                 SocketAddress{Address: "::1", Port: 8080},
+			want:              false,
+			matchesGetAddress: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.a.Equal(tc.b)
+			assert.Equal(t, tc.want, got)
+
+			// Equal is symmetric.
+			assert.Equal(t, got, tc.b.Equal(tc.a))
+
+			if tc.matchesGetAddress {
+				assert.Equal(t, tc.a.GetAddress() == tc.b.GetAddress(), got,
+					"Equal must agree with GetAddress() comparison for case %q", tc.name)
+			}
+		})
+	}
+}

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -18,6 +18,7 @@
 package model
 
 import (
+	"crypto/sha256"
 	"fmt"
 )
 
@@ -127,4 +128,115 @@ func (c *ClusterConfig) CreateConsistentHash() {
 
 func (e Endpoint) GetHost() string {
 	return fmt.Sprintf("%s:%d", e.Address.Address, e.Address.Port)
+}
+
+// GeneratedEndpointID returns a deterministic runtime identity for endpoints
+// that do not provide an explicit ID.
+func GeneratedEndpointID(clusterName string, endpoint *Endpoint) string {
+	sum := sha256.Sum256([]byte(endpointIDMaterial(clusterName, endpoint)))
+	return fmt.Sprintf("generated-%x", sum[:8])
+}
+
+func endpointIDMaterial(clusterName string, endpoint *Endpoint) string {
+	if endpoint == nil {
+		return clusterName
+	}
+	provider := ""
+	apiKey := ""
+	if endpoint.LLMMeta != nil {
+		provider = endpoint.LLMMeta.Provider
+		apiKey = endpoint.LLMMeta.APIKey
+	}
+	return clusterName + "\x00" +
+		endpoint.Address.GetAddress() + "\x00" +
+		provider + "\x00" +
+		apiKey
+}
+
+func CloneEndpoints(endpoints []*Endpoint) []*Endpoint {
+	if endpoints == nil {
+		return nil
+	}
+	cloned := make([]*Endpoint, len(endpoints))
+	for i, endpoint := range endpoints {
+		cloned[i] = CloneEndpoint(endpoint)
+	}
+	return cloned
+}
+
+func CloneEndpoint(endpoint *Endpoint) *Endpoint {
+	if endpoint == nil {
+		return nil
+	}
+	cloned := *endpoint
+	cloned.Address = cloneSocketAddress(endpoint.Address)
+	cloned.Metadata = cloneMetadata(endpoint.Metadata)
+	cloned.LLMMeta = cloneLLMMeta(endpoint.LLMMeta)
+	return &cloned
+}
+
+func cloneSocketAddress(address SocketAddress) SocketAddress {
+	cloned := address
+	if address.Domains != nil {
+		cloned.Domains = append([]string(nil), address.Domains...)
+	}
+	return cloned
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	if metadata == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneLLMMeta(meta *LLMMeta) *LLMMeta {
+	if meta == nil {
+		return nil
+	}
+	cloned := *meta
+	cloned.RetryPolicy.Config = cloneAnyMap(meta.RetryPolicy.Config)
+	return &cloned
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(input))
+	for key, value := range input {
+		cloned[key] = cloneAnyValue(value)
+	}
+	return cloned
+}
+
+func cloneAnyValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneAnyValue(item)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), typed...)
+	case []int:
+		return append([]int(nil), typed...)
+	case []int64:
+		return append([]int64(nil), typed...)
+	case []float64:
+		return append([]float64(nil), typed...)
+	case []bool:
+		return append([]bool(nil), typed...)
+	case map[string]string:
+		return cloneMetadata(typed)
+	default:
+		return value
+	}
 }

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -102,3 +102,62 @@ func TestEndpoint_GetHost(t *testing.T) {
 
 	assert.Equal(t, "127.0.0.1:20880", endpoint.GetHost())
 }
+
+func TestGeneratedEndpointIDIncludesLLMIdentity(t *testing.T) {
+	endpoint := &model.Endpoint{
+		Name: "shared-llm",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    20880,
+		},
+		LLMMeta: &model.LLMMeta{
+			Provider: "openai",
+			APIKey:   "key-a",
+		},
+	}
+	same := model.CloneEndpoint(endpoint)
+	renamed := model.CloneEndpoint(endpoint)
+	renamed.Name = "renamed-llm"
+	otherKey := model.CloneEndpoint(endpoint)
+	otherKey.LLMMeta.APIKey = "key-b"
+
+	id := model.GeneratedEndpointID("cluster-a", endpoint)
+
+	assert.Equal(t, id, model.GeneratedEndpointID("cluster-a", same))
+	assert.Equal(t, id, model.GeneratedEndpointID("cluster-a", renamed))
+	assert.NotEqual(t, id, model.GeneratedEndpointID("cluster-a", otherKey))
+	assert.Contains(t, id, "generated-")
+	assert.NotContains(t, id, endpoint.LLMMeta.APIKey)
+}
+
+func TestCloneEndpointDeepCopiesRuntimeMutableFields(t *testing.T) {
+	endpoint := &model.Endpoint{
+		ID:   "ep-1",
+		Name: "endpoint-1",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    20880,
+			Domains: []string{"api.example.com"},
+		},
+		Metadata: map[string]string{"weight": "1"},
+		LLMMeta: &model.LLMMeta{
+			APIKey: "key-a",
+			RetryPolicy: model.RetryPolicy{
+				Config: map[string]any{
+					"nested": map[string]any{"delays": []any{"100ms"}},
+				},
+			},
+		},
+	}
+
+	cloned := model.CloneEndpoint(endpoint)
+	cloned.Address.Domains[0] = "changed.example.com"
+	cloned.Metadata["weight"] = "99"
+	cloned.LLMMeta.APIKey = "key-b"
+	cloned.LLMMeta.RetryPolicy.Config["nested"].(map[string]any)["delays"].([]any)[0] = "200ms"
+
+	assert.Equal(t, []string{"api.example.com"}, endpoint.Address.Domains)
+	assert.Equal(t, map[string]string{"weight": "1"}, endpoint.Metadata)
+	assert.Equal(t, "key-a", endpoint.LLMMeta.APIKey)
+	assert.Equal(t, "100ms", endpoint.LLMMeta.RetryPolicy.Config["nested"].(map[string]any)["delays"].([]any)[0])
+}

--- a/pkg/model/lb.go
+++ b/pkg/model/lb.go
@@ -40,13 +40,41 @@ type LbPolicy interface {
 	GenerateHash() string
 }
 
-// LbConsistentHash supports consistent hash load balancing
-type LbConsistentHash interface {
+// LbConsistentHashView supports read-only consistent hash lookups.
+type LbConsistentHashView interface {
 	Hash(key string) uint32
-	Add(host string)
 	Get(key string) (string, error)
 	GetHash(key uint32) (string, error)
+}
+
+// LbConsistentHash supports mutable consistent hash load balancing.
+type LbConsistentHash interface {
+	LbConsistentHashView
+	Add(host string)
 	Remove(host string) bool
+}
+
+type readOnlyConsistentHash struct {
+	hash LbConsistentHash
+}
+
+func (h readOnlyConsistentHash) Hash(key string) uint32 {
+	return h.hash.Hash(key)
+}
+
+func (h readOnlyConsistentHash) Get(key string) (string, error) {
+	return h.hash.Get(key)
+}
+
+func (h readOnlyConsistentHash) GetHash(key uint32) (string, error) {
+	return h.hash.GetHash(key)
+}
+
+func ReadOnlyConsistentHash(hash LbConsistentHash) LbConsistentHashView {
+	if hash == nil {
+		return nil
+	}
+	return readOnlyConsistentHash{hash: hash}
 }
 
 type ConsistentHashInitFunc = func(ConsistentHash, []*Endpoint) LbConsistentHash

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -165,7 +165,12 @@ func (cm *ClusterManager) compareAndSetStore(store *ClusterStore) (bool, []*clus
 	}
 
 	currentStore := cm.store
-	replacedClusters := store.ensureRuntimeClusters()
+	var replacedClusters []*cluster.Cluster
+	if store == currentStore {
+		replacedClusters = store.ensureRuntimeClusters()
+	} else {
+		replacedClusters = store.ensureRuntimeClustersFrom(currentStore)
+	}
 	store.carryOverRuntimeStateFrom(currentStore)
 	cm.store = store
 	if store != currentStore {
@@ -178,12 +183,12 @@ func (cm *ClusterManager) compareAndSetStore(store *ClusterStore) (bool, []*clus
 func (cm *ClusterManager) PickEndpoint(clusterName string, policy model.LbPolicy) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
-	c := cm.getCluster(clusterName)
-	if c == nil {
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
 		logger.Warnf("[dubbo-go-pixiu] cluster %s not found", clusterName)
 		return nil
 	}
-	return cm.pickOneEndpoint(c, policy)
+	return cm.pickOneEndpoint(runtimeCluster, policy)
 }
 
 // PickNextEndpoint picks the next endpoint in the cluster after the current endpoint ID.
@@ -191,17 +196,28 @@ func (cm *ClusterManager) PickNextEndpoint(clusterName string, curEndpointID str
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
 
-	c := cm.getCluster(clusterName)
-	if c == nil {
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
 		logger.Warnf("[dubbo-go-pixiu] cluster %s not found", clusterName)
 		return nil
 	}
 
-	for i, endpoint := range c.Endpoints {
+	snapshot := runtimeCluster.EndpointSnapshot()
+	endpoints := snapshot.AllEndpoints()
+	for i, endpoint := range endpoints {
+		if endpoint == nil {
+			continue
+		}
 		if endpoint.ID == curEndpointID {
-			// pick next endpoint
-			if i < len(c.Endpoints)-1 {
-				return c.Endpoints[i+1]
+			// Fallback keeps the configured endpoint order, but skips endpoints
+			// that are no longer healthy in the current runtime snapshot.
+			for _, nextEndpoint := range endpoints[i+1:] {
+				if nextEndpoint == nil {
+					continue
+				}
+				if healthyEndpoint := snapshot.HealthyEndpointByID(nextEndpoint.ID); healthyEndpoint != nil {
+					return healthyEndpoint
+				}
 			}
 			return nil // have tried all endpoints
 		}
@@ -215,44 +231,64 @@ func (cm *ClusterManager) GetEndpointByID(clusterName string, endpointID string)
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
 
-	c := cm.getCluster(clusterName)
-	if c == nil {
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
 		return nil
 	}
-	for _, endpoint := range c.Endpoints {
-		if endpoint.ID == endpointID && !endpoint.UnHealthy {
-			return endpoint
-		}
+	return runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpointID)
+}
+
+// GetEndpointRuntimeState returns runtime state only when the endpoint ID still
+// resolves to the same address. This prevents stale request goroutines from
+// writing state onto an endpoint that has been replaced under the same ID.
+func (cm *ClusterManager) GetEndpointRuntimeState(
+	clusterName string,
+	endpointID string,
+	endpointAddress string,
+) *cluster.EndpointRuntimeState {
+	cm.rw.RLock()
+	defer cm.rw.RUnlock()
+
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
+		return nil
 	}
-	return nil
+	return runtimeCluster.EndpointRuntimeState(endpointID, endpointAddress)
 }
 
 // getCluster returns the cluster configuration by its name.
 func (cm *ClusterManager) getCluster(clusterName string) *model.ClusterConfig {
-	runtimeCluster := cm.store.clustersMap[clusterName]
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
 	if runtimeCluster == nil {
 		return nil
 	}
 	return runtimeCluster.Config
 }
 
-func (cm *ClusterManager) pickOneEndpoint(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
-	if len(c.Endpoints) == 0 {
+func (cm *ClusterManager) getRuntimeCluster(clusterName string) *cluster.Cluster {
+	return cm.store.clustersMap[clusterName]
+}
+
+func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, policy model.LbPolicy) *model.Endpoint {
+	snapshot := runtimeCluster.EndpointSnapshot()
+	healthyEndpoints := snapshot.HealthyEndpoints()
+	if len(healthyEndpoints) == 0 {
 		return nil
 	}
-
-	if len(c.Endpoints) == 1 {
-		if !c.Endpoints[0].UnHealthy {
-			return c.Endpoints[0]
-		}
-		return nil
+	if snapshot.EndpointCount() == 1 {
+		return healthyEndpoints[0]
 	}
 
+	c := runtimeCluster.Config
+	pickContext := loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: healthyEndpoints,
+	}
 	loadBalancer, ok := loadbalancer.LoadBalancerStrategy[c.LbStr]
 	if ok {
-		return loadBalancer.Handler(c, policy)
+		return loadbalancer.PickEndpoint(loadBalancer, pickContext, policy)
 	}
-	return loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand].Handler(c, policy)
+	return loadbalancer.PickEndpoint(loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand], pickContext, policy)
 }
 
 func (cm *ClusterManager) RemoveCluster(namesToDel []string) {
@@ -333,12 +369,24 @@ func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 
 // replaceClusterRuntime returns the old runtime so callers decide when to stop it.
 func (s *ClusterStore) replaceClusterRuntime(name string, config *model.ClusterConfig) *cluster.Cluster {
+	var previous *cluster.EndpointSnapshot
+	if oldRuntime := s.clustersMap[name]; oldRuntime != nil {
+		previous = oldRuntime.SnapshotForRuntimeReplacement()
+	}
+	return s.replaceClusterRuntimeWithSnapshot(name, config, previous)
+}
+
+func (s *ClusterStore) replaceClusterRuntimeWithSnapshot(
+	name string,
+	config *model.ClusterConfig,
+	previous *cluster.EndpointSnapshot,
+) *cluster.Cluster {
 	if s.clustersMap == nil {
 		s.clustersMap = map[string]*cluster.Cluster{}
 	}
 
 	oldRuntime := s.clustersMap[name]
-	s.clustersMap[name] = cluster.NewCluster(config)
+	s.clustersMap[name] = cluster.NewClusterWithEndpointSnapshot(config, previous)
 	return oldRuntime
 }
 
@@ -363,6 +411,50 @@ func (s *ClusterStore) ensureRuntimeClusters() []*cluster.Cluster {
 		runtimeCluster := s.clustersMap[clusterConfig.Name]
 		if runtimeCluster == nil || runtimeCluster.Config != clusterConfig {
 			if oldRuntime := s.replaceClusterRuntime(clusterConfig.Name, clusterConfig); oldRuntime != nil {
+				replacedClusters = append(replacedClusters, oldRuntime)
+			}
+		}
+	}
+
+	for name, runtimeCluster := range s.clustersMap {
+		if _, ok := configsByName[name]; !ok {
+			replacedClusters = append(replacedClusters, runtimeCluster)
+			delete(s.clustersMap, name)
+		}
+	}
+	return replacedClusters
+}
+
+// ensureRuntimeClustersFrom repairs a candidate store using the currently
+// published runtime snapshots before the candidate runtime starts health checks.
+func (s *ClusterStore) ensureRuntimeClustersFrom(old *ClusterStore) []*cluster.Cluster {
+	if s == nil {
+		return nil
+	}
+	if old == nil || s == old {
+		return s.ensureRuntimeClusters()
+	}
+	if s.clustersMap == nil {
+		s.clustersMap = map[string]*cluster.Cluster{}
+	}
+
+	replacedClusters := make([]*cluster.Cluster, 0)
+	configsByName := make(map[string]*model.ClusterConfig, len(s.Config))
+	for _, clusterConfig := range s.Config {
+		if clusterConfig == nil {
+			continue
+		}
+		s.prepareClusterConfig(clusterConfig)
+		configsByName[clusterConfig.Name] = clusterConfig
+
+		var previous *cluster.EndpointSnapshot
+		if oldRuntime := old.clustersMap[clusterConfig.Name]; oldRuntime != nil {
+			previous = oldRuntime.SnapshotForRuntimeReplacement()
+		}
+
+		runtimeCluster := s.clustersMap[clusterConfig.Name]
+		if runtimeCluster == nil || runtimeCluster.Config != clusterConfig || previous != nil {
+			if oldRuntime := s.replaceClusterRuntimeWithSnapshot(clusterConfig.Name, clusterConfig, previous); oldRuntime != nil {
 				replacedClusters = append(replacedClusters, oldRuntime)
 			}
 		}
@@ -453,21 +545,38 @@ func (s *ClusterStore) SetEndpoint(clusterName string, endpoint *model.Endpoint)
 		runtimeCluster = s.clustersMap[clusterName]
 	}
 
-	for _, e := range clusterConfig.Endpoints {
+	for i, e := range clusterConfig.Endpoints {
 		if e.ID == endpoint.ID {
-			// Remove before mutating address because healthcheck keys by address.
+			// Remove before replacing the endpoint because healthcheck keys by address.
 			runtimeCluster.RemoveEndpoint(e)
-			e.Name = endpoint.Name
-			e.Metadata = endpoint.Metadata
-			e.Address = endpoint.Address
+			mergedEndpoint := mergeEndpointForSet(e, endpoint)
+			clusterConfig.Endpoints[i] = mergedEndpoint
 			s.prepareClusterConfig(clusterConfig)
-			runtimeCluster.AddEndpoint(e)
+			runtimeCluster.RefreshEndpoints()
+			runtimeCluster.AddEndpoint(mergedEndpoint)
 			return
 		}
 	}
 	clusterConfig.Endpoints = append(clusterConfig.Endpoints, endpoint)
 	s.prepareClusterConfig(clusterConfig)
+	runtimeCluster.RefreshEndpoints()
 	runtimeCluster.AddEndpoint(endpoint)
+}
+
+func mergeEndpointForSet(oldEndpoint *model.Endpoint, incoming *model.Endpoint) *model.Endpoint {
+	if oldEndpoint == nil || incoming == nil {
+		return incoming
+	}
+
+	merged := *oldEndpoint
+	merged.ID = incoming.ID
+	merged.Name = incoming.Name
+	merged.Address = incoming.Address
+	merged.Metadata = incoming.Metadata
+	if incoming.LLMMeta != nil {
+		merged.LLMMeta = incoming.LLMMeta
+	}
+	return &merged
 }
 
 func (s *ClusterStore) DeleteEndpoint(clusterName string, endpointID string) {
@@ -488,6 +597,7 @@ func (s *ClusterStore) DeleteEndpoint(clusterName string, endpointID string) {
 			runtimeCluster.RemoveEndpoint(e)
 			clusterConfig.Endpoints = append(clusterConfig.Endpoints[:i], clusterConfig.Endpoints[i+1:]...)
 			s.prepareClusterConfig(clusterConfig)
+			runtimeCluster.RefreshEndpoints()
 			return
 		}
 	}

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -24,10 +24,6 @@ import (
 )
 
 import (
-	"github.com/hashicorp/go-uuid"
-)
-
-import (
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster"
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/yaml"
@@ -214,6 +210,19 @@ func (cm *ClusterManager) GetEndpointByID(clusterName, endpointID string) *model
 	return cm.GetHealthyEndpointByID(clusterName, endpointID)
 }
 
+// GetAnyEndpointByID returns the runtime endpoint by ID regardless of its
+// current health in the runtime snapshot.
+func (cm *ClusterManager) GetAnyEndpointByID(clusterName, endpointID string) *model.Endpoint {
+	cm.rw.RLock()
+	defer cm.rw.RUnlock()
+
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
+		return nil
+	}
+	return runtimeCluster.EndpointSnapshot().EndpointByID(endpointID)
+}
+
 // GetHealthyEndpointByID returns the runtime endpoint by ID only when it is
 // healthy in the current runtime snapshot.
 func (cm *ClusterManager) GetHealthyEndpointByID(clusterName, endpointID string) *model.Endpoint {
@@ -258,18 +267,27 @@ func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, polic
 		loadBalancer = loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand]
 	}
 	if _, ok := loadBalancer.(loadbalancer.SnapshotLoadBalancer); ok {
+		var allEndpoints []*model.Endpoint
+		if loadbalancer.NeedsAllEndpoints(loadBalancer) {
+			allEndpoints = snapshot.AllEndpoints()
+		}
 		return snapshot.PickHealthyEndpoint(func(healthyEndpoints []*model.Endpoint) *model.Endpoint {
 			return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, loadbalancer.PickContext{
-				Config:           c,
-				HealthyEndpoints: healthyEndpoints,
+				Config:                c,
+				HealthyConsistentHash: snapshot.HealthyConsistentHash(),
+				AllEndpoints:          allEndpoints,
+				HealthyEndpoints:      healthyEndpoints,
 			}, policy)
 		})
 	}
 
+	allEndpoints := snapshot.AllEndpoints()
 	healthyEndpoints := snapshot.HealthyEndpoints()
 	return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, loadbalancer.PickContext{
-		Config:           c,
-		HealthyEndpoints: healthyEndpoints,
+		Config:                c,
+		HealthyConsistentHash: snapshot.HealthyConsistentHash(),
+		AllEndpoints:          allEndpoints,
+		HealthyEndpoints:      healthyEndpoints,
 	}, policy)
 }
 
@@ -334,17 +352,44 @@ func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 		return
 	}
 
+	endpointIDs := make(map[string]struct{}, len(c.Endpoints))
 	for i, endpoint := range c.Endpoints {
-		// If the endpoint ID is not set, set it to the index + 1
-		if endpoint.ID == "" {
-			endpoint.ID, _ = uuid.GenerateUUID()
+		if endpoint == nil {
+			continue
 		}
+		// Endpoint IDs are runtime health keys, so keep them unique per cluster.
+		if endpoint.ID == "" {
+			endpoint.ID = nextStableEndpointID(c.Name, endpoint, endpointIDs)
+		} else if _, exists := endpointIDs[endpoint.ID]; exists {
+			duplicateID := endpoint.ID
+			endpoint.ID = nextStableEndpointID(c.Name, endpoint, endpointIDs)
+			logger.Warnf(
+				"[dubbo-go-pixiu] duplicate endpoint ID %s in cluster %s, assigned endpoint ID %s",
+				duplicateID,
+				c.Name,
+				endpoint.ID,
+			)
+		}
+		endpointIDs[endpoint.ID] = struct{}{}
 
 		// If the endpoint has no name, set a default name
 		if endpoint.Name == "" && endpoint.LLMMeta != nil {
 			endpoint.Name = fmt.Sprintf("endpoint-%d#%s", i+1, endpoint.LLMMeta.Provider)
 		} else if endpoint.Name == "" && endpoint.LLMMeta == nil {
 			endpoint.Name = fmt.Sprintf("endpoint-%d", i+1)
+		}
+	}
+}
+
+func nextStableEndpointID(clusterName string, endpoint *model.Endpoint, endpointIDs map[string]struct{}) string {
+	baseID := model.GeneratedEndpointID(clusterName, endpoint)
+	for suffix := 0; ; suffix++ {
+		id := baseID
+		if suffix > 0 {
+			id = fmt.Sprintf("%s-%d", baseID, suffix+1)
+		}
+		if _, exists := endpointIDs[id]; !exists {
+			return id
 		}
 	}
 }
@@ -543,6 +588,10 @@ func (s *ClusterStore) SetEndpoint(clusterName string, endpoint *model.Endpoint)
 		runtimeCluster = s.clustersMap[clusterName]
 	}
 
+	if endpoint.ID == "" {
+		endpoint.ID = stableEndpointIDForSet(clusterName, endpoint, clusterConfig.Endpoints)
+	}
+
 	for i, e := range clusterConfig.Endpoints {
 		if e.ID == endpoint.ID {
 			// Remove before replacing the endpoint because healthcheck keys by address.
@@ -575,6 +624,37 @@ func mergeEndpointForSet(oldEndpoint, incoming *model.Endpoint) *model.Endpoint 
 		merged.LLMMeta = incoming.LLMMeta
 	}
 	return &merged
+}
+
+func stableEndpointIDForSet(clusterName string, endpoint *model.Endpoint, endpoints []*model.Endpoint) string {
+	generatedID := model.GeneratedEndpointID(clusterName, endpoint)
+	if existingEndpointMatchesGeneratedID(clusterName, generatedID, endpoints) {
+		return generatedID
+	}
+	return nextStableEndpointID(clusterName, endpoint, existingEndpointIDs(endpoints))
+}
+
+func existingEndpointMatchesGeneratedID(clusterName, generatedID string, endpoints []*model.Endpoint) bool {
+	for _, existing := range endpoints {
+		if existing == nil || existing.ID != generatedID {
+			continue
+		}
+		if model.GeneratedEndpointID(clusterName, existing) == generatedID {
+			return true
+		}
+	}
+	return false
+}
+
+func existingEndpointIDs(endpoints []*model.Endpoint) map[string]struct{} {
+	ids := make(map[string]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint == nil || endpoint.ID == "" {
+			continue
+		}
+		ids[endpoint.ID] = struct{}{}
+	}
+	return ids
 }
 
 func (s *ClusterStore) DeleteEndpoint(clusterName string, endpointID string) {

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -280,15 +280,21 @@ func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, polic
 	}
 
 	c := runtimeCluster.Config
+	legacyPickLock := runtimeCluster.LegacyPickLock()
 	pickContext := loadbalancer.PickContext{
 		Config:           c,
 		HealthyEndpoints: healthyEndpoints,
 	}
 	loadBalancer, ok := loadbalancer.LoadBalancerStrategy[c.LbStr]
 	if ok {
-		return loadbalancer.PickEndpoint(loadBalancer, pickContext, policy)
+		return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, pickContext, policy)
 	}
-	return loadbalancer.PickEndpoint(loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand], pickContext, policy)
+	return loadbalancer.PickEndpointWithLegacyLock(
+		loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand],
+		legacyPickLock,
+		pickContext,
+		policy,
+	)
 }
 
 func (cm *ClusterManager) RemoveCluster(namesToDel []string) {

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -206,32 +206,7 @@ func (cm *ClusterManager) PickNextEndpoint(clusterName, curEndpointID string) *m
 }
 
 func pickNextHealthyEndpoint(snapshot *cluster.EndpointSnapshot, curEndpointID string) *model.Endpoint {
-	endpoints := snapshot.AllEndpoints()
-	start := nextEndpointStartIndex(endpoints, curEndpointID)
-	if start < 0 {
-		return nil
-	}
-
-	// Fallback keeps the configured endpoint order, but skips endpoints that are
-	// no longer healthy in the current runtime snapshot.
-	for _, nextEndpoint := range endpoints[start:] {
-		if nextEndpoint == nil {
-			continue
-		}
-		if healthyEndpoint := snapshot.HealthyEndpointByID(nextEndpoint.ID); healthyEndpoint != nil {
-			return healthyEndpoint
-		}
-	}
-	return nil // have tried all endpoints
-}
-
-func nextEndpointStartIndex(endpoints []*model.Endpoint, curEndpointID string) int {
-	for i, endpoint := range endpoints {
-		if endpoint != nil && endpoint.ID == curEndpointID {
-			return i + 1
-		}
-	}
-	return -1
+	return snapshot.NextHealthyEndpoint(curEndpointID)
 }
 
 // GetEndpointByID returns the healthy runtime endpoint by ID in the given cluster.
@@ -267,30 +242,35 @@ func (cm *ClusterManager) getRuntimeCluster(clusterName string) *cluster.Cluster
 
 func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, policy model.LbPolicy) *model.Endpoint {
 	snapshot := runtimeCluster.EndpointSnapshot()
-	healthyEndpoints := snapshot.HealthyEndpoints()
-	if len(healthyEndpoints) == 0 {
+	if snapshot.HealthyEndpointCount() == 0 {
 		return nil
 	}
 	if snapshot.EndpointCount() == 1 {
-		return healthyEndpoints[0]
+		return snapshot.PickHealthyEndpoint(func(healthyEndpoints []*model.Endpoint) *model.Endpoint {
+			return healthyEndpoints[0]
+		})
 	}
 
 	c := runtimeCluster.Config
 	legacyPickLock := runtimeCluster.LegacyPickLock()
-	pickContext := loadbalancer.PickContext{
+	loadBalancer, ok := loadbalancer.LoadBalancerStrategy[c.LbStr]
+	if !ok {
+		loadBalancer = loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand]
+	}
+	if _, ok := loadBalancer.(loadbalancer.SnapshotLoadBalancer); ok {
+		return snapshot.PickHealthyEndpoint(func(healthyEndpoints []*model.Endpoint) *model.Endpoint {
+			return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, loadbalancer.PickContext{
+				Config:           c,
+				HealthyEndpoints: healthyEndpoints,
+			}, policy)
+		})
+	}
+
+	healthyEndpoints := snapshot.HealthyEndpoints()
+	return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, loadbalancer.PickContext{
 		Config:           c,
 		HealthyEndpoints: healthyEndpoints,
-	}
-	loadBalancer, ok := loadbalancer.LoadBalancerStrategy[c.LbStr]
-	if ok {
-		return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, pickContext, policy)
-	}
-	return loadbalancer.PickEndpointWithLegacyLock(
-		loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand],
-		legacyPickLock,
-		pickContext,
-		policy,
-	)
+	}, policy)
 }
 
 func (cm *ClusterManager) RemoveCluster(namesToDel []string) {

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -234,8 +234,14 @@ func nextEndpointStartIndex(endpoints []*model.Endpoint, curEndpointID string) i
 	return -1
 }
 
-// GetEndpointByID returns the endpoint by ID in the given cluster.
+// GetEndpointByID returns the healthy runtime endpoint by ID in the given cluster.
 func (cm *ClusterManager) GetEndpointByID(clusterName, endpointID string) *model.Endpoint {
+	return cm.GetHealthyEndpointByID(clusterName, endpointID)
+}
+
+// GetHealthyEndpointByID returns the runtime endpoint by ID only when it is
+// healthy in the current runtime snapshot.
+func (cm *ClusterManager) GetHealthyEndpointByID(clusterName, endpointID string) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
 
@@ -244,22 +250,6 @@ func (cm *ClusterManager) GetEndpointByID(clusterName, endpointID string) *model
 		return nil
 	}
 	return runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpointID)
-}
-
-// GetEndpointRuntimeState returns runtime state only when the endpoint ID still
-// resolves to the same address. This prevents stale request goroutines from
-// writing state onto an endpoint that has been replaced under the same ID.
-func (cm *ClusterManager) GetEndpointRuntimeState(
-	clusterName, endpointID, endpointAddress string,
-) *cluster.EndpointRuntimeState {
-	cm.rw.RLock()
-	defer cm.rw.RUnlock()
-
-	runtimeCluster := cm.getRuntimeCluster(clusterName)
-	if runtimeCluster == nil {
-		return nil
-	}
-	return runtimeCluster.EndpointRuntimeState(endpointID, endpointAddress)
 }
 
 // getCluster returns the cluster configuration by its name.

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -192,7 +192,7 @@ func (cm *ClusterManager) PickEndpoint(clusterName string, policy model.LbPolicy
 }
 
 // PickNextEndpoint picks the next endpoint in the cluster after the current endpoint ID.
-func (cm *ClusterManager) PickNextEndpoint(clusterName string, curEndpointID string) *model.Endpoint {
+func (cm *ClusterManager) PickNextEndpoint(clusterName, curEndpointID string) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
 
@@ -202,32 +202,40 @@ func (cm *ClusterManager) PickNextEndpoint(clusterName string, curEndpointID str
 		return nil
 	}
 
-	snapshot := runtimeCluster.EndpointSnapshot()
+	return pickNextHealthyEndpoint(runtimeCluster.EndpointSnapshot(), curEndpointID)
+}
+
+func pickNextHealthyEndpoint(snapshot *cluster.EndpointSnapshot, curEndpointID string) *model.Endpoint {
 	endpoints := snapshot.AllEndpoints()
-	for i, endpoint := range endpoints {
-		if endpoint == nil {
-			continue
-		}
-		if endpoint.ID == curEndpointID {
-			// Fallback keeps the configured endpoint order, but skips endpoints
-			// that are no longer healthy in the current runtime snapshot.
-			for _, nextEndpoint := range endpoints[i+1:] {
-				if nextEndpoint == nil {
-					continue
-				}
-				if healthyEndpoint := snapshot.HealthyEndpointByID(nextEndpoint.ID); healthyEndpoint != nil {
-					return healthyEndpoint
-				}
-			}
-			return nil // have tried all endpoints
-		}
+	start := nextEndpointStartIndex(endpoints, curEndpointID)
+	if start < 0 {
+		return nil
 	}
 
-	return nil
+	// Fallback keeps the configured endpoint order, but skips endpoints that are
+	// no longer healthy in the current runtime snapshot.
+	for _, nextEndpoint := range endpoints[start:] {
+		if nextEndpoint == nil {
+			continue
+		}
+		if healthyEndpoint := snapshot.HealthyEndpointByID(nextEndpoint.ID); healthyEndpoint != nil {
+			return healthyEndpoint
+		}
+	}
+	return nil // have tried all endpoints
+}
+
+func nextEndpointStartIndex(endpoints []*model.Endpoint, curEndpointID string) int {
+	for i, endpoint := range endpoints {
+		if endpoint != nil && endpoint.ID == curEndpointID {
+			return i + 1
+		}
+	}
+	return -1
 }
 
 // GetEndpointByID returns the endpoint by ID in the given cluster.
-func (cm *ClusterManager) GetEndpointByID(clusterName string, endpointID string) *model.Endpoint {
+func (cm *ClusterManager) GetEndpointByID(clusterName, endpointID string) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
 
@@ -242,9 +250,7 @@ func (cm *ClusterManager) GetEndpointByID(clusterName string, endpointID string)
 // resolves to the same address. This prevents stale request goroutines from
 // writing state onto an endpoint that has been replaced under the same ID.
 func (cm *ClusterManager) GetEndpointRuntimeState(
-	clusterName string,
-	endpointID string,
-	endpointAddress string,
+	clusterName, endpointID, endpointAddress string,
 ) *cluster.EndpointRuntimeState {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
@@ -387,13 +393,17 @@ func (s *ClusterStore) replaceClusterRuntimeWithSnapshot(
 	config *model.ClusterConfig,
 	previous *cluster.EndpointSnapshot,
 ) *cluster.Cluster {
-	if s.clustersMap == nil {
-		s.clustersMap = map[string]*cluster.Cluster{}
-	}
+	s.ensureRuntimeClusterMap()
 
 	oldRuntime := s.clustersMap[name]
 	s.clustersMap[name] = cluster.NewClusterWithEndpointSnapshot(config, previous)
 	return oldRuntime
+}
+
+func (s *ClusterStore) ensureRuntimeClusterMap() {
+	if s.clustersMap == nil {
+		s.clustersMap = map[string]*cluster.Cluster{}
+	}
 }
 
 // ensureRuntimeClusters repairs clustersMap to match Config by name and pointer.
@@ -401,9 +411,7 @@ func (s *ClusterStore) ensureRuntimeClusters() []*cluster.Cluster {
 	if s == nil {
 		return nil
 	}
-	if s.clustersMap == nil {
-		s.clustersMap = map[string]*cluster.Cluster{}
-	}
+	s.ensureRuntimeClusterMap()
 
 	replacedClusters := make([]*cluster.Cluster, 0)
 	configsByName := make(map[string]*model.ClusterConfig, len(s.Config))
@@ -422,13 +430,7 @@ func (s *ClusterStore) ensureRuntimeClusters() []*cluster.Cluster {
 		}
 	}
 
-	for name, runtimeCluster := range s.clustersMap {
-		if _, ok := configsByName[name]; !ok {
-			replacedClusters = append(replacedClusters, runtimeCluster)
-			delete(s.clustersMap, name)
-		}
-	}
-	return replacedClusters
+	return append(replacedClusters, s.removeRuntimeClustersNotIn(configsByName)...)
 }
 
 // ensureRuntimeClustersFrom repairs a candidate store using the currently
@@ -440,32 +442,52 @@ func (s *ClusterStore) ensureRuntimeClustersFrom(old *ClusterStore) []*cluster.C
 	if old == nil || s == old {
 		return s.ensureRuntimeClusters()
 	}
-	if s.clustersMap == nil {
-		s.clustersMap = map[string]*cluster.Cluster{}
-	}
+	s.ensureRuntimeClusterMap()
 
 	replacedClusters := make([]*cluster.Cluster, 0)
 	configsByName := make(map[string]*model.ClusterConfig, len(s.Config))
 	for _, clusterConfig := range s.Config {
-		if clusterConfig == nil {
+		clusterName, oldRuntime := s.repairRuntimeClusterFromPrevious(clusterConfig, old)
+		if clusterName == "" {
 			continue
 		}
-		s.prepareClusterConfig(clusterConfig)
-		configsByName[clusterConfig.Name] = clusterConfig
-
-		var previous *cluster.EndpointSnapshot
-		if oldRuntime := old.clustersMap[clusterConfig.Name]; oldRuntime != nil {
-			previous = oldRuntime.SnapshotForRuntimeReplacement()
-		}
-
-		runtimeCluster := s.clustersMap[clusterConfig.Name]
-		if runtimeCluster == nil || runtimeCluster.Config != clusterConfig || previous != nil {
-			if oldRuntime := s.replaceClusterRuntimeWithSnapshot(clusterConfig.Name, clusterConfig, previous); oldRuntime != nil {
-				replacedClusters = append(replacedClusters, oldRuntime)
-			}
+		configsByName[clusterName] = clusterConfig
+		if oldRuntime != nil {
+			replacedClusters = append(replacedClusters, oldRuntime)
 		}
 	}
 
+	return append(replacedClusters, s.removeRuntimeClustersNotIn(configsByName)...)
+}
+
+func (s *ClusterStore) repairRuntimeClusterFromPrevious(
+	clusterConfig *model.ClusterConfig,
+	old *ClusterStore,
+) (string, *cluster.Cluster) {
+	if clusterConfig == nil {
+		return "", nil
+	}
+	s.prepareClusterConfig(clusterConfig)
+	previous := snapshotForRuntimeReplacement(old, clusterConfig.Name)
+	runtimeCluster := s.clustersMap[clusterConfig.Name]
+	if runtimeCluster != nil && runtimeCluster.Config == clusterConfig && previous == nil {
+		return clusterConfig.Name, nil
+	}
+	return clusterConfig.Name, s.replaceClusterRuntimeWithSnapshot(clusterConfig.Name, clusterConfig, previous)
+}
+
+func snapshotForRuntimeReplacement(old *ClusterStore, clusterName string) *cluster.EndpointSnapshot {
+	if old == nil {
+		return nil
+	}
+	if oldRuntime := old.clustersMap[clusterName]; oldRuntime != nil {
+		return oldRuntime.SnapshotForRuntimeReplacement()
+	}
+	return nil
+}
+
+func (s *ClusterStore) removeRuntimeClustersNotIn(configsByName map[string]*model.ClusterConfig) []*cluster.Cluster {
+	replacedClusters := make([]*cluster.Cluster, 0)
 	for name, runtimeCluster := range s.clustersMap {
 		if _, ok := configsByName[name]; !ok {
 			replacedClusters = append(replacedClusters, runtimeCluster)
@@ -569,7 +591,7 @@ func (s *ClusterStore) SetEndpoint(clusterName string, endpoint *model.Endpoint)
 	runtimeCluster.AddEndpoint(endpoint)
 }
 
-func mergeEndpointForSet(oldEndpoint *model.Endpoint, incoming *model.Endpoint) *model.Endpoint {
+func mergeEndpointForSet(oldEndpoint, incoming *model.Endpoint) *model.Endpoint {
 	if oldEndpoint == nil || incoming == nil {
 		return incoming
 	}

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -254,10 +254,9 @@ func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, polic
 	if snapshot.HealthyEndpointCount() == 0 {
 		return nil
 	}
+	healthyEndpoints := snapshot.HealthyEndpointsForPick()
 	if snapshot.EndpointCount() == 1 {
-		return snapshot.PickHealthyEndpoint(func(healthyEndpoints []*model.Endpoint) *model.Endpoint {
-			return healthyEndpoints[0]
-		})
+		return model.CloneEndpoint(healthyEndpoints[0])
 	}
 
 	c := runtimeCluster.Config
@@ -266,23 +265,12 @@ func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, polic
 	if !ok {
 		loadBalancer = loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand]
 	}
-	if _, ok := loadBalancer.(loadbalancer.SnapshotLoadBalancer); ok {
-		var allEndpoints []*model.Endpoint
-		if loadbalancer.NeedsAllEndpoints(loadBalancer) {
-			allEndpoints = snapshot.AllEndpoints()
-		}
-		return snapshot.PickHealthyEndpoint(func(healthyEndpoints []*model.Endpoint) *model.Endpoint {
-			return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, loadbalancer.PickContext{
-				Config:                c,
-				HealthyConsistentHash: snapshot.HealthyConsistentHash(),
-				AllEndpoints:          allEndpoints,
-				HealthyEndpoints:      healthyEndpoints,
-			}, policy)
-		})
+
+	var allEndpoints []*model.Endpoint
+	if loadbalancer.NeedsAllEndpoints(loadBalancer) {
+		allEndpoints = snapshot.AllEndpointsForPick()
 	}
 
-	allEndpoints := snapshot.AllEndpoints()
-	healthyEndpoints := snapshot.HealthyEndpoints()
 	return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, loadbalancer.PickContext{
 		Config:                c,
 		HealthyConsistentHash: snapshot.HealthyConsistentHash(),

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"     // Register Maglev for benchmark coverage.
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"       // Register Rand for benchmark coverage.
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"   // Register RingHash for benchmark coverage.
@@ -106,32 +107,33 @@ func BenchmarkClusterLoadBalancerHotPathSerial(b *testing.B) {
 		for _, endpointCount := range []int{4, 64, 512} {
 			b.Run(fmt.Sprintf("%s/endpoints=%d", lbType, endpointCount), func(b *testing.B) {
 				cm := &ClusterManager{}
-				cluster := benchmarkClusterConfig("lb-hot-path", lbType, endpointCount, 0)
+				runtimeCluster := cluster.NewCluster(benchmarkClusterConfig("lb-hot-path", lbType, endpointCount, 0))
 
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					benchmarkEndpointSink = cm.pickOneEndpoint(cluster, nil)
+					benchmarkEndpointSink = cm.pickOneEndpoint(runtimeCluster, nil)
 				}
 			})
 		}
 	}
 }
 
-func BenchmarkClusterHealthyFilterCost(b *testing.B) {
+func BenchmarkClusterHealthySnapshotLoad(b *testing.B) {
 	for _, endpointCount := range []int{8, 64, 512} {
 		for _, healthyRatio := range []int{100, 50, 0} {
 			b.Run(fmt.Sprintf("endpoints=%d/healthy=%d", endpointCount, healthyRatio), func(b *testing.B) {
-				cluster := benchmarkClusterConfig("healthy-filter", model.LoadBalancerRoundRobin, endpointCount, 0)
+				clusterConfig := benchmarkClusterConfig("healthy-snapshot", model.LoadBalancerRoundRobin, endpointCount, 0)
 				healthyCount := endpointCount * healthyRatio / 100
-				for i := healthyCount; i < len(cluster.Endpoints); i++ {
-					cluster.Endpoints[i].UnHealthy = true
+				for i := healthyCount; i < len(clusterConfig.Endpoints); i++ {
+					clusterConfig.Endpoints[i].UnHealthy = true
 				}
+				runtimeCluster := cluster.NewCluster(clusterConfig)
 
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					benchmarkEndpointsSink = cluster.GetEndpoint(true)
+					benchmarkEndpointsSink = runtimeCluster.EndpointSnapshot().HealthyEndpoints()
 				}
 			})
 		}

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -101,6 +101,27 @@ func TestClusterManager_PickNextEndpointUsesRuntimeClusterMap(t *testing.T) {
 	}
 }
 
+func TestClusterManager_PickNextEndpointSkipsSnapshotUnhealthyEndpoints(t *testing.T) {
+	ep1 := testEndpoint("fallback-1", "127.0.0.1", 18087)
+	ep2 := testEndpoint("fallback-2", "127.0.0.1", 18088)
+	ep3 := testEndpoint("fallback-3", "127.0.0.1", 18089)
+	cm := testClusterManager(
+		testCluster("fallback-health", model.LoadBalancerRoundRobin, []*model.Endpoint{ep1, ep2, ep3}),
+	)
+	runtimeCluster := cm.store.clustersMap["fallback-health"]
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(ep2.ID, ep2.Address.GetAddress(), false))
+	assert.False(t, ep2.UnHealthy)
+
+	endpoint := cm.PickNextEndpoint("fallback-health", ep1.ID)
+	if assert.NotNil(t, endpoint) {
+		assert.Equal(t, ep3.ID, endpoint.ID)
+	}
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(ep3.ID, ep3.Address.GetAddress(), false))
+	assert.Nil(t, cm.PickNextEndpoint("fallback-health", ep1.ID))
+}
+
 func TestClusterManager_GetEndpointByIDUsesRuntimeClusterMap(t *testing.T) {
 	runtimeConfig := testCluster("runtime-id-lookup", model.LoadBalancerRoundRobin, []*model.Endpoint{
 		testEndpoint("runtime-ep", "127.0.0.1", 18089),
@@ -116,6 +137,56 @@ func TestClusterManager_GetEndpointByIDUsesRuntimeClusterMap(t *testing.T) {
 
 	if assert.NotNil(t, endpoint) {
 		assert.Equal(t, "runtime-ep", endpoint.ID)
+	}
+}
+
+func TestClusterManager_PickEndpointUsesHealthySnapshot(t *testing.T) {
+	endpoint := testEndpoint("snapshot-ep", "127.0.0.1", 18088)
+	cm := testClusterManager(
+		testCluster("snapshot-pick", model.LoadBalancerRoundRobin, []*model.Endpoint{endpoint}),
+	)
+	runtimeCluster := cm.store.clustersMap["snapshot-pick"]
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	assert.False(t, endpoint.UnHealthy)
+	assert.Nil(t, cm.PickEndpoint("snapshot-pick", nil))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+	if picked := cm.PickEndpoint("snapshot-pick", nil); assert.NotNil(t, picked) {
+		assert.Equal(t, endpoint.ID, picked.ID)
+	}
+}
+
+func TestClusterManager_PickEndpointSingleHealthyInMultiEndpointUsesLoadBalancer(t *testing.T) {
+	ep1 := testEndpoint("snapshot-lb-1", "127.0.0.1", 18089)
+	ep2 := testEndpoint("snapshot-lb-2", "127.0.0.1", 18090)
+	config := testCluster("snapshot-lb-degraded", model.LoadBalancerRoundRobin, []*model.Endpoint{ep1, ep2})
+	cm := testClusterManager(config)
+	runtimeCluster := cm.store.clustersMap[config.Name]
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(ep1.ID, ep1.Address.GetAddress(), false))
+	picked := cm.PickEndpoint(config.Name, nil)
+
+	if assert.NotNil(t, picked) {
+		assert.Equal(t, ep2.ID, picked.ID)
+	}
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&config.PrePickEndpointIndex))
+}
+
+func TestClusterManager_GetEndpointByIDUsesHealthySnapshot(t *testing.T) {
+	endpoint := testEndpoint("snapshot-id-ep", "127.0.0.1", 18089)
+	cm := testClusterManager(
+		testCluster("snapshot-id", model.LoadBalancerRoundRobin, []*model.Endpoint{endpoint}),
+	)
+	runtimeCluster := cm.store.clustersMap["snapshot-id"]
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	assert.False(t, endpoint.UnHealthy)
+	assert.Nil(t, cm.GetEndpointByID("snapshot-id", endpoint.ID))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+	if got := cm.GetEndpointByID("snapshot-id", endpoint.ID); assert.NotNil(t, got) {
+		assert.Equal(t, endpoint.ID, got.ID)
 	}
 }
 
@@ -169,17 +240,27 @@ func TestClusterManager_CompareAndSetStorePreservesRoundRobinCursorAcrossRefresh
 		testEndpoint("ep-1", "127.0.0.1", 19200),
 		testEndpoint("ep-2", "127.0.0.1", 19201),
 		testEndpoint("ep-3", "127.0.0.1", 19202),
-	})
+	}, testHealthCheck())
 	cm := testClusterManager(cluster)
+	defer stopStoreRuntimes(cm.store)
 
 	const expectedCursor uint32 = 5
 	atomic.StoreUint32(&cm.store.Config[0].PrePickEndpointIndex, expectedCursor)
+	oldRuntime := cm.store.clustersMap[cluster.Name]
+	temporarilyUnhealthy := cluster.Endpoints[1]
+	assert.True(t, oldRuntime.UpdateEndpointHealth(
+		temporarilyUnhealthy.ID,
+		temporarilyUnhealthy.Address.GetAddress(),
+		false,
+	))
 
 	oldStore, err := cm.CloneStore()
 	if !assert.NoError(t, err) {
 		return
 	}
 	newStore := cm.NewStore(oldStore.Version)
+	defer stopStoreRuntimes(newStore)
+	newStore.AddCluster(testCluster(cluster.Name, model.LoadBalancerRoundRobin, nil, testHealthCheck()))
 	for _, endpoint := range oldStore.Config[0].Endpoints {
 		copied := *endpoint
 		newStore.SetEndpoint(cluster.Name, &copied)
@@ -189,6 +270,13 @@ func TestClusterManager_CompareAndSetStorePreservesRoundRobinCursorAcrossRefresh
 	if assert.Len(t, cm.store.Config, 1) {
 		assert.Equal(t, expectedCursor, atomic.LoadUint32(&cm.store.Config[0].PrePickEndpointIndex))
 	}
+	assert.Nil(t, cm.GetEndpointByID(cluster.Name, temporarilyUnhealthy.ID))
+	assert.False(t, oldRuntime.UpdateEndpointHealth(
+		temporarilyUnhealthy.ID,
+		temporarilyUnhealthy.Address.GetAddress(),
+		true,
+	))
+	assert.Nil(t, cm.GetEndpointByID(cluster.Name, temporarilyUnhealthy.ID))
 
 	endpoint := cm.PickEndpoint(cluster.Name, nil)
 	if assert.NotNil(t, endpoint) {
@@ -413,6 +501,18 @@ func TestClusterManager_SetEndpointUpdateRebuildsConsistentHash(t *testing.T) {
 			newHost := newEndpoint.GetHost()
 			cm.SetEndpoint(config.Name, newEndpoint)
 
+			runtime := cm.store.clustersMap[config.Name]
+			if assert.NotNil(t, runtime) {
+				runtimeEndpoint := runtime.EndpointSnapshot().EndpointByID(newEndpoint.ID)
+				if assert.NotNil(t, runtimeEndpoint) {
+					assert.Equal(t, newEndpoint.Address, runtimeEndpoint.Address)
+				}
+				healthyEndpoint := runtime.EndpointSnapshot().HealthyEndpointByID(newEndpoint.ID)
+				if assert.NotNil(t, healthyEndpoint) {
+					assert.Equal(t, newEndpoint.Address, healthyEndpoint.Address)
+				}
+			}
+
 			hash := cm.store.Config[0].ConsistentHash.Hash
 			if !assert.NotNil(t, hash) {
 				return
@@ -427,6 +527,43 @@ func TestClusterManager_SetEndpointUpdateRebuildsConsistentHash(t *testing.T) {
 			assert.True(t, hash.Remove(newHost))
 		})
 	}
+}
+
+func TestClusterManager_SetEndpointUpdateMergesWithoutMutatingOldEndpoint(t *testing.T) {
+	oldEndpoint := testEndpoint("ep-1", "127.0.0.1", 19345)
+	oldEndpoint.Metadata = map[string]string{"stable": "old"}
+	oldEndpoint.LLMMeta = &model.LLMMeta{
+		Provider: "openai",
+		APIKey:   "old-key",
+	}
+	oldEndpoint.UnHealthy = true
+	config := testCluster("endpoint-merge", model.LoadBalancerRoundRobin, []*model.Endpoint{oldEndpoint})
+	cm := testClusterManager(config)
+
+	incoming := testEndpoint("ep-1", "127.0.0.2", 19346)
+	incoming.Metadata = map[string]string{"discovered": "new"}
+	cm.SetEndpoint(config.Name, incoming)
+
+	if !assert.Len(t, config.Endpoints, 1) {
+		return
+	}
+	merged := config.Endpoints[0]
+	assert.NotSame(t, oldEndpoint, merged)
+	assert.NotSame(t, incoming, merged)
+	assert.Equal(t, incoming.ID, merged.ID)
+	assert.Equal(t, incoming.Name, merged.Name)
+	assert.Equal(t, incoming.Address, merged.Address)
+	assert.Equal(t, incoming.Metadata, merged.Metadata)
+	assert.Same(t, oldEndpoint.LLMMeta, merged.LLMMeta)
+	assert.True(t, merged.UnHealthy)
+
+	assert.Equal(t, "endpoint-ep-1", oldEndpoint.Name)
+	assert.Equal(t, model.SocketAddress{Address: "127.0.0.1", Port: 19345}, oldEndpoint.Address)
+	assert.Equal(t, map[string]string{"stable": "old"}, oldEndpoint.Metadata)
+
+	runtimeEndpoint := cm.store.clustersMap[config.Name].EndpointSnapshot().EndpointByID(incoming.ID)
+	assert.Same(t, merged, runtimeEndpoint)
+	assert.Nil(t, cm.store.clustersMap[config.Name].EndpointSnapshot().HealthyEndpointByID(incoming.ID))
 }
 
 func TestClusterManager_DeleteEndpointRepairsRuntimeAndConsistentHash(t *testing.T) {
@@ -459,6 +596,8 @@ func TestClusterManager_DeleteEndpointRepairsRuntimeAndConsistentHash(t *testing
 	if assert.Len(t, config.Endpoints, 1) {
 		assert.Same(t, remainingEndpoint, config.Endpoints[0])
 	}
+	assert.Equal(t, []*model.Endpoint{remainingEndpoint}, runtime.EndpointSnapshot().AllEndpoints())
+	assert.Equal(t, []*model.Endpoint{remainingEndpoint}, runtime.EndpointSnapshot().HealthyEndpoints())
 
 	hash := config.ConsistentHash.Hash
 	if !assert.NotNil(t, hash) {
@@ -495,6 +634,45 @@ func TestClusterManager_Race_RoundRobinPickEndpoint(t *testing.T) {
 			}
 		}()
 	}
+
+	close(start)
+	wg.Wait()
+}
+
+func TestClusterManager_Race_PickEndpointWithHealthUpdates(t *testing.T) {
+	cluster := testCluster("race-health-snapshot", model.LoadBalancerRoundRobin, []*model.Endpoint{
+		testEndpoint("ep-1", "127.0.0.1", 19400),
+		testEndpoint("ep-2", "127.0.0.1", 19401),
+		testEndpoint("ep-3", "127.0.0.1", 19402),
+		testEndpoint("ep-4", "127.0.0.1", 19403),
+	})
+	cm := testClusterManager(cluster)
+	runtimeCluster := cm.store.clustersMap[cluster.Name]
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 4000; j++ {
+				_ = cm.PickEndpoint(cluster.Name, nil)
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		target := cluster.Endpoints[0]
+		address := target.Address.GetAddress()
+		for j := 0; j < 4000; j++ {
+			_ = runtimeCluster.UpdateEndpointHealth(target.ID, address, j%2 == 0)
+		}
+	}()
 
 	close(start)
 	wg.Wait()

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -476,6 +476,32 @@ func TestClusterManager_SnapshotLoadBalancerReceivesAllEndpoints(t *testing.T) {
 	}
 }
 
+func TestClusterManager_PickEndpointToleratesNilEntryInAllEndpoints(t *testing.T) {
+	balancer := &serverSnapshotAllEndpointsLoadBalancer{}
+	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testSnapshotAllEndpointsLB]
+	loadbalancer.LoadBalancerStrategy[testSnapshotAllEndpointsLB] = balancer
+	t.Cleanup(func() {
+		if hadPrevious {
+			loadbalancer.LoadBalancerStrategy[testSnapshotAllEndpointsLB] = previous
+			return
+		}
+		delete(loadbalancer.LoadBalancerStrategy, testSnapshotAllEndpointsLB)
+	})
+
+	healthy := testEndpoint("snapshot-nil-tolerant-healthy", "127.0.0.1", 18099)
+	config := testCluster("snapshot-nil-tolerant", testSnapshotAllEndpointsLB, []*model.Endpoint{healthy, nil})
+	cm := testClusterManager(config)
+
+	picked := cm.PickEndpoint(config.Name, nil)
+	if assert.NotNil(t, picked) {
+		assert.Equal(t, healthy.ID, picked.ID)
+	}
+	if assert.Len(t, balancer.seenAll, 2) {
+		assert.NotNil(t, balancer.seenAll[0])
+		assert.Nil(t, balancer.seenAll[1])
+	}
+}
+
 func TestClusterManager_SnapshotLoadBalancerCannotMutateOrBypassHealthySnapshot(t *testing.T) {
 	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testSnapshotMutatingLB]
 	loadbalancer.LoadBalancerStrategy[testSnapshotMutatingLB] = serverSnapshotMutatingLoadBalancer{}

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 import (
@@ -31,12 +32,40 @@ import (
 
 import (
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster"
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"     // Register Maglev for cluster-manager tests.
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"       // Register Rand for cluster-manager tests.
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"   // Register RingHash for cluster-manager tests.
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin" // Register RoundRobin for cluster-manager tests.
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
+
+const (
+	testLegacyCompatibilityLockLB model.LbPolicyType = "test-legacy-compatibility-lock"
+	testLegacyScopedLockLB        model.LbPolicyType = "test-legacy-scoped-lock"
+)
+
+type serverBlockingLegacyLoadBalancer struct {
+	entered chan string
+	release chan struct{}
+}
+
+type serverClusterScopedBlockingLegacyLoadBalancer struct {
+	*serverBlockingLegacyLoadBalancer
+}
+
+func (b *serverBlockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	b.entered <- c.Name
+	<-b.release
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	return c.Endpoints[0]
+}
+
+func (b *serverClusterScopedBlockingLegacyLoadBalancer) UseClusterScopedLegacyLock() bool {
+	return true
+}
 
 func TestClusterManager(t *testing.T) {
 	cm := testClusterManager(
@@ -678,6 +707,172 @@ func TestClusterManager_Race_PickEndpointWithHealthUpdates(t *testing.T) {
 	wg.Wait()
 }
 
+func TestClusterManager_LegacyLoadBalancerPicksUseCompatibilityLockAcrossClusters(t *testing.T) {
+	balancer := &serverBlockingLegacyLoadBalancer{
+		entered: make(chan string, 2),
+		release: make(chan struct{}),
+	}
+	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testLegacyCompatibilityLockLB]
+	loadbalancer.LoadBalancerStrategy[testLegacyCompatibilityLockLB] = balancer
+	t.Cleanup(func() {
+		if hadPrevious {
+			loadbalancer.LoadBalancerStrategy[testLegacyCompatibilityLockLB] = previous
+			return
+		}
+		delete(loadbalancer.LoadBalancerStrategy, testLegacyCompatibilityLockLB)
+	})
+
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() {
+			close(balancer.release)
+		})
+	})
+
+	cm := testClusterManager(
+		testCluster("legacy-cluster-a", testLegacyCompatibilityLockLB, []*model.Endpoint{
+			testEndpoint("legacy-a-1", "127.0.0.1", 19500),
+			testEndpoint("legacy-a-2", "127.0.0.1", 19501),
+		}),
+		testCluster("legacy-cluster-b", testLegacyCompatibilityLockLB, []*model.Endpoint{
+			testEndpoint("legacy-b-1", "127.0.0.1", 19502),
+			testEndpoint("legacy-b-2", "127.0.0.1", 19503),
+		}),
+	)
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_ = cm.PickEndpoint("legacy-cluster-a", nil)
+	}()
+	assert.Equal(t, "legacy-cluster-a", waitServerLegacyHandlerEntry(t, balancer.entered))
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = cm.PickEndpoint("legacy-cluster-b", nil)
+	}()
+
+	assertNoServerLegacyHandlerEntry(t, balancer.entered)
+
+	releaseOnce.Do(func() {
+		close(balancer.release)
+	})
+	assert.Equal(t, "legacy-cluster-b", waitServerLegacyHandlerEntry(t, balancer.entered))
+	waitServerClosed(t, firstDone)
+	waitServerClosed(t, secondDone)
+}
+
+func TestClusterManager_OptInLegacyLoadBalancerPicksUseRuntimeScopedLocksAcrossClusters(t *testing.T) {
+	balancer := &serverClusterScopedBlockingLegacyLoadBalancer{
+		serverBlockingLegacyLoadBalancer: &serverBlockingLegacyLoadBalancer{
+			entered: make(chan string, 2),
+			release: make(chan struct{}),
+		},
+	}
+	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB]
+	loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB] = balancer
+	t.Cleanup(func() {
+		if hadPrevious {
+			loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB] = previous
+			return
+		}
+		delete(loadbalancer.LoadBalancerStrategy, testLegacyScopedLockLB)
+	})
+
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() {
+			close(balancer.release)
+		})
+	})
+
+	cm := testClusterManager(
+		testCluster("legacy-cluster-a", testLegacyScopedLockLB, []*model.Endpoint{
+			testEndpoint("legacy-a-1", "127.0.0.1", 19500),
+			testEndpoint("legacy-a-2", "127.0.0.1", 19501),
+		}),
+		testCluster("legacy-cluster-b", testLegacyScopedLockLB, []*model.Endpoint{
+			testEndpoint("legacy-b-1", "127.0.0.1", 19502),
+			testEndpoint("legacy-b-2", "127.0.0.1", 19503),
+		}),
+	)
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_ = cm.PickEndpoint("legacy-cluster-a", nil)
+	}()
+	assert.Equal(t, "legacy-cluster-a", waitServerLegacyHandlerEntry(t, balancer.entered))
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = cm.PickEndpoint("legacy-cluster-b", nil)
+	}()
+	assert.Equal(t, "legacy-cluster-b", waitServerLegacyHandlerEntry(t, balancer.entered))
+
+	releaseOnce.Do(func() {
+		close(balancer.release)
+	})
+	waitServerClosed(t, firstDone)
+	waitServerClosed(t, secondDone)
+}
+
+func TestClusterManager_OptInLegacyLoadBalancerPicksSerializeWithinSameCluster(t *testing.T) {
+	balancer := &serverClusterScopedBlockingLegacyLoadBalancer{
+		serverBlockingLegacyLoadBalancer: &serverBlockingLegacyLoadBalancer{
+			entered: make(chan string, 2),
+			release: make(chan struct{}),
+		},
+	}
+	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB]
+	loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB] = balancer
+	t.Cleanup(func() {
+		if hadPrevious {
+			loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB] = previous
+			return
+		}
+		delete(loadbalancer.LoadBalancerStrategy, testLegacyScopedLockLB)
+	})
+
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() {
+			close(balancer.release)
+		})
+	})
+
+	cm := testClusterManager(
+		testCluster("legacy-cluster-a", testLegacyScopedLockLB, []*model.Endpoint{
+			testEndpoint("legacy-a-1", "127.0.0.1", 19500),
+			testEndpoint("legacy-a-2", "127.0.0.1", 19501),
+		}),
+	)
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_ = cm.PickEndpoint("legacy-cluster-a", nil)
+	}()
+	assert.Equal(t, "legacy-cluster-a", waitServerLegacyHandlerEntry(t, balancer.entered))
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = cm.PickEndpoint("legacy-cluster-a", nil)
+	}()
+
+	assertNoServerLegacyHandlerEntry(t, balancer.entered)
+
+	releaseOnce.Do(func() {
+		close(balancer.release)
+	})
+	assert.Equal(t, "legacy-cluster-a", waitServerLegacyHandlerEntry(t, balancer.entered))
+	waitServerClosed(t, firstDone)
+	waitServerClosed(t, secondDone)
+}
+
 func testClusterManager(clusters ...*model.ClusterConfig) *ClusterManager {
 	return CreateDefaultClusterManager(&model.Bootstrap{
 		StaticResources: model.StaticResources{
@@ -733,4 +928,33 @@ func healthCheckersLen(runtime *cluster.Cluster) int {
 		return 0
 	}
 	return reflect.ValueOf(runtime.HealthCheck).Elem().FieldByName("checkers").Len()
+}
+
+func waitServerLegacyHandlerEntry(t *testing.T, entered <-chan string) string {
+	t.Helper()
+	select {
+	case clusterName := <-entered:
+		return clusterName
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for legacy handler entry")
+		return ""
+	}
+}
+
+func assertNoServerLegacyHandlerEntry(t *testing.T, entered <-chan string) {
+	t.Helper()
+	select {
+	case clusterName := <-entered:
+		t.Fatalf("legacy handler for %s entered before the first cluster pick returned", clusterName)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func waitServerClosed(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for legacy pick to finish")
+	}
 }

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -43,6 +43,7 @@ import (
 const (
 	testLegacyCompatibilityLockLB model.LbPolicyType = "test-legacy-compatibility-lock"
 	testLegacyScopedLockLB        model.LbPolicyType = "test-legacy-scoped-lock"
+	testLegacyHealthFilteringLB   model.LbPolicyType = "test-legacy-health-filtering"
 )
 
 type serverBlockingLegacyLoadBalancer struct {
@@ -53,6 +54,8 @@ type serverBlockingLegacyLoadBalancer struct {
 type serverClusterScopedBlockingLegacyLoadBalancer struct {
 	*serverBlockingLegacyLoadBalancer
 }
+
+type serverHealthFilteringLegacyLoadBalancer struct{}
 
 type serverLegacyPickHarness struct {
 	t           *testing.T
@@ -71,6 +74,14 @@ func (b *serverBlockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ mod
 
 func (b *serverClusterScopedBlockingLegacyLoadBalancer) UseClusterScopedLegacyLock() bool {
 	return true
+}
+
+func (serverHealthFilteringLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	endpoints := c.GetEndpoint(true)
+	if len(endpoints) == 0 {
+		return nil
+	}
+	return endpoints[0]
 }
 
 func registerServerLegacyBalancer(t *testing.T, policy model.LbPolicyType, scoped bool) *serverLegacyPickHarness {
@@ -252,6 +263,34 @@ func TestClusterManager_PickEndpointUsesHealthySnapshot(t *testing.T) {
 	if picked := cm.PickEndpoint("snapshot-pick", nil); assert.NotNil(t, picked) {
 		assert.Equal(t, endpoint.ID, picked.ID)
 	}
+}
+
+func TestClusterManager_PickEndpointLegacyLBSeesRestoredRuntimeHealth(t *testing.T) {
+	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testLegacyHealthFilteringLB]
+	loadbalancer.LoadBalancerStrategy[testLegacyHealthFilteringLB] = serverHealthFilteringLegacyLoadBalancer{}
+	t.Cleanup(func() {
+		if hadPrevious {
+			loadbalancer.LoadBalancerStrategy[testLegacyHealthFilteringLB] = previous
+			return
+		}
+		delete(loadbalancer.LoadBalancerStrategy, testLegacyHealthFilteringLB)
+	})
+
+	restored := testEndpoint("snapshot-restored", "127.0.0.1", 18088)
+	restored.UnHealthy = true
+	fallback := testEndpoint("snapshot-fallback", "127.0.0.1", 18089)
+	config := testCluster("snapshot-legacy-health", testLegacyHealthFilteringLB, []*model.Endpoint{restored, fallback})
+	cm := testClusterManager(config)
+	runtimeCluster := cm.store.clustersMap[config.Name]
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(restored.ID, restored.Address.GetAddress(), true))
+
+	picked := cm.PickEndpoint(config.Name, nil)
+	if assert.NotNil(t, picked) {
+		assert.Equal(t, restored.ID, picked.ID)
+		assert.False(t, picked.UnHealthy)
+	}
+	assert.True(t, restored.UnHealthy)
 }
 
 func TestClusterManager_PickEndpointSingleHealthyInMultiEndpointUsesLoadBalancer(t *testing.T) {

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -44,6 +44,8 @@ const (
 	testLegacyCompatibilityLockLB model.LbPolicyType = "test-legacy-compatibility-lock"
 	testLegacyScopedLockLB        model.LbPolicyType = "test-legacy-scoped-lock"
 	testLegacyHealthFilteringLB   model.LbPolicyType = "test-legacy-health-filtering"
+	testSnapshotAllEndpointsLB    model.LbPolicyType = "test-snapshot-all-endpoints"
+	testSnapshotMutatingLB        model.LbPolicyType = "test-snapshot-mutating"
 )
 
 type serverBlockingLegacyLoadBalancer struct {
@@ -56,6 +58,13 @@ type serverClusterScopedBlockingLegacyLoadBalancer struct {
 }
 
 type serverHealthFilteringLegacyLoadBalancer struct{}
+
+type serverSnapshotAllEndpointsLoadBalancer struct {
+	seenAll     []*model.Endpoint
+	seenHealthy []*model.Endpoint
+}
+
+type serverSnapshotMutatingLoadBalancer struct{}
 
 type serverLegacyPickHarness struct {
 	t           *testing.T
@@ -82,6 +91,33 @@ func (serverHealthFilteringLegacyLoadBalancer) Handler(c *model.ClusterConfig, _
 		return nil
 	}
 	return endpoints[0]
+}
+
+func (b *serverSnapshotAllEndpointsLoadBalancer) Handler(_ *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (b *serverSnapshotAllEndpointsLoadBalancer) HandlerWithSnapshot(c loadbalancer.PickContext, _ model.LbPolicy) *model.Endpoint {
+	b.seenAll = c.AllEndpoints
+	b.seenHealthy = c.HealthyEndpoints
+	if len(c.HealthyEndpoints) == 0 {
+		return nil
+	}
+	return c.HealthyEndpoints[0]
+}
+
+func (serverSnapshotMutatingLoadBalancer) Handler(_ *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (serverSnapshotMutatingLoadBalancer) HandlerWithSnapshot(c loadbalancer.PickContext, _ model.LbPolicy) *model.Endpoint {
+	if len(c.HealthyEndpoints) > 0 {
+		c.HealthyEndpoints[0].Metadata["weight"] = "99"
+	}
+	if len(c.AllEndpoints) > 1 {
+		return c.AllEndpoints[1]
+	}
+	return nil
 }
 
 func registerServerLegacyBalancer(t *testing.T, policy model.LbPolicyType, scoped bool) *serverLegacyPickHarness {
@@ -164,6 +200,77 @@ func TestClusterManager(t *testing.T) {
 	cm.SetEndpoint("test2", testEndpoint("2", "127.0.0.1", 18082))
 	assert.Equal(t, "1", cm.PickEndpoint("test", nil).ID)
 	cm.DeleteEndpoint("test2", "1")
+}
+
+func TestClusterManagerRepairsDuplicateEndpointIDsBeforeRuntimeSnapshot(t *testing.T) {
+	first := testEndpoint("duplicate", "127.0.0.1", 18082)
+	second := testEndpoint("duplicate", "127.0.0.2", 18083)
+	config := testCluster("duplicate-endpoint-id", model.LoadBalancerRoundRobin, []*model.Endpoint{first, second})
+	cm := testClusterManager(config)
+
+	if !assert.Len(t, config.Endpoints, 2) {
+		return
+	}
+	assert.Equal(t, "duplicate", first.ID)
+	assert.NotEmpty(t, second.ID)
+	assert.NotEqual(t, first.ID, second.ID)
+
+	runtimeCluster := cm.store.clustersMap[config.Name]
+	if !assert.NotNil(t, runtimeCluster) {
+		return
+	}
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(first.ID, first.Address.GetAddress(), false))
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(second.ID, second.Address.GetAddress(), false))
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+	assert.NotNil(t, runtimeCluster.EndpointSnapshot().EndpointByID(first.ID))
+	assert.NotNil(t, runtimeCluster.EndpointSnapshot().EndpointByID(second.ID))
+}
+
+func TestClusterManager_SetEndpointFreshAnonymousEndpointUpdatesStableEndpoint(t *testing.T) {
+	config := testCluster("set-anonymous-endpoint", model.LoadBalancerRoundRobin, nil)
+	cm := testClusterManager(config)
+
+	first := testEndpoint("", "127.0.0.1", 18084)
+	first.Metadata = map[string]string{"version": "1"}
+	cm.SetEndpoint(config.Name, first)
+	firstID := first.ID
+	assert.NotEmpty(t, firstID)
+
+	second := testEndpoint("", "127.0.0.1", 18084)
+	second.Metadata = map[string]string{"version": "2"}
+	cm.SetEndpoint(config.Name, second)
+
+	if assert.Len(t, config.Endpoints, 1) {
+		assert.Equal(t, firstID, config.Endpoints[0].ID)
+		assert.Equal(t, map[string]string{"version": "2"}, config.Endpoints[0].Metadata)
+	}
+	snapshot := cm.store.clustersMap[config.Name].EndpointSnapshot()
+	assert.Len(t, snapshot.AllEndpoints(), 1)
+	if picked := cm.PickEndpoint(config.Name, nil); assert.NotNil(t, picked) {
+		assert.Equal(t, firstID, picked.ID)
+		assert.Equal(t, map[string]string{"version": "2"}, picked.Metadata)
+	}
+}
+
+func TestClusterManager_SetEndpointAnonymousIDAvoidsExistingExplicitGeneratedID(t *testing.T) {
+	clusterName := "set-anonymous-id-collision"
+	incoming := testEndpoint("", "127.0.0.2", 18085)
+	collidingID := model.GeneratedEndpointID(clusterName, incoming)
+	existing := testEndpoint(collidingID, "127.0.0.1", 18084)
+	config := testCluster(clusterName, model.LoadBalancerRoundRobin, []*model.Endpoint{existing})
+	cm := testClusterManager(config)
+
+	cm.SetEndpoint(config.Name, incoming)
+
+	if !assert.Len(t, config.Endpoints, 2) {
+		return
+	}
+	assert.Equal(t, collidingID, config.Endpoints[0].ID)
+	assert.Equal(t, model.SocketAddress{Address: "127.0.0.1", Port: 18084}, config.Endpoints[0].Address)
+	assert.NotEmpty(t, incoming.ID)
+	assert.NotEqual(t, collidingID, incoming.ID)
+	assert.Equal(t, incoming.ID, config.Endpoints[1].ID)
+	assert.Equal(t, model.SocketAddress{Address: "127.0.0.2", Port: 18085}, config.Endpoints[1].Address)
 }
 
 func TestClusterManager_PickEndpointReturnsNilForMissingCluster(t *testing.T) {
@@ -265,6 +372,33 @@ func TestClusterManager_PickEndpointUsesHealthySnapshot(t *testing.T) {
 	}
 }
 
+func TestClusterManager_PickEndpointSkipsSameAddressEndpointsAfterAddressHealthEvent(t *testing.T) {
+	first := testEndpoint("snapshot-shared-address-1", "127.0.0.1", 18088)
+	second := testEndpoint("snapshot-shared-address-2", "127.0.0.1", 18088)
+	fallback := testEndpoint("snapshot-shared-address-fallback", "127.0.0.1", 18089)
+	config := testCluster("snapshot-shared-address", model.LoadBalancerRoundRobin, []*model.Endpoint{
+		first,
+		second,
+		fallback,
+	})
+	cm := testClusterManager(config)
+	runtimeCluster := cm.store.clustersMap[config.Name]
+
+	assert.True(t, runtimeCluster.UpdateEndpointAddressHealth(first.Address.GetAddress(), false))
+	assert.Nil(t, cm.GetHealthyEndpointByID(config.Name, first.ID))
+	assert.Nil(t, cm.GetHealthyEndpointByID(config.Name, second.ID))
+	assert.NotNil(t, cm.GetHealthyEndpointByID(config.Name, fallback.ID))
+
+	picked := cm.PickEndpoint(config.Name, nil)
+	if assert.NotNil(t, picked) {
+		assert.Equal(t, fallback.ID, picked.ID)
+	}
+
+	assert.True(t, runtimeCluster.UpdateEndpointAddressHealth(first.Address.GetAddress(), true))
+	assert.NotNil(t, cm.GetHealthyEndpointByID(config.Name, first.ID))
+	assert.NotNil(t, cm.GetHealthyEndpointByID(config.Name, second.ID))
+}
+
 func TestClusterManager_PickEndpointLegacyLBSeesRestoredRuntimeHealth(t *testing.T) {
 	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testLegacyHealthFilteringLB]
 	loadbalancer.LoadBalancerStrategy[testLegacyHealthFilteringLB] = serverHealthFilteringLegacyLoadBalancer{}
@@ -309,6 +443,66 @@ func TestClusterManager_PickEndpointSingleHealthyInMultiEndpointUsesLoadBalancer
 	assert.Equal(t, uint32(1), atomic.LoadUint32(&config.PrePickEndpointIndex))
 }
 
+func TestClusterManager_SnapshotLoadBalancerReceivesAllEndpoints(t *testing.T) {
+	balancer := &serverSnapshotAllEndpointsLoadBalancer{}
+	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testSnapshotAllEndpointsLB]
+	loadbalancer.LoadBalancerStrategy[testSnapshotAllEndpointsLB] = balancer
+	t.Cleanup(func() {
+		if hadPrevious {
+			loadbalancer.LoadBalancerStrategy[testSnapshotAllEndpointsLB] = previous
+			return
+		}
+		delete(loadbalancer.LoadBalancerStrategy, testSnapshotAllEndpointsLB)
+	})
+
+	healthy := testEndpoint("snapshot-all-healthy", "127.0.0.1", 18091)
+	unhealthy := testEndpoint("snapshot-all-unhealthy", "127.0.0.1", 18092)
+	config := testCluster("snapshot-all-endpoints", testSnapshotAllEndpointsLB, []*model.Endpoint{healthy, unhealthy})
+	cm := testClusterManager(config)
+	runtimeCluster := cm.store.clustersMap[config.Name]
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(unhealthy.ID, unhealthy.Address.GetAddress(), false))
+	picked := cm.PickEndpoint(config.Name, nil)
+
+	if assert.NotNil(t, picked) {
+		assert.Equal(t, healthy.ID, picked.ID)
+	}
+	assert.Equal(t, []*model.Endpoint{healthy}, balancer.seenHealthy)
+	if assert.Len(t, balancer.seenAll, 2) {
+		assert.Equal(t, healthy.ID, balancer.seenAll[0].ID)
+		assert.False(t, balancer.seenAll[0].UnHealthy)
+		assert.Equal(t, unhealthy.ID, balancer.seenAll[1].ID)
+		assert.True(t, balancer.seenAll[1].UnHealthy)
+	}
+}
+
+func TestClusterManager_SnapshotLoadBalancerCannotMutateOrBypassHealthySnapshot(t *testing.T) {
+	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testSnapshotMutatingLB]
+	loadbalancer.LoadBalancerStrategy[testSnapshotMutatingLB] = serverSnapshotMutatingLoadBalancer{}
+	t.Cleanup(func() {
+		if hadPrevious {
+			loadbalancer.LoadBalancerStrategy[testSnapshotMutatingLB] = previous
+			return
+		}
+		delete(loadbalancer.LoadBalancerStrategy, testSnapshotMutatingLB)
+	})
+
+	healthy := testEndpoint("snapshot-safe-healthy", "127.0.0.1", 18093)
+	healthy.Metadata = map[string]string{"weight": "1"}
+	unhealthy := testEndpoint("snapshot-safe-unhealthy", "127.0.0.1", 18094)
+	config := testCluster("snapshot-safe", testSnapshotMutatingLB, []*model.Endpoint{healthy, unhealthy})
+	cm := testClusterManager(config)
+	runtimeCluster := cm.store.clustersMap[config.Name]
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(unhealthy.ID, unhealthy.Address.GetAddress(), false))
+	assert.Nil(t, cm.PickEndpoint(config.Name, nil))
+
+	if got := runtimeCluster.EndpointSnapshot().HealthyEndpointByID(healthy.ID); assert.NotNil(t, got) {
+		assert.Equal(t, map[string]string{"weight": "1"}, got.Metadata)
+	}
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(unhealthy.ID))
+}
+
 func TestClusterManager_GetEndpointByIDUsesHealthySnapshot(t *testing.T) {
 	endpoint := testEndpoint("snapshot-id-ep", "127.0.0.1", 18089)
 	cm := testClusterManager(
@@ -320,6 +514,10 @@ func TestClusterManager_GetEndpointByIDUsesHealthySnapshot(t *testing.T) {
 	assert.False(t, endpoint.UnHealthy)
 	assert.Nil(t, cm.GetEndpointByID("snapshot-id", endpoint.ID))
 	assert.Nil(t, cm.GetHealthyEndpointByID("snapshot-id", endpoint.ID))
+	if got := cm.GetAnyEndpointByID("snapshot-id", endpoint.ID); assert.NotNil(t, got) {
+		assert.Equal(t, endpoint.ID, got.ID)
+		assert.True(t, got.UnHealthy)
+	}
 	if got := runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID); assert.NotNil(t, got) {
 		assert.Equal(t, endpoint.ID, got.ID)
 	}
@@ -430,6 +628,75 @@ func TestClusterManager_CompareAndSetStorePreservesRoundRobinCursorAcrossRefresh
 	if assert.NotNil(t, endpoint) {
 		assert.Equal(t, "ep-3", endpoint.ID)
 	}
+}
+
+func TestClusterManager_CompareAndSetStorePreservesAnonymousEndpointHealthAcrossRefresh(t *testing.T) {
+	initialEndpoint := testEndpoint("", "127.0.0.1", 19203)
+	cluster := testCluster("refresh-anonymous-health", model.LoadBalancerRoundRobin, []*model.Endpoint{
+		initialEndpoint,
+	}, testHealthCheck())
+	cm := testClusterManager(cluster)
+	defer stopStoreRuntimes(cm.store)
+
+	initialID := initialEndpoint.ID
+	assert.NotEmpty(t, initialID)
+
+	oldRuntime := cm.store.clustersMap[cluster.Name]
+	assert.True(t, oldRuntime.UpdateEndpointHealth(
+		initialID,
+		initialEndpoint.Address.GetAddress(),
+		false,
+	))
+
+	newStore := cm.NewStore(cm.store.Version)
+	defer stopStoreRuntimes(newStore)
+	refreshedEndpoint := testEndpoint("", "127.0.0.1", 19203)
+	refreshedEndpoint.Name = "renamed-endpoint"
+	newStore.AddCluster(testCluster(cluster.Name, model.LoadBalancerRoundRobin, []*model.Endpoint{
+		refreshedEndpoint,
+	}, testHealthCheck()))
+	assert.Equal(t, initialID, refreshedEndpoint.ID)
+
+	assert.True(t, cm.CompareAndSetStore(newStore))
+	assert.Nil(t, cm.GetHealthyEndpointByID(cluster.Name, initialID))
+	if got := cm.store.clustersMap[cluster.Name].EndpointSnapshot().EndpointByID(initialID); assert.NotNil(t, got) {
+		assert.True(t, got.UnHealthy)
+	}
+}
+
+func TestClusterManager_GeneratedEndpointIDsIncludeLLMIdentity(t *testing.T) {
+	first := testLLMIdentityEndpoint("127.0.0.1", 19204, "openai", "key-a")
+	second := testLLMIdentityEndpoint("127.0.0.1", 19204, "openai", "key-b")
+	cluster := testCluster("refresh-llm-identity", model.LoadBalancerRoundRobin, []*model.Endpoint{
+		first,
+		second,
+	}, testHealthCheck())
+	cm := testClusterManager(cluster)
+	defer stopStoreRuntimes(cm.store)
+
+	firstID := first.ID
+	secondID := second.ID
+	assert.NotEmpty(t, firstID)
+	assert.NotEmpty(t, secondID)
+	assert.NotEqual(t, firstID, secondID)
+
+	oldRuntime := cm.store.clustersMap[cluster.Name]
+	assert.True(t, oldRuntime.UpdateEndpointHealth(secondID, second.Address.GetAddress(), false))
+
+	newStore := cm.NewStore(cm.store.Version)
+	defer stopStoreRuntimes(newStore)
+	refreshedSecond := testLLMIdentityEndpoint("127.0.0.1", 19204, "openai", "key-b")
+	refreshedFirst := testLLMIdentityEndpoint("127.0.0.1", 19204, "openai", "key-a")
+	newStore.AddCluster(testCluster(cluster.Name, model.LoadBalancerRoundRobin, []*model.Endpoint{
+		refreshedSecond,
+		refreshedFirst,
+	}, testHealthCheck()))
+
+	assert.Equal(t, secondID, refreshedSecond.ID)
+	assert.Equal(t, firstID, refreshedFirst.ID)
+	assert.True(t, cm.CompareAndSetStore(newStore))
+	assert.Nil(t, cm.GetHealthyEndpointByID(cluster.Name, secondID))
+	assert.NotNil(t, cm.GetHealthyEndpointByID(cluster.Name, firstID))
 }
 
 func TestClusterManager_UpdateClusterRebuildsRuntimeCluster(t *testing.T) {
@@ -920,6 +1187,16 @@ func testEndpoint(id string, host string, port int) *model.Endpoint {
 			Port:    port,
 		},
 	}
+}
+
+func testLLMIdentityEndpoint(host string, port int, provider, apiKey string) *model.Endpoint {
+	endpoint := testEndpoint("", host, port)
+	endpoint.Name = "shared-llm"
+	endpoint.LLMMeta = &model.LLMMeta{
+		Provider: provider,
+		APIKey:   apiKey,
+	}
+	return endpoint
 }
 
 func testHealthCheck() model.HealthCheckConfig {

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -280,9 +280,16 @@ func TestClusterManager_GetEndpointByIDUsesHealthySnapshot(t *testing.T) {
 	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
 	assert.False(t, endpoint.UnHealthy)
 	assert.Nil(t, cm.GetEndpointByID("snapshot-id", endpoint.ID))
+	assert.Nil(t, cm.GetHealthyEndpointByID("snapshot-id", endpoint.ID))
+	if got := runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID); assert.NotNil(t, got) {
+		assert.Equal(t, endpoint.ID, got.ID)
+	}
 
 	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
 	if got := cm.GetEndpointByID("snapshot-id", endpoint.ID); assert.NotNil(t, got) {
+		assert.Equal(t, endpoint.ID, got.ID)
+	}
+	if got := cm.GetHealthyEndpointByID("snapshot-id", endpoint.ID); assert.NotNil(t, got) {
 		assert.Equal(t, endpoint.ID, got.ID)
 	}
 }
@@ -368,12 +375,17 @@ func TestClusterManager_CompareAndSetStorePreservesRoundRobinCursorAcrossRefresh
 		assert.Equal(t, expectedCursor, atomic.LoadUint32(&cm.store.Config[0].PrePickEndpointIndex))
 	}
 	assert.Nil(t, cm.GetEndpointByID(cluster.Name, temporarilyUnhealthy.ID))
+	assert.Nil(t, cm.GetHealthyEndpointByID(cluster.Name, temporarilyUnhealthy.ID))
+	if got := cm.store.clustersMap[cluster.Name].EndpointSnapshot().EndpointByID(temporarilyUnhealthy.ID); assert.NotNil(t, got) {
+		assert.Equal(t, temporarilyUnhealthy.ID, got.ID)
+	}
 	assert.False(t, oldRuntime.UpdateEndpointHealth(
 		temporarilyUnhealthy.ID,
 		temporarilyUnhealthy.Address.GetAddress(),
 		true,
 	))
 	assert.Nil(t, cm.GetEndpointByID(cluster.Name, temporarilyUnhealthy.ID))
+	assert.Nil(t, cm.GetHealthyEndpointByID(cluster.Name, temporarilyUnhealthy.ID))
 
 	endpoint := cm.PickEndpoint(cluster.Name, nil)
 	if assert.NotNil(t, endpoint) {
@@ -668,7 +680,8 @@ func TestClusterManager_SetEndpointUpdateMergesWithoutMutatingOldEndpoint(t *tes
 	assert.Equal(t, map[string]string{"stable": "old"}, oldEndpoint.Metadata)
 
 	runtimeEndpoint := cm.store.clustersMap[config.Name].EndpointSnapshot().EndpointByID(incoming.ID)
-	assert.Same(t, merged, runtimeEndpoint)
+	assert.NotSame(t, merged, runtimeEndpoint)
+	assert.Equal(t, merged, runtimeEndpoint)
 	assert.Nil(t, cm.store.clustersMap[config.Name].EndpointSnapshot().HealthyEndpointByID(incoming.ID))
 }
 

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -54,6 +54,12 @@ type serverClusterScopedBlockingLegacyLoadBalancer struct {
 	*serverBlockingLegacyLoadBalancer
 }
 
+type serverLegacyPickHarness struct {
+	t           *testing.T
+	balancer    *serverBlockingLegacyLoadBalancer
+	releaseOnce sync.Once
+}
+
 func (b *serverBlockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
 	b.entered <- c.Name
 	<-b.release
@@ -65,6 +71,68 @@ func (b *serverBlockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ mod
 
 func (b *serverClusterScopedBlockingLegacyLoadBalancer) UseClusterScopedLegacyLock() bool {
 	return true
+}
+
+func registerServerLegacyBalancer(t *testing.T, policy model.LbPolicyType, scoped bool) *serverLegacyPickHarness {
+	t.Helper()
+	blocking := &serverBlockingLegacyLoadBalancer{
+		entered: make(chan string, 2),
+		release: make(chan struct{}),
+	}
+	var registered loadbalancer.LoadBalancer = blocking
+	if scoped {
+		registered = &serverClusterScopedBlockingLegacyLoadBalancer{
+			serverBlockingLegacyLoadBalancer: blocking,
+		}
+	}
+
+	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[policy]
+	loadbalancer.LoadBalancerStrategy[policy] = registered
+	harness := &serverLegacyPickHarness{
+		t:        t,
+		balancer: blocking,
+	}
+	t.Cleanup(func() {
+		harness.release()
+		if hadPrevious {
+			loadbalancer.LoadBalancerStrategy[policy] = previous
+			return
+		}
+		delete(loadbalancer.LoadBalancerStrategy, policy)
+	})
+	return harness
+}
+
+func testLegacyLockCluster(name string, policy model.LbPolicyType, portBase int) *model.ClusterConfig {
+	return testCluster(name, policy, []*model.Endpoint{
+		testEndpoint(name+"-1", "127.0.0.1", portBase),
+		testEndpoint(name+"-2", "127.0.0.1", portBase+1),
+	})
+}
+
+func startServerPick(cm *ClusterManager, clusterName string) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = cm.PickEndpoint(clusterName, nil)
+	}()
+	return done
+}
+
+func (h *serverLegacyPickHarness) release() {
+	h.releaseOnce.Do(func() {
+		close(h.balancer.release)
+	})
+}
+
+func (h *serverLegacyPickHarness) waitEntry() string {
+	h.t.Helper()
+	return waitServerLegacyHandlerEntry(h.t, h.balancer.entered)
+}
+
+func (h *serverLegacyPickHarness) assertNoEntry() {
+	h.t.Helper()
+	assertNoServerLegacyHandlerEntry(h.t, h.balancer.entered)
 }
 
 func TestClusterManager(t *testing.T) {
@@ -530,32 +598,41 @@ func TestClusterManager_SetEndpointUpdateRebuildsConsistentHash(t *testing.T) {
 			newHost := newEndpoint.GetHost()
 			cm.SetEndpoint(config.Name, newEndpoint)
 
-			runtime := cm.store.clustersMap[config.Name]
-			if assert.NotNil(t, runtime) {
-				runtimeEndpoint := runtime.EndpointSnapshot().EndpointByID(newEndpoint.ID)
-				if assert.NotNil(t, runtimeEndpoint) {
-					assert.Equal(t, newEndpoint.Address, runtimeEndpoint.Address)
-				}
-				healthyEndpoint := runtime.EndpointSnapshot().HealthyEndpointByID(newEndpoint.ID)
-				if assert.NotNil(t, healthyEndpoint) {
-					assert.Equal(t, newEndpoint.Address, healthyEndpoint.Address)
-				}
-			}
-
-			hash := cm.store.Config[0].ConsistentHash.Hash
-			if !assert.NotNil(t, hash) {
-				return
-			}
-			if hostList, ok := hash.(interface{ Hosts() []string }); ok {
-				hosts := hostList.Hosts()
-				assert.NotContains(t, hosts, oldHost)
-				assert.Contains(t, hosts, newHost)
-				return
-			}
-			assert.False(t, hash.Remove(oldHost))
-			assert.True(t, hash.Remove(newHost))
+			assertRuntimeEndpointAddress(t, cm.store.clustersMap[config.Name], newEndpoint)
+			assertConsistentHashRebuilt(t, cm.store.Config[0].ConsistentHash.Hash, oldHost, newHost)
 		})
 	}
+}
+
+func assertRuntimeEndpointAddress(t *testing.T, runtime *cluster.Cluster, endpoint *model.Endpoint) {
+	t.Helper()
+	if !assert.NotNil(t, runtime) {
+		return
+	}
+	snapshot := runtime.EndpointSnapshot()
+	runtimeEndpoint := snapshot.EndpointByID(endpoint.ID)
+	if assert.NotNil(t, runtimeEndpoint) {
+		assert.Equal(t, endpoint.Address, runtimeEndpoint.Address)
+	}
+	healthyEndpoint := snapshot.HealthyEndpointByID(endpoint.ID)
+	if assert.NotNil(t, healthyEndpoint) {
+		assert.Equal(t, endpoint.Address, healthyEndpoint.Address)
+	}
+}
+
+func assertConsistentHashRebuilt(t *testing.T, hash model.LbConsistentHash, oldHost, newHost string) {
+	t.Helper()
+	if !assert.NotNil(t, hash) {
+		return
+	}
+	if hostList, ok := hash.(interface{ Hosts() []string }); ok {
+		hosts := hostList.Hosts()
+		assert.NotContains(t, hosts, oldHost)
+		assert.Contains(t, hosts, newHost)
+		return
+	}
+	assert.False(t, hash.Remove(oldHost))
+	assert.True(t, hash.Remove(newHost))
 }
 
 func TestClusterManager_SetEndpointUpdateMergesWithoutMutatingOldEndpoint(t *testing.T) {
@@ -708,167 +785,56 @@ func TestClusterManager_Race_PickEndpointWithHealthUpdates(t *testing.T) {
 }
 
 func TestClusterManager_LegacyLoadBalancerPicksUseCompatibilityLockAcrossClusters(t *testing.T) {
-	balancer := &serverBlockingLegacyLoadBalancer{
-		entered: make(chan string, 2),
-		release: make(chan struct{}),
-	}
-	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testLegacyCompatibilityLockLB]
-	loadbalancer.LoadBalancerStrategy[testLegacyCompatibilityLockLB] = balancer
-	t.Cleanup(func() {
-		if hadPrevious {
-			loadbalancer.LoadBalancerStrategy[testLegacyCompatibilityLockLB] = previous
-			return
-		}
-		delete(loadbalancer.LoadBalancerStrategy, testLegacyCompatibilityLockLB)
-	})
-
-	var releaseOnce sync.Once
-	t.Cleanup(func() {
-		releaseOnce.Do(func() {
-			close(balancer.release)
-		})
-	})
-
+	harness := registerServerLegacyBalancer(t, testLegacyCompatibilityLockLB, false)
 	cm := testClusterManager(
-		testCluster("legacy-cluster-a", testLegacyCompatibilityLockLB, []*model.Endpoint{
-			testEndpoint("legacy-a-1", "127.0.0.1", 19500),
-			testEndpoint("legacy-a-2", "127.0.0.1", 19501),
-		}),
-		testCluster("legacy-cluster-b", testLegacyCompatibilityLockLB, []*model.Endpoint{
-			testEndpoint("legacy-b-1", "127.0.0.1", 19502),
-			testEndpoint("legacy-b-2", "127.0.0.1", 19503),
-		}),
+		testLegacyLockCluster("legacy-cluster-a", testLegacyCompatibilityLockLB, 19500),
+		testLegacyLockCluster("legacy-cluster-b", testLegacyCompatibilityLockLB, 19502),
 	)
 
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		_ = cm.PickEndpoint("legacy-cluster-a", nil)
-	}()
-	assert.Equal(t, "legacy-cluster-a", waitServerLegacyHandlerEntry(t, balancer.entered))
+	firstDone := startServerPick(cm, "legacy-cluster-a")
+	assert.Equal(t, "legacy-cluster-a", harness.waitEntry())
 
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = cm.PickEndpoint("legacy-cluster-b", nil)
-	}()
+	secondDone := startServerPick(cm, "legacy-cluster-b")
+	harness.assertNoEntry()
 
-	assertNoServerLegacyHandlerEntry(t, balancer.entered)
-
-	releaseOnce.Do(func() {
-		close(balancer.release)
-	})
-	assert.Equal(t, "legacy-cluster-b", waitServerLegacyHandlerEntry(t, balancer.entered))
+	harness.release()
+	assert.Equal(t, "legacy-cluster-b", harness.waitEntry())
 	waitServerClosed(t, firstDone)
 	waitServerClosed(t, secondDone)
 }
 
 func TestClusterManager_OptInLegacyLoadBalancerPicksUseRuntimeScopedLocksAcrossClusters(t *testing.T) {
-	balancer := &serverClusterScopedBlockingLegacyLoadBalancer{
-		serverBlockingLegacyLoadBalancer: &serverBlockingLegacyLoadBalancer{
-			entered: make(chan string, 2),
-			release: make(chan struct{}),
-		},
-	}
-	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB]
-	loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB] = balancer
-	t.Cleanup(func() {
-		if hadPrevious {
-			loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB] = previous
-			return
-		}
-		delete(loadbalancer.LoadBalancerStrategy, testLegacyScopedLockLB)
-	})
-
-	var releaseOnce sync.Once
-	t.Cleanup(func() {
-		releaseOnce.Do(func() {
-			close(balancer.release)
-		})
-	})
-
+	harness := registerServerLegacyBalancer(t, testLegacyScopedLockLB, true)
 	cm := testClusterManager(
-		testCluster("legacy-cluster-a", testLegacyScopedLockLB, []*model.Endpoint{
-			testEndpoint("legacy-a-1", "127.0.0.1", 19500),
-			testEndpoint("legacy-a-2", "127.0.0.1", 19501),
-		}),
-		testCluster("legacy-cluster-b", testLegacyScopedLockLB, []*model.Endpoint{
-			testEndpoint("legacy-b-1", "127.0.0.1", 19502),
-			testEndpoint("legacy-b-2", "127.0.0.1", 19503),
-		}),
+		testLegacyLockCluster("legacy-cluster-a", testLegacyScopedLockLB, 19500),
+		testLegacyLockCluster("legacy-cluster-b", testLegacyScopedLockLB, 19502),
 	)
 
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		_ = cm.PickEndpoint("legacy-cluster-a", nil)
-	}()
-	assert.Equal(t, "legacy-cluster-a", waitServerLegacyHandlerEntry(t, balancer.entered))
+	firstDone := startServerPick(cm, "legacy-cluster-a")
+	assert.Equal(t, "legacy-cluster-a", harness.waitEntry())
 
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = cm.PickEndpoint("legacy-cluster-b", nil)
-	}()
-	assert.Equal(t, "legacy-cluster-b", waitServerLegacyHandlerEntry(t, balancer.entered))
+	secondDone := startServerPick(cm, "legacy-cluster-b")
+	assert.Equal(t, "legacy-cluster-b", harness.waitEntry())
 
-	releaseOnce.Do(func() {
-		close(balancer.release)
-	})
+	harness.release()
 	waitServerClosed(t, firstDone)
 	waitServerClosed(t, secondDone)
 }
 
 func TestClusterManager_OptInLegacyLoadBalancerPicksSerializeWithinSameCluster(t *testing.T) {
-	balancer := &serverClusterScopedBlockingLegacyLoadBalancer{
-		serverBlockingLegacyLoadBalancer: &serverBlockingLegacyLoadBalancer{
-			entered: make(chan string, 2),
-			release: make(chan struct{}),
-		},
-	}
-	previous, hadPrevious := loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB]
-	loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB] = balancer
-	t.Cleanup(func() {
-		if hadPrevious {
-			loadbalancer.LoadBalancerStrategy[testLegacyScopedLockLB] = previous
-			return
-		}
-		delete(loadbalancer.LoadBalancerStrategy, testLegacyScopedLockLB)
-	})
-
-	var releaseOnce sync.Once
-	t.Cleanup(func() {
-		releaseOnce.Do(func() {
-			close(balancer.release)
-		})
-	})
-
+	harness := registerServerLegacyBalancer(t, testLegacyScopedLockLB, true)
 	cm := testClusterManager(
-		testCluster("legacy-cluster-a", testLegacyScopedLockLB, []*model.Endpoint{
-			testEndpoint("legacy-a-1", "127.0.0.1", 19500),
-			testEndpoint("legacy-a-2", "127.0.0.1", 19501),
-		}),
+		testLegacyLockCluster("legacy-cluster-a", testLegacyScopedLockLB, 19500),
 	)
 
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		_ = cm.PickEndpoint("legacy-cluster-a", nil)
-	}()
-	assert.Equal(t, "legacy-cluster-a", waitServerLegacyHandlerEntry(t, balancer.entered))
+	firstDone := startServerPick(cm, "legacy-cluster-a")
+	assert.Equal(t, "legacy-cluster-a", harness.waitEntry())
 
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = cm.PickEndpoint("legacy-cluster-a", nil)
-	}()
+	secondDone := startServerPick(cm, "legacy-cluster-a")
+	harness.assertNoEntry()
 
-	assertNoServerLegacyHandlerEntry(t, balancer.entered)
-
-	releaseOnce.Do(func() {
-		close(balancer.release)
-	})
-	assert.Equal(t, "legacy-cluster-a", waitServerLegacyHandlerEntry(t, balancer.entered))
+	harness.release()
+	assert.Equal(t, "legacy-cluster-a", harness.waitEntry())
 	waitServerClosed(t, firstDone)
 	waitServerClosed(t, secondDone)
 }


### PR DESCRIPTION
## Summary
     
  Implements [#905](https://github.com/apache/dubbo-go-pixiu/issues/905) Step 5: introduces an immutable, atomically-published `EndpointSnapshot` so the cluster runtime can publish healthy endpoints,
  address-scoped health events, and an O(1) consistent-hash view without per-request linear scans against `ClusterConfig`. The simple-LB request hot path holds at one allocation per pick on the in-tree
  balancers, and is faster than develop for any non-trivial cluster size. Existing defensive contracts and tests are unchanged.
  
  ## What changed
  
  ### Snapshot data structure
  
  - `EndpointSnapshot` carries `all`, `healthy`, and ID/address indexes; published via `atomic.Pointer[EndpointSnapshot]` on `Cluster`.
  - Health checks publish ID/address-scoped events through `UpdateEndpointHealth` / `UpdateEndpointAddressHealth`. Stale events from replaced addresses are ignored.
  - Endpoint refresh inherits runtime health only when the endpoint ID and address still match; otherwise the snapshot is seeded from config.
  - Snapshots deep-clone config endpoints (including `Metadata` and `LLMMeta`); the request path consumes snapshot endpoints, never config pointers.
  - `HealthyConsistentHash` is built lazily via `sync.Once` and skipped when the balancer doesn't read it.
  
  ### Defensive contract
  
  The public accessors `HealthyEndpoints()` and `AllEndpoints()` return **defensive deep copies** — the earlier PR-description wording "shallow copies" was inaccurate. For the request-path picker, the new
  `HealthyEndpointsForPick` / `AllEndpointsForPick` accessors alias the snapshot's internal slices; their doc contract forbids mutating or retaining the slice, and snapshot↔caller isolation is enforced by a
  single `model.CloneEndpoint` at the picker return boundary (`healthyEndpointFromSnapshot`).
  
  External / out-of-tree balancers are unaffected: they keep going through `PickHealthyEndpoint(pick func)` (zero-copy callback that clones the chosen endpoint) or the deep-copy `HealthyEndpoints()`
  accessor. The `ZeroCopySnapshotLoadBalancer` / `HealthyOnlySnapshotLoadBalancer` marker interfaces gate the defensive clone tier; the in-tree balancers (Rand / RoundRobin / WeightRandom / Maglev /
  RingHash) all opt into both.
  
  ### LLM filter
  
  Per-API-key fallback cooldown moved out of `Endpoint.Metadata` and the cluster runtime into the LLM proxy filter itself, keyed by `clusterName + endpointID + endpointAddress` with a bounded LRU and
  throttled sweep. Cooldown state no longer pollutes snapshot equality or hash inputs.
  
  ## Hot-path performance
  
  `BenchmarkClusterLoadBalancerHotPathSerial` on Apple M5, `count=5`, `benchtime=1s`. **Before** = `develop`; **After** = this PR HEAD after the cleanup commits.
  
  | Benchmark | Before mean ns/op | Before range | After mean ns/op | After range | B/op before -> after | allocs/op before -> after |
  | --- | ---: | ---: | ---: | ---: | ---: | ---: |
  | Rand / `endpoints=4` | 13.44 | 13.25-13.79 | 64.75 | 64.08-65.57 | 0 -> 144 | 0 -> 1 |
  | Rand / `endpoints=64` | 133.30 | 131.40-134.70 | 126.54 | 125.30-128.90 | 512 -> 144 | 1 -> 1 |
  | Rand / `endpoints=512` | 903.06 | 880.90-916.20 | 532.34 | 530.60-534.20 | 4864 -> 144 | 1 -> 1 |
  | RoundRobin / `endpoints=4` | 10.07 | 9.75-10.39 | 58.29 | 57.70-59.86 | 0 -> 144 | 0 -> 1 |
  | RoundRobin / `endpoints=64` | 122.64 | 122.20-123.20 | 122.76 | 122.40-123.50 | 512 -> 144 | 1 -> 1 |
  | RoundRobin / `endpoints=512` | 838.56 | 835.30-844.40 | 526.82 | 525.40-531.60 | 4864 -> 144 | 1 -> 1 |
  
  The single remaining allocation per pick is the snapshot↔caller isolation clone at the picker return boundary; this is what makes the new architecture safe for callers that previously mutated config-shared
   endpoints. The small-N slowdown (`endpoints=4`: +51 ns vs develop) is the price of that guarantee — develop returned bare config pointers with no isolation. At `endpoints=64` we reach parity, and at
  `endpoints=512` the new path is ~37% faster because per-pick health filtering no longer scans config.
  
  `BenchmarkClusterHealthySnapshotLoad` is intentionally unchanged — it measures the deep-clone `HealthyEndpoints()` external API, which we keep as the safe-default contract for callers outside the request
  path. First pick after a snapshot rebuild additionally pays the lazy `HealthyConsistentHash` build cost, which steady-state benchmarks do not reflect.
  
  Late-stage review feedback initially accreted defensive copies that regressed the simple-LB hot path on small clusters (an early draft of this PR landed at 213 ns / 8 allocs for `endpoints=4`). The
  regression was fixed inside this PR, in four separate cleanup commits, rather than deferred to Step 6:
  
  - `perf(model): add SocketAddress.Equal to avoid GetAddress allocation`
  - `perf(cluster): add zero-copy snapshot accessors for the request path`
  - `perf(server): drop closure and double-clone from pickOneEndpoint`
  - `docs: capture snapshot architecture and hot-path perf in CHANGELOG`
  
  Step 6's scope remains the consistent-hash / weighted-random optimizations.
  
  ## Upgrade-visible behavior changes
  
  - **Endpoint IDs**: random UUIDs replaced by `model.GeneratedEndpointID` (deterministic from cluster name + address + LLM identity), and the direct `hashicorp/go-uuid` dependency is dropped. Operators that
   persist endpoint IDs across restarts will now see stable IDs derived from configuration rather than per-process randomness.
  - **Maglev hash key**: stable hashing for Maglev consistent-hash distribution; existing key→endpoint mappings may rebalance one time on upgrade.
  - **Nacos LLM registry**: when an instance's metadata port is invalid, the endpoint now falls back to `instance.Port` instead of dropping the address.
  - **Runtime health inheritance**: when a `ClusterConfig` refresh produces a new endpoint set, runtime health is preserved for endpoints whose ID and address are unchanged. Endpoints with a new ID or
  address are seeded from config.
  
  ## Step progress
  
  | Step | State |
  | --- | --- |
  | 1. Add tests + benchmarks | Complete |
  | 2. Fix obvious correctness issues | Complete |
  | 3. Tighten runtime consistency | Complete |
  | 4. Switch cluster lookup to O(1) ([#923](https://github.com/apache/dubbo-go-pixiu/pull/923)) | Complete |
  | **5. Healthy endpoint snapshot (this PR)** | **Ready** |
  | 6. Optimize simple LB hot path further | Pending |
  | 7. Optimize consistent-hash LBs | Pending |
  
  ## Testing
  
  ```
  go test -race -count=1 ./pkg/model ./pkg/cluster/... ./pkg/server ./pkg/filter/llm/proxy
  go test ./pkg/server -run '^$' -bench 'BenchmarkClusterLoadBalancerHotPathSerial' -benchmem -count=5 -benchtime=1s
  ```
  
  Defensive contract preserved by the existing tests:
  
  - `TestClusterEndpointSnapshotReturnsDefensiveEndpointSlices` (`pkg/cluster/cluster_test.go`)
  - `TestClusterEndpointSnapshotReturnsDefensiveEndpointObjects` (`pkg/cluster/cluster_test.go`)
  - `TestPickEndpointSnapshotMutationsDoNotEscape` (`pkg/cluster/loadbalancer/load_balancer_test.go`)
  - `TestClusterManager_SnapshotLoadBalancerCannotMutateOrBypassHealthySnapshot` (`pkg/server/cluster_manager_test.go`)
  
  New tests added in the cleanup commits:
  
  - `TestSocketAddressEqual` — 8 representative pairs, cross-validated against `GetAddress()` equality (`pkg/model/base_test.go`)
  - `TestClusterEndpointSnapshotForPickAccessorsAliasInternalStorage` — verifies the new accessors are zero-copy aliases (`pkg/cluster/cluster_test.go`)
  - `TestClusterManager_PickEndpointToleratesNilEntryInAllEndpoints` — nil entries in `s.all` propagate to `AllEndpoints` snapshots without panicking (`pkg/server/cluster_manager_test.go`)
  
  Race tests untouched and passing:
  
  - `TestClusterManager_Race_RoundRobinPickEndpoint`
  - `TestClusterManager_Race_PickEndpointWithHealthUpdates`
  
  ## Notes
  
  - `Endpoint.UnHealthy` is retained for config compatibility and snapshot seeding; it is no longer the runtime source of truth.
  - Full separation of cluster runtime state from `ClusterConfig` continues in later steps.
  - `defensiveSnapshotPickContext` is unchanged in this PR — it is dead code for the in-tree balancers (all are `ZeroCopySnapshotLoadBalancer`), and tightening it is forward-looking polish that belongs in
  Step 6 alongside the non-zero-copy snapshot LB cases.
