### PR TITLE
fix(loadbalancer/maglev): use fast deterministic request hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/alibaba/sentinel-golang v1.0.4
 	github.com/apache/dubbo-getty v1.4.10
 	github.com/apache/dubbo-go-hessian2 v1.12.5
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/creasty/defaults v1.5.2
 	github.com/crewjam/saml v0.5.1
 	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5
@@ -111,7 +112,6 @@ require (
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clbanning/mxj/v2 v2.5.5 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect

--- a/pkg/cluster/loadbalancer/maglev/maglev_hash_test.go
+++ b/pkg/cluster/loadbalancer/maglev/maglev_hash_test.go
@@ -60,3 +60,17 @@ func TestMaglevHash(t *testing.T) {
 	}
 
 }
+
+func TestLookUpTableHashIsStableForSameKey(t *testing.T) {
+	table, err := NewLookUpTable(521, []string{"127.0.0.1:18080", "127.0.0.1:18081"})
+	if err != nil {
+		t.Fatalf("NewLookUpTable() error = %v", err)
+	}
+
+	first := table.Hash("same-request-key")
+	for i := 0; i < 20; i++ {
+		if got := table.Hash("same-request-key"); got != first {
+			t.Fatalf("Hash() = %d, want stable %d", got, first)
+		}
+	}
+}

--- a/pkg/cluster/loadbalancer/maglev/permutation.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation.go
@@ -187,7 +187,7 @@ func (t *LookUpTable) removePerm(dst int) {
 
 // Hash the input key.
 func (t *LookUpTable) Hash(key string) uint32 {
-	return _requestHash(key)
+	return requestHash(key)
 }
 
 // Get a slot by hashing the input key.
@@ -275,7 +275,7 @@ func (t *LookUpTable) remove(host string) bool {
 	return false
 }
 
-func _requestHash(key string) uint32 {
+func requestHash(key string) uint32 {
 	return uint32(xxhash.Sum64String(key))
 }
 

--- a/pkg/cluster/loadbalancer/maglev/permutation.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation.go
@@ -19,7 +19,6 @@ package maglev
 
 import (
 	"encoding/binary"
-	"hash/maphash"
 	"math"
 	"math/big"
 	"sync"
@@ -187,10 +186,7 @@ func (t *LookUpTable) removePerm(dst int) {
 
 // Hash the input key.
 func (t *LookUpTable) Hash(key string) uint32 {
-	var h maphash.Hash
-	h.SetSeed(maphash.MakeSeed())
-	h.WriteString(key)
-	return uint32(h.Sum64())
+	return _hash1(key)
 }
 
 // Get a slot by hashing the input key.

--- a/pkg/cluster/loadbalancer/maglev/permutation.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation.go
@@ -25,6 +25,7 @@ import (
 )
 
 import (
+	"github.com/cespare/xxhash/v2"
 	"github.com/pkg/errors"
 
 	"golang.org/x/crypto/blake2b"
@@ -186,7 +187,7 @@ func (t *LookUpTable) removePerm(dst int) {
 
 // Hash the input key.
 func (t *LookUpTable) Hash(key string) uint32 {
-	return _hash1(key)
+	return _requestHash(key)
 }
 
 // Get a slot by hashing the input key.
@@ -219,7 +220,7 @@ func (t *LookUpTable) GetHash(key uint32) (string, error) {
 		return "", errors.New("no host added")
 	}
 
-	return t.slots[key], nil
+	return t.slots[key%uint32(t.size)], nil
 }
 
 // Add one endpoint into lookup table.
@@ -272,6 +273,10 @@ func (t *LookUpTable) remove(host string) bool {
 	}
 
 	return false
+}
+
+func _requestHash(key string) uint32 {
+	return uint32(xxhash.Sum64String(key))
 }
 
 func _hash1(key string) uint32 {

--- a/pkg/cluster/loadbalancer/maglev/permutation.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation.go
@@ -26,6 +26,7 @@ import (
 
 import (
 	"github.com/cespare/xxhash/v2"
+
 	"github.com/pkg/errors"
 
 	"golang.org/x/crypto/blake2b"

--- a/pkg/cluster/loadbalancer/maglev/permutation_bench_test.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation_bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkLookUpTableHash(b *testing.B) {
 
 	b.Run("xxhash", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			benchmarkHashSink = _requestHash(key)
+			benchmarkHashSink = requestHash(key)
 		}
 	})
 }

--- a/pkg/cluster/loadbalancer/maglev/permutation_bench_test.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation_bench_test.go
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package maglev
+
+import (
+	"encoding/binary"
+	"hash/maphash"
+	"testing"
+)
+
+import (
+	"golang.org/x/crypto/sha3"
+)
+
+var benchmarkHashSink uint32
+var benchmarkEndpointSink string
+
+func BenchmarkLookUpTableHash(b *testing.B) {
+	key := "GET./pixiu?total=100&user=benchmark"
+
+	b.Run("maphash-random-seed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkHashSink = benchmarkMapHash(key)
+		}
+	})
+
+	b.Run("sha3-512", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkHashSink = benchmarkSHA3Hash(key)
+		}
+	})
+
+	b.Run("xxhash", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkHashSink = _requestHash(key)
+		}
+	})
+}
+
+func BenchmarkLookUpTableGet(b *testing.B) {
+	table := createTableWithNodes(10007, 100)
+	table.Populate()
+
+	keys := []string{
+		"GET./pixiu?total=1",
+		"GET./pixiu?total=2",
+		"POST./api/v1/orders?id=100",
+		"GET./grpc.service.Method",
+		"GET./dubbo.method.provider",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		endpoint, err := table.Get(keys[i%len(keys)])
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkEndpointSink = endpoint
+	}
+}
+
+func benchmarkMapHash(key string) uint32 {
+	var h maphash.Hash
+	h.SetSeed(maphash.MakeSeed())
+	h.WriteString(key)
+	return uint32(h.Sum64())
+}
+
+func benchmarkSHA3Hash(key string) uint32 {
+	out := sha3.Sum512([]byte(key))
+	return binary.LittleEndian.Uint32(out[:])
+}

--- a/pkg/cluster/loadbalancer/maglev/permutation_test.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation_test.go
@@ -153,7 +153,7 @@ func TestLookUpTable_HashIsDeterministic(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		assert.Equal(t, want, table.Hash(key), "Hash should be stable for the same request key")
 	}
-	assert.Equal(t, _requestHash(key), want, "Hash should use the request-key hash")
+	assert.Equal(t, requestHash(key), want, "Hash should use the request-key hash")
 }
 
 func TestLookUpTable_GetHashNormalizesHashedKey(t *testing.T) {

--- a/pkg/cluster/loadbalancer/maglev/permutation_test.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation_test.go
@@ -145,6 +145,33 @@ func TestLookUpTable_Get(t *testing.T) {
 	assert.NotEqual(t, "", ep, "Wrong endpoint")
 }
 
+func TestLookUpTable_HashIsDeterministic(t *testing.T) {
+	table := createTableWithNodes(1033, 10)
+	key := "/this/is/a/test"
+
+	want := table.Hash(key)
+	for i := 0; i < 100; i++ {
+		assert.Equal(t, want, table.Hash(key), "Hash should be stable for the same request key")
+	}
+	assert.Equal(t, _requestHash(key), want, "Hash should use the request-key hash")
+}
+
+func TestLookUpTable_GetHashNormalizesHashedKey(t *testing.T) {
+	table := createTableWithNodes(1033, 10)
+
+	_, err := table.GetHash(0)
+	assert.NotNil(t, err, "Got endpoint before populating")
+
+	table.Populate()
+
+	key := uint32(table.size*3 + 17)
+	want := table.slots[int(key%uint32(table.size))]
+
+	got, err := table.GetHash(key)
+	assert.Nil(t, err, "Fail to get endpoint by hashed key")
+	assert.Equal(t, want, got)
+}
+
 func TestLookUpTable_Add(t *testing.T) {
 	testCases := []struct {
 		nodeCount int


### PR DESCRIPTION
## What

Fix Maglev request-key hashing so repeated lookups for the same key are deterministic without putting SHA3-512 on the request path.

## Why

`LookUpTable.Hash` originally created a fresh `maphash.MakeSeed()` on every call, so the same request key could map to a different slot on each lookup. The first deterministic fix routed `Hash()` through `_hash1`, but that uses SHA3-512 and allocates on the hot path. Maglev request routing only needs a stable, fast, well-distributed non-cryptographic hash.

## How

- Keep `_hash1/_hash2` for Maglev table permutation generation to avoid broad endpoint-to-slot distribution churn.
- Add `requestHash` for request keys using `github.com/cespare/xxhash/v2`.
- Make `LookUpTable.Hash()` call `requestHash`.
- Normalize `GetHash(uint32)` with `% table size` so callers can pass a raw hash safely.
- Add regression coverage for deterministic hashing and `GetHash` normalization.
- Add benchmarks comparing the old random `maphash`, SHA3-512, and xxHash request hashing.
- Rename the helper from `_requestHash` to `requestHash` to satisfy Sonar rule go:S100.

## Tests

- [x] `go test ./pkg/cluster/loadbalancer/maglev`
- [x] `go test ./pkg/cluster/loadbalancer/maglev -run '^$' -bench 'BenchmarkLookUpTable(Hash|Get)$' -benchmem`
- [x] `go test ./pkg/model`
- [x] `go test ./pkg/server -run 'TestClusterConfig|TestClusterManager|Test.*Maglev|Test.*Consistent|^$'`
- [x] `go test ./pkg/cluster/loadbalancer/...`
- [x] `go test ./pkg/cluster/loadbalancer/maglev -run 'TestLookUpTable_HashIsDeterministic|TestLookUpTable_GetHashNormalizesHashedKey' -count=20`

Benchmark result on darwin/arm64 Apple M5:

```text
BenchmarkLookUpTableHash/maphash-random-seed-10   8.381 ns/op    0 B/op  0 allocs/op
BenchmarkLookUpTableHash/sha3-512-10            148.9 ns/op     48 B/op  1 allocs/op
BenchmarkLookUpTableHash/xxhash-10                4.477 ns/op    0 B/op  0 allocs/op
BenchmarkLookUpTableGet-10                       10.12 ns/op     0 B/op  0 allocs/op
```

## Notes

This intentionally changes request-key-to-slot mapping compared with the SHA3-based intermediate fix, but preserves deterministic behavior and keeps Maglev viable for high-QPS request routing.
