### PR TITLE
fix(endpoint): stabilize endpoint.ID across restarts (nacos + static-config paths)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -127,6 +127,8 @@ jobs:
       SAMPLES_CLONE_DIR: integrate_samples
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'

--- a/docs/ai/kvcache.md
+++ b/docs/ai/kvcache.md
@@ -51,7 +51,7 @@ value wins:
 1. `metadata["id"]` on the registry instance (Nacos LLM registry), or
    the `id:` field on a static-config endpoint.
 2. The Nacos `InstanceId` if present.
-3. A deterministic `generated-<sha8>` hash derived from
+3. A deterministic `pixiu-generated-endpoint-<sha8>` hash derived from
    `(cluster_name, address, provider, api_key)`.
 
 All three forms are stable across pixiu restarts as long as the underlying

--- a/docs/ai/kvcache.md
+++ b/docs/ai/kvcache.md
@@ -43,6 +43,30 @@ So for routing to work:
 
 If no match exists, the request falls back to normal load-balancing behavior.
 
+#### How `pixiu cluster endpoint.id` is derived
+
+Pixiu picks the endpoint identifier in three-tier order. The first non-empty
+value wins:
+
+1. `metadata["id"]` on the registry instance (Nacos LLM registry), or
+   the `id:` field on a static-config endpoint.
+2. The Nacos `InstanceId` if present.
+3. A deterministic `generated-<sha8>` hash derived from
+   `(cluster_name, address, provider, api_key)`.
+
+All three forms are stable across pixiu restarts as long as the underlying
+attributes are unchanged, so the `LMCache instance_id ↔ pixiu endpoint.id`
+contract holds long-term.
+
+#### Upgrade note
+
+Earlier pixiu versions used a random UUID for tiers 2 and 3, which made
+`endpoint.id` change on every restart and re-subscription. The current
+version is deterministic; LMCache deployments whose `instance_id` values
+were derived from those random UUIDs will see a one-time ID-shape
+transition on upgrade. After the transition, LMCache only needs to
+relearn the `instance_id` once per endpoint; routing then stays stable.
+
 Note:
 
 - Current implementation does **not** call LMCache `/query_worker_info`.

--- a/docs/ai/kvcache_CN.md
+++ b/docs/ai/kvcache_CN.md
@@ -43,6 +43,27 @@
 
 如果不一致，请求会自动回退到正常负载均衡。
 
+#### `pixiu cluster endpoint.id` 的生成规则
+
+按三档优先级取第一个非空值：
+
+1. 注册中心实例上的 `metadata["id"]`（Nacos LLM 注册中心），
+   或静态配置 endpoint 上的 `id:` 字段。
+2. Nacos 的 `InstanceId`（若存在）。
+3. 由 `(cluster_name, address, provider, api_key)` 派生的确定性哈希
+   `generated-<sha8>`。
+
+三种形式在 pixiu 重启之间都保持稳定，只要底层属性没有变化，所以
+`LMCache instance_id ↔ pixiu endpoint.id` 这条契约长期成立。
+
+#### 升级说明
+
+早期 pixiu 版本在第 2、3 档使用随机 UUID，导致 `endpoint.id` 每次
+重启和重订阅都会变化。当前版本改为确定性 ID；如果你的 LMCache
+部署中 `instance_id` 是基于那些随机 UUID 推导的，升级时会看到一次性
+的 ID 形态切换。切换之后，LMCache 只需为每个 endpoint 重新学习一次
+`instance_id`，之后路由恢复稳定。
+
 说明：
 
 - 当前实现 **不会** 调 LMCache `/query_worker_info`

--- a/docs/ai/kvcache_CN.md
+++ b/docs/ai/kvcache_CN.md
@@ -54,7 +54,7 @@
    `generated-<sha8>`。
 
 三种形式在 pixiu 重启之间都保持稳定，只要底层属性没有变化，所以
-`LMCache instance_id ↔ pixiu endpoint.id` 这条契约长期成立。
+`LMCache instance_id ↔ pixiu endpoint.id` 这样定义长期成立。
 
 #### 升级说明
 

--- a/docs/ai/kvcache_CN.md
+++ b/docs/ai/kvcache_CN.md
@@ -51,7 +51,7 @@
    或静态配置 endpoint 上的 `id:` 字段。
 2. Nacos 的 `InstanceId`（若存在）。
 3. 由 `(cluster_name, address, provider, api_key)` 派生的确定性哈希
-   `generated-<sha8>`。
+   `pixiu-generated-endpoint-<sha8>`。
 
 三种形式在 pixiu 重启之间都保持稳定，只要底层属性没有变化，所以
 `LMCache instance_id ↔ pixiu endpoint.id` 这样定义长期成立。

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
-	github.com/hashicorp/go-uuid v1.0.3
 	github.com/jhump/protoreflect v1.17.0
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
 	github.com/lestrrat-go/httprc/v3 v3.0.1
@@ -160,6 +159,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/vault/sdk v0.7.0 // indirect

--- a/pkg/adapter/llmregistry/registry/nacos/listener.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener.go
@@ -31,8 +31,6 @@ import (
 
 	"github.com/creasty/defaults"
 
-	"github.com/hashicorp/go-uuid"
-
 	"github.com/nacos-group/nacos-sdk-go/clients/naming_client"
 	nacosModel "github.com/nacos-group/nacos-sdk-go/model"
 	"github.com/nacos-group/nacos-sdk-go/vo"
@@ -275,6 +273,9 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 		return nil
 	}
 
+	ret.Address.Address = instance.Ip
+	ret.Address.Port = int(instance.Port)
+
 	if ip, ok := instance.Metadata["ip"]; ok {
 		ret.Address.Address = ip
 	}
@@ -283,14 +284,9 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 		p, err := strconv.Atoi(port)
 		if err != nil {
 			logger.Warnf("Invalid port in metadata: %s, error: %v", port, err)
+		} else {
+			ret.Address.Port = p
 		}
-		ret.Address.Port = p
-	}
-
-	if id, ok := instance.Metadata["id"]; ok {
-		ret.ID = id
-	} else {
-		ret.ID, _ = uuid.GenerateUUID()
 	}
 
 	if name, ok := instance.Metadata["name"]; ok {
@@ -316,8 +312,19 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 	}
 
 	ret.Metadata = instance.Metadata
+	ret.ID = nacosEndpointID(instance, ret)
 
 	return ret
+}
+
+func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) string {
+	if id, ok := instance.Metadata["id"]; ok && strings.TrimSpace(id) != "" {
+		return strings.TrimSpace(id)
+	}
+	if instanceID := strings.TrimSpace(instance.InstanceId); instanceID != "" {
+		return instanceID
+	}
+	return model.GeneratedEndpointID(instance.Metadata["cluster"], endpoint)
 }
 
 func generateInstance(ss nacosModel.SubscribeService) nacosModel.Instance {

--- a/pkg/adapter/llmregistry/registry/nacos/listener.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener.go
@@ -318,8 +318,8 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 }
 
 func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) string {
-	if id, ok := instance.Metadata["id"]; ok && strings.TrimSpace(id) != "" {
-		return strings.TrimSpace(id)
+	if id := strings.TrimSpace(instance.Metadata["id"]); id != "" {
+		return id
 	}
 	if instanceID := strings.TrimSpace(instance.InstanceId); instanceID != "" {
 		return instanceID

--- a/pkg/adapter/llmregistry/registry/nacos/listener.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener.go
@@ -324,7 +324,11 @@ func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) str
 	if instanceID := strings.TrimSpace(instance.InstanceId); instanceID != "" {
 		return instanceID
 	}
-	return model.GenerateEndpointID(instance.Metadata["cluster"], endpoint)
+	clusterName := strings.TrimSpace(instance.Metadata["cluster"])
+	if clusterName == "" {
+		clusterName = strings.TrimSpace(instance.ClusterName)
+	}
+	return model.GenerateEndpointID(clusterName, endpoint)
 }
 
 func generateInstance(ss nacosModel.SubscribeService) nacosModel.Instance {

--- a/pkg/adapter/llmregistry/registry/nacos/listener.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener.go
@@ -324,7 +324,7 @@ func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) str
 	if instanceID := strings.TrimSpace(instance.InstanceId); instanceID != "" {
 		return instanceID
 	}
-	return model.GeneratedEndpointID(instance.Metadata["cluster"], endpoint)
+	return model.GenerateEndpointID(instance.Metadata["cluster"], endpoint)
 }
 
 func generateInstance(ss nacosModel.SubscribeService) nacosModel.Instance {

--- a/pkg/adapter/llmregistry/registry/nacos/listener_test.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener_test.go
@@ -209,6 +209,28 @@ func TestGenerateEndpoint(t *testing.T) {
 		assert.Contains(t, first.ID, "generated-")
 		assert.NotContains(t, first.ID, "key-a")
 	})
+
+	t.Run("Missing metadata cluster falls back to Nacos cluster name", func(t *testing.T) {
+		build := func(clusterName string) nacosModel.Instance {
+			return nacosModel.Instance{
+				Ip:          "127.0.0.1",
+				Port:        8080,
+				ClusterName: clusterName,
+				Metadata: map[string]string{
+					"name":             "shared-llm",
+					"llm-meta.api_key": "key-a",
+				},
+			}
+		}
+
+		clusterA := generateEndpoint(build("cluster-a"))
+		clusterB := generateEndpoint(build("cluster-b"))
+
+		assert.NotNil(t, clusterA)
+		assert.NotNil(t, clusterB)
+		assert.Contains(t, clusterA.ID, "generated-")
+		assert.NotEqual(t, clusterA.ID, clusterB.ID)
+	})
 }
 
 func TestDiscoverAndSubscribe(t *testing.T) {

--- a/pkg/adapter/llmregistry/registry/nacos/listener_test.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener_test.go
@@ -154,10 +154,60 @@ func TestGenerateEndpoint(t *testing.T) {
 	})
 
 	t.Run("Invalid port", func(t *testing.T) {
-		instance := nacosModel.Instance{Metadata: map[string]string{"port": "not-a-number"}}
+		instance := nacosModel.Instance{
+			Port:     8080,
+			Metadata: map[string]string{"port": "not-a-number"},
+		}
 		endpoint := generateEndpoint(instance)
 		assert.NotNil(t, endpoint)
-		assert.Equal(t, 0, endpoint.Address.Port)
+		assert.Equal(t, 8080, endpoint.Address.Port)
+	})
+
+	t.Run("Missing metadata ID uses Nacos instance identity", func(t *testing.T) {
+		instance := nacosModel.Instance{
+			InstanceId: "nacos-instance-1",
+			Ip:         "10.0.0.1",
+			Port:       18080,
+			Metadata: map[string]string{
+				"cluster": "llm-cluster",
+				"name":    "shared-llm",
+			},
+		}
+
+		endpoint := generateEndpoint(instance)
+		assert.NotNil(t, endpoint)
+		assert.Equal(t, "nacos-instance-1", endpoint.ID)
+		assert.Equal(t, "10.0.0.1", endpoint.Address.Address)
+		assert.Equal(t, 18080, endpoint.Address.Port)
+	})
+
+	t.Run("Missing ID uses stable generated endpoint ID", func(t *testing.T) {
+		instance := nacosModel.Instance{
+			Metadata: map[string]string{
+				"cluster":          "llm-cluster",
+				"name":             "shared-llm",
+				"ip":               "127.0.0.1",
+				"port":             "8080",
+				"llm-meta.api_key": "key-a",
+			},
+		}
+
+		first := generateEndpoint(instance)
+		second := generateEndpoint(instance)
+		changedCredential := instance
+		changedCredential.Metadata = map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm",
+			"ip":               "127.0.0.1",
+			"port":             "8080",
+			"llm-meta.api_key": "key-b",
+		}
+
+		assert.NotNil(t, first)
+		assert.Equal(t, first.ID, second.ID)
+		assert.NotEqual(t, first.ID, generateEndpoint(changedCredential).ID)
+		assert.Contains(t, first.ID, "generated-")
+		assert.NotContains(t, first.ID, "key-a")
 	})
 }
 
@@ -271,6 +321,151 @@ func TestServiceCallback(t *testing.T) {
 		assert.Empty(t, adapterListener.addedEndpoints, "Should not trigger add for unchanged instance")
 		assert.Empty(t, adapterListener.removedEndpoints, "Should not trigger remove for unchanged instance")
 	})
+}
+
+func TestServiceCallbackUsesStableGeneratedEndpointID(t *testing.T) {
+	l, client, adapterListener := testSetup()
+
+	_ = client.Subscribe(&vo.SubscribeParam{
+		ServiceName:       "service-generated",
+		SubscribeCallback: l.serviceCallback,
+	})
+
+	instance1 := nacosModel.SubscribeService{
+		ServiceName: "service-generated",
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm-a",
+			"ip":               "127.0.0.1",
+			"port":             "8080",
+			"llm-meta.api_key": "key-a",
+		},
+	}
+	instance2 := nacosModel.SubscribeService{
+		ServiceName: "service-generated",
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm-b",
+			"ip":               "127.0.0.1",
+			"port":             "8080",
+			"llm-meta.api_key": "key-b",
+		},
+	}
+
+	client.subscribeCallback([]nacosModel.SubscribeService{instance1, instance2}, nil)
+	assert.Len(t, adapterListener.addedEndpoints, 2)
+
+	var removedID string
+	for id, endpoint := range adapterListener.addedEndpoints {
+		if endpoint.Name == "shared-llm-a" {
+			removedID = id
+		}
+	}
+	assert.NotEmpty(t, removedID)
+
+	adapterListener.reset()
+	client.subscribeCallback([]nacosModel.SubscribeService{instance2}, nil)
+
+	assert.Empty(t, adapterListener.addedEndpoints)
+	assert.Contains(t, adapterListener.removedEndpoints, removedID)
+}
+
+func TestServiceCallbackKeepsGeneratedEndpointIDWhenNameChanges(t *testing.T) {
+	l, client, adapterListener := testSetup()
+
+	_ = client.Subscribe(&vo.SubscribeParam{
+		ServiceName:       "service-rename",
+		SubscribeCallback: l.serviceCallback,
+	})
+
+	instance := nacosModel.SubscribeService{
+		ServiceName: "service-rename",
+		Ip:          "127.0.0.1",
+		Port:        8080,
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm-old",
+			"llm-meta.api_key": "key-a",
+		},
+	}
+
+	client.subscribeCallback([]nacosModel.SubscribeService{instance}, nil)
+	assert.Len(t, adapterListener.addedEndpoints, 1)
+
+	var endpointID string
+	for id := range adapterListener.addedEndpoints {
+		endpointID = id
+	}
+	assert.NotEmpty(t, endpointID)
+
+	renamed := instance
+	renamed.Metadata = map[string]string{
+		"cluster":          "llm-cluster",
+		"name":             "shared-llm-new",
+		"llm-meta.api_key": "key-a",
+	}
+
+	adapterListener.reset()
+	client.subscribeCallback([]nacosModel.SubscribeService{renamed}, nil)
+
+	assert.Empty(t, adapterListener.removedEndpoints)
+	if assert.Contains(t, adapterListener.addedEndpoints, endpointID) {
+		assert.Equal(t, "shared-llm-new", adapterListener.addedEndpoints[endpointID].Name)
+	}
+}
+
+func TestServiceCallbackKeepsNacosInstancesWithoutMetadataIDDistinct(t *testing.T) {
+	l, client, adapterListener := testSetup()
+
+	_ = client.Subscribe(&vo.SubscribeParam{
+		ServiceName:       "service-instance-id",
+		SubscribeCallback: l.serviceCallback,
+	})
+
+	instance1 := nacosModel.SubscribeService{
+		InstanceId:  "nacos-instance-a",
+		ServiceName: "service-instance-id",
+		Ip:          "10.0.0.1",
+		Port:        18080,
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm",
+			"llm-meta.api_key": "same-key",
+		},
+	}
+	instance2 := nacosModel.SubscribeService{
+		InstanceId:  "nacos-instance-b",
+		ServiceName: "service-instance-id",
+		Ip:          "10.0.0.2",
+		Port:        18081,
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			"cluster":          "llm-cluster",
+			"name":             "shared-llm",
+			"llm-meta.api_key": "same-key",
+		},
+	}
+
+	client.subscribeCallback([]nacosModel.SubscribeService{instance1, instance2}, nil)
+
+	assert.Len(t, adapterListener.addedEndpoints, 2)
+	assert.Contains(t, adapterListener.addedEndpoints, "nacos-instance-a")
+	assert.Contains(t, adapterListener.addedEndpoints, "nacos-instance-b")
+
+	adapterListener.reset()
+	client.subscribeCallback([]nacosModel.SubscribeService{instance2}, nil)
+
+	assert.Empty(t, adapterListener.addedEndpoints)
+	assert.Contains(t, adapterListener.removedEndpoints, "nacos-instance-a")
 }
 
 func TestLifecycle(t *testing.T) {

--- a/pkg/adapter/llmregistry/registry/nacos/listener_test.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener_test.go
@@ -206,7 +206,7 @@ func TestGenerateEndpoint(t *testing.T) {
 		assert.NotNil(t, first)
 		assert.Equal(t, first.ID, second.ID)
 		assert.NotEqual(t, first.ID, generateEndpoint(changedCredential).ID)
-		assert.Contains(t, first.ID, "generated-")
+		assert.Contains(t, first.ID, "pixiu-generated-endpoint-")
 		assert.NotContains(t, first.ID, "key-a")
 	})
 
@@ -228,7 +228,7 @@ func TestGenerateEndpoint(t *testing.T) {
 
 		assert.NotNil(t, clusterA)
 		assert.NotNil(t, clusterB)
-		assert.Contains(t, clusterA.ID, "generated-")
+		assert.Contains(t, clusterA.ID, "pixiu-generated-endpoint-")
 		assert.NotEqual(t, clusterA.ID, clusterB.ID)
 	})
 }

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -130,12 +130,25 @@ func (e Endpoint) GetHost() string {
 	return fmt.Sprintf("%s:%d", e.Address.Address, e.Address.Port)
 }
 
-// GeneratedEndpointID returns a deterministic runtime identity for endpoints
+// GenerateEndpointID returns a deterministic runtime identity for endpoints
 // that do not provide an explicit ID. The hash material includes cluster name,
 // endpoint address, and (when present) LLM provider + API key, so endpoints
 // that differ only by credential do not collide and the same endpoint hashes
 // to the same ID across process restarts.
-func GeneratedEndpointID(clusterName string, endpoint *Endpoint) string {
+//
+// Design notes:
+//   - The output is sha256(material) truncated to the first 8 bytes (64 bits).
+//     Birthday-collision probability becomes meaningful only around 2^32
+//     endpoints, far above any per-cluster scale we operate at.
+//   - clusterName is part of the material so endpoints in different clusters
+//     never alias. Callers from the Nacos LLM path supply
+//     instance.Metadata["cluster"]; if that metadata is missing the value is
+//     the empty string, and identity is then determined by address +
+//     credential only.
+//   - The LLM API key is included on purpose so two endpoints that share an
+//     address but use different credentials never alias to the same ID. The
+//     output is one-way (sha256), so the raw key never appears in the ID.
+func GenerateEndpointID(clusterName string, endpoint *Endpoint) string {
 	sum := sha256.Sum256([]byte(endpointIDMaterial(clusterName, endpoint)))
 	return fmt.Sprintf("generated-%x", sum[:8])
 }

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -18,6 +18,7 @@
 package model
 
 import (
+	"crypto/sha256"
 	"fmt"
 )
 
@@ -127,4 +128,30 @@ func (c *ClusterConfig) CreateConsistentHash() {
 
 func (e Endpoint) GetHost() string {
 	return fmt.Sprintf("%s:%d", e.Address.Address, e.Address.Port)
+}
+
+// GeneratedEndpointID returns a deterministic runtime identity for endpoints
+// that do not provide an explicit ID. The hash material includes cluster name,
+// endpoint address, and (when present) LLM provider + API key, so endpoints
+// that differ only by credential do not collide and the same endpoint hashes
+// to the same ID across process restarts.
+func GeneratedEndpointID(clusterName string, endpoint *Endpoint) string {
+	sum := sha256.Sum256([]byte(endpointIDMaterial(clusterName, endpoint)))
+	return fmt.Sprintf("generated-%x", sum[:8])
+}
+
+func endpointIDMaterial(clusterName string, endpoint *Endpoint) string {
+	if endpoint == nil {
+		return clusterName
+	}
+	provider := ""
+	apiKey := ""
+	if endpoint.LLMMeta != nil {
+		provider = endpoint.LLMMeta.Provider
+		apiKey = endpoint.LLMMeta.APIKey
+	}
+	return clusterName + "\x00" +
+		endpoint.Address.GetAddress() + "\x00" +
+		provider + "\x00" +
+		apiKey
 }

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -139,7 +139,7 @@ func (e Endpoint) GetHost() string {
 // Design notes:
 //   - The output is sha256(material) truncated to the first 8 bytes (64 bits).
 //     Birthday-collision probability becomes meaningful only around 2^32
-//     endpoints, far above any per-cluster scale we operate at.
+//     endpoints, far above any realistic per-cluster scale.
 //   - clusterName is part of the material so endpoints in different clusters
 //     never alias. Callers from the Nacos LLM path supply
 //     instance.Metadata["cluster"]; if that metadata is missing the value is
@@ -153,6 +153,14 @@ func GenerateEndpointID(clusterName string, endpoint *Endpoint) string {
 	return fmt.Sprintf("generated-%x", sum[:8])
 }
 
+// endpointIDMaterial builds the byte string fed into the hash inside
+// GenerateEndpointID.
+//
+// Contract: this function MUST NOT depend on endpoint.Name. Callers
+// (notably ClusterStore.assembleClusterEndpoints) rely on being able to
+// derive the ID before assigning a default Name. Adding Name into the
+// material would also break the rename-invariance guarantee asserted by
+// TestGenerateEndpointIDIgnoresEndpointName.
 func endpointIDMaterial(clusterName string, endpoint *Endpoint) string {
 	if endpoint == nil {
 		return clusterName

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 )
 
+const generatedEndpointIDPrefix = "pixiu-generated-endpoint-"
+
 const (
 	Static DiscoveryType = iota
 	StrictDNS
@@ -140,6 +142,9 @@ func (e Endpoint) GetHost() string {
 //   - The output is sha256(material) truncated to the first 8 bytes (64 bits).
 //     Birthday-collision probability becomes meaningful only around 2^32
 //     endpoints, far above any realistic per-cluster scale.
+//   - The output uses the pixiu-generated-endpoint- prefix so generated IDs
+//     are recognizable in logs and dashboards without implying they only come
+//     from the LLM registry path. Static-config endpoints use this helper too.
 //   - clusterName is part of the material so endpoints in different clusters
 //     never alias. Callers from the Nacos LLM path supply
 //     instance.Metadata["cluster"]; if that metadata is missing the value is
@@ -150,11 +155,12 @@ func (e Endpoint) GetHost() string {
 //     output is one-way (sha256), so the raw key never appears in the ID.
 func GenerateEndpointID(clusterName string, endpoint *Endpoint) string {
 	sum := sha256.Sum256([]byte(endpointIDMaterial(clusterName, endpoint)))
-	return fmt.Sprintf("generated-%x", sum[:8])
+	return fmt.Sprintf("%s%x", generatedEndpointIDPrefix, sum[:8])
 }
 
 // endpointIDMaterial builds the byte string fed into the hash inside
-// GenerateEndpointID.
+// GenerateEndpointID. Each component is tagged and length-prefixed so field
+// boundaries remain unambiguous even if values contain punctuation or newlines.
 //
 // Contract: this function MUST NOT depend on endpoint.Name. Callers
 // (notably ClusterStore.assembleClusterEndpoints) rely on being able to
@@ -162,17 +168,22 @@ func GenerateEndpointID(clusterName string, endpoint *Endpoint) string {
 // material would also break the rename-invariance guarantee asserted by
 // TestGenerateEndpointIDIgnoresEndpointName.
 func endpointIDMaterial(clusterName string, endpoint *Endpoint) string {
-	if endpoint == nil {
-		return clusterName
-	}
+	address := ""
 	provider := ""
 	apiKey := ""
-	if endpoint.LLMMeta != nil {
+	if endpoint != nil {
+		address = endpoint.Address.GetAddress()
+	}
+	if endpoint != nil && endpoint.LLMMeta != nil {
 		provider = endpoint.LLMMeta.Provider
 		apiKey = endpoint.LLMMeta.APIKey
 	}
-	return clusterName + "\x00" +
-		endpoint.Address.GetAddress() + "\x00" +
-		provider + "\x00" +
-		apiKey
+	return endpointIDMaterialField("cluster", clusterName) +
+		endpointIDMaterialField("address", address) +
+		endpointIDMaterialField("llm_provider", provider) +
+		endpointIDMaterialField("llm_api_key", apiKey)
+}
+
+func endpointIDMaterialField(name, value string) string {
+	return fmt.Sprintf("%s:%d:%s\n", name, len(value), value)
 }

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -102,3 +102,44 @@ func TestEndpoint_GetHost(t *testing.T) {
 
 	assert.Equal(t, "127.0.0.1:20880", endpoint.GetHost())
 }
+
+func TestGeneratedEndpointIDIsDeterministic(t *testing.T) {
+	build := func(apiKey string) *model.Endpoint {
+		return &model.Endpoint{
+			Name:    "shared-llm",
+			Address: model.SocketAddress{Address: "127.0.0.1", Port: 20880},
+			LLMMeta: &model.LLMMeta{Provider: "openai", APIKey: apiKey},
+		}
+	}
+
+	first := model.GeneratedEndpointID("cluster-a", build("key-a"))
+	second := model.GeneratedEndpointID("cluster-a", build("key-a"))
+	other := model.GeneratedEndpointID("cluster-a", build("key-b"))
+
+	assert.Equal(t, first, second, "same material must produce same ID")
+	assert.NotEqual(t, first, other, "different credential must produce different ID")
+	assert.True(t, strings.HasPrefix(first, "generated-"), "ID must use generated- prefix")
+	assert.NotContains(t, first, "key-a", "raw API key must not leak into the ID")
+}
+
+func TestGeneratedEndpointIDIgnoresEndpointName(t *testing.T) {
+	base := &model.Endpoint{
+		Name:    "old-name",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 20880},
+		LLMMeta: &model.LLMMeta{Provider: "openai", APIKey: "k"},
+	}
+	renamed := *base
+	renamed.Name = "new-name"
+
+	assert.Equal(t,
+		model.GeneratedEndpointID("cluster-a", base),
+		model.GeneratedEndpointID("cluster-a", &renamed),
+	)
+}
+
+func TestGeneratedEndpointIDHandlesNilEndpoint(t *testing.T) {
+	a := model.GeneratedEndpointID("cluster-a", nil)
+	b := model.GeneratedEndpointID("cluster-b", nil)
+	assert.True(t, strings.HasPrefix(a, "generated-"))
+	assert.NotEqual(t, a, b)
+}

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -103,7 +103,7 @@ func TestEndpoint_GetHost(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:20880", endpoint.GetHost())
 }
 
-func TestGeneratedEndpointIDIsDeterministic(t *testing.T) {
+func TestGenerateEndpointIDIsDeterministic(t *testing.T) {
 	build := func(apiKey string) *model.Endpoint {
 		return &model.Endpoint{
 			Name:    "shared-llm",
@@ -112,9 +112,9 @@ func TestGeneratedEndpointIDIsDeterministic(t *testing.T) {
 		}
 	}
 
-	first := model.GeneratedEndpointID("cluster-a", build("key-a"))
-	second := model.GeneratedEndpointID("cluster-a", build("key-a"))
-	other := model.GeneratedEndpointID("cluster-a", build("key-b"))
+	first := model.GenerateEndpointID("cluster-a", build("key-a"))
+	second := model.GenerateEndpointID("cluster-a", build("key-a"))
+	other := model.GenerateEndpointID("cluster-a", build("key-b"))
 
 	assert.Equal(t, first, second, "same material must produce same ID")
 	assert.NotEqual(t, first, other, "different credential must produce different ID")
@@ -122,7 +122,7 @@ func TestGeneratedEndpointIDIsDeterministic(t *testing.T) {
 	assert.NotContains(t, first, "key-a", "raw API key must not leak into the ID")
 }
 
-func TestGeneratedEndpointIDIgnoresEndpointName(t *testing.T) {
+func TestGenerateEndpointIDIgnoresEndpointName(t *testing.T) {
 	base := &model.Endpoint{
 		Name:    "old-name",
 		Address: model.SocketAddress{Address: "127.0.0.1", Port: 20880},
@@ -132,14 +132,44 @@ func TestGeneratedEndpointIDIgnoresEndpointName(t *testing.T) {
 	renamed.Name = "new-name"
 
 	assert.Equal(t,
-		model.GeneratedEndpointID("cluster-a", base),
-		model.GeneratedEndpointID("cluster-a", &renamed),
+		model.GenerateEndpointID("cluster-a", base),
+		model.GenerateEndpointID("cluster-a", &renamed),
 	)
 }
 
-func TestGeneratedEndpointIDHandlesNilEndpoint(t *testing.T) {
-	a := model.GeneratedEndpointID("cluster-a", nil)
-	b := model.GeneratedEndpointID("cluster-b", nil)
+func TestGenerateEndpointIDSeparatesClusters(t *testing.T) {
+	endpoint := &model.Endpoint{
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 20880},
+		LLMMeta: &model.LLMMeta{Provider: "openai", APIKey: "k"},
+	}
+
+	a := model.GenerateEndpointID("cluster-a", endpoint)
+	b := model.GenerateEndpointID("cluster-b", endpoint)
+
+	assert.NotEqual(t, a, b, "different cluster names must produce different IDs for the same endpoint")
+}
+
+func TestGenerateEndpointIDSeparatesAddresses(t *testing.T) {
+	build := func(host string, port int) *model.Endpoint {
+		return &model.Endpoint{
+			Address: model.SocketAddress{Address: host, Port: port},
+			LLMMeta: &model.LLMMeta{Provider: "openai", APIKey: "k"},
+		}
+	}
+
+	base := model.GenerateEndpointID("cluster-a", build("127.0.0.1", 20880))
+
+	assert.NotEqual(t, base,
+		model.GenerateEndpointID("cluster-a", build("127.0.0.2", 20880)),
+		"different host must produce different ID")
+	assert.NotEqual(t, base,
+		model.GenerateEndpointID("cluster-a", build("127.0.0.1", 20881)),
+		"different port must produce different ID")
+}
+
+func TestGenerateEndpointIDHandlesNilEndpoint(t *testing.T) {
+	a := model.GenerateEndpointID("cluster-a", nil)
+	b := model.GenerateEndpointID("cluster-b", nil)
 	assert.True(t, strings.HasPrefix(a, "generated-"))
 	assert.NotEqual(t, a, b)
 }

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -118,7 +118,8 @@ func TestGenerateEndpointIDIsDeterministic(t *testing.T) {
 
 	assert.Equal(t, first, second, "same material must produce same ID")
 	assert.NotEqual(t, first, other, "different credential must produce different ID")
-	assert.True(t, strings.HasPrefix(first, "generated-"), "ID must use generated- prefix")
+	assert.True(t, strings.HasPrefix(first, "pixiu-generated-endpoint-"),
+		"ID must use pixiu-generated-endpoint- prefix")
 	assert.NotContains(t, first, "key-a", "raw API key must not leak into the ID")
 }
 
@@ -170,6 +171,6 @@ func TestGenerateEndpointIDSeparatesAddresses(t *testing.T) {
 func TestGenerateEndpointIDHandlesNilEndpoint(t *testing.T) {
 	a := model.GenerateEndpointID("cluster-a", nil)
 	b := model.GenerateEndpointID("cluster-b", nil)
-	assert.True(t, strings.HasPrefix(a, "generated-"))
+	assert.True(t, strings.HasPrefix(a, "pixiu-generated-endpoint-"))
 	assert.NotEqual(t, a, b)
 }

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -312,6 +312,13 @@ func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 		return
 	}
 
+	// generatedIDIndex tracks the slice position where each generated ID was
+	// first observed within this cluster. A duplicate means two endpoints
+	// share (cluster_name, address, provider, api_key) and collapse onto a
+	// single identifier, which is silent in the runtime path; warn loudly so
+	// the operator can disambiguate by setting an explicit `id:`.
+	generatedIDIndex := make(map[string]int, len(c.Endpoints))
+
 	for i, endpoint := range c.Endpoints {
 		// If the endpoint ID is not set, derive a deterministic one so the same
 		// endpoint hashes to the same ID across process restarts. Identifiers
@@ -319,6 +326,13 @@ func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 		// (PickNextEndpoint, GetEndpointByID, DeleteEndpoint).
 		if endpoint.ID == "" {
 			endpoint.ID = model.GenerateEndpointID(c.Name, endpoint)
+			if prev, dup := generatedIDIndex[endpoint.ID]; dup {
+				logger.Warnf("[cluster=%s] endpoints[%d] and endpoints[%d] share generated ID %s; "+
+					"set an explicit `id:` on one of them to keep them distinct",
+					c.Name, prev, i, endpoint.ID)
+			} else {
+				generatedIDIndex[endpoint.ID] = i
+			}
 		}
 
 		// If the endpoint has no name, set a default name

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -24,10 +24,6 @@ import (
 )
 
 import (
-	"github.com/hashicorp/go-uuid"
-)
-
-import (
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster"
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/yaml"
@@ -317,9 +313,12 @@ func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 	}
 
 	for i, endpoint := range c.Endpoints {
-		// If the endpoint ID is not set, set it to the index + 1
+		// If the endpoint ID is not set, derive a deterministic one so the same
+		// endpoint hashes to the same ID across process restarts. Identifiers
+		// must be stable for metrics/log correlation and runtime lookups
+		// (PickNextEndpoint, GetEndpointByID, DeleteEndpoint).
 		if endpoint.ID == "" {
-			endpoint.ID, _ = uuid.GenerateUUID()
+			endpoint.ID = model.GenerateEndpointID(c.Name, endpoint)
 		}
 
 		// If the endpoint has no name, set a default name

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -500,6 +500,61 @@ func TestClusterManager_Race_RoundRobinPickEndpoint(t *testing.T) {
 	wg.Wait()
 }
 
+func TestClusterManager_AssembleEndpointsAssignsDeterministicID(t *testing.T) {
+	build := func() *model.ClusterConfig {
+		return &model.ClusterConfig{
+			Name:  "assemble-id",
+			LbStr: model.LoadBalancerRoundRobin,
+			Endpoints: []*model.Endpoint{
+				{Address: model.SocketAddress{Address: "127.0.0.1", Port: 21080}},
+				{Address: model.SocketAddress{Address: "127.0.0.1", Port: 21081}},
+			},
+		}
+	}
+
+	first := testClusterManager(build())
+	defer stopStoreRuntimes(first.store)
+	second := testClusterManager(build())
+	defer stopStoreRuntimes(second.store)
+
+	firstEPs := first.store.Config[0].Endpoints
+	secondEPs := second.store.Config[0].Endpoints
+
+	if !assert.Len(t, firstEPs, 2) || !assert.Len(t, secondEPs, 2) {
+		return
+	}
+
+	// Deterministic: identical static config produces identical IDs across
+	// independent constructions, so dashboards keyed on endpoint.ID survive
+	// process restart.
+	assert.Equal(t, firstEPs[0].ID, secondEPs[0].ID)
+	assert.Equal(t, firstEPs[1].ID, secondEPs[1].ID)
+
+	// Generated prefix indicates the deterministic helper, not the legacy
+	// random UUID fallback.
+	assert.Contains(t, firstEPs[0].ID, "generated-")
+
+	// Endpoints differing only by port must not collide within the same cluster.
+	assert.NotEqual(t, firstEPs[0].ID, firstEPs[1].ID)
+}
+
+func TestClusterManager_AssembleEndpointsPreservesExplicitID(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		Name:  "explicit-id",
+		LbStr: model.LoadBalancerRoundRobin,
+		Endpoints: []*model.Endpoint{
+			{ID: "operator-pinned", Address: model.SocketAddress{Address: "127.0.0.1", Port: 21082}},
+		},
+	}
+
+	cm := testClusterManager(cluster)
+	defer stopStoreRuntimes(cm.store)
+
+	if assert.Len(t, cm.store.Config[0].Endpoints, 1) {
+		assert.Equal(t, "operator-pinned", cm.store.Config[0].Endpoints[0].ID)
+	}
+}
+
 func testClusterManager(clusters ...*model.ClusterConfig) *ClusterManager {
 	return CreateDefaultClusterManager(&model.Bootstrap{
 		StaticResources: model.StaticResources{

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -555,6 +555,36 @@ func TestClusterManager_AssembleEndpointsPreservesExplicitID(t *testing.T) {
 	}
 }
 
+// TestClusterManager_AssembleEndpointsCollapseDuplicateGenerated locks the
+// documented collapse behavior: two static endpoints sharing every input that
+// feeds GenerateEndpointID (cluster name, address, LLM credential) end up with
+// the same generated ID, and operators must set an explicit `id:` to keep
+// them distinct.
+func TestClusterManager_AssembleEndpointsCollapseDuplicateGenerated(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		Name:  "collapse-id",
+		LbStr: model.LoadBalancerRoundRobin,
+		Endpoints: []*model.Endpoint{
+			{Address: model.SocketAddress{Address: "127.0.0.1", Port: 21083}},
+			{Address: model.SocketAddress{Address: "127.0.0.1", Port: 21083}},
+		},
+	}
+
+	cm := testClusterManager(cluster)
+	defer stopStoreRuntimes(cm.store)
+
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 2) {
+		return
+	}
+
+	// Both endpoints survived in the slice (we do not silently dedupe) but
+	// share the same generated identifier.
+	assert.Equal(t, endpoints[0].ID, endpoints[1].ID,
+		"endpoints with identical hash material must collapse to the same ID")
+	assert.Contains(t, endpoints[0].ID, "generated-")
+}
+
 func testClusterManager(clusters ...*model.ClusterConfig) *ClusterManager {
 	return CreateDefaultClusterManager(&model.Bootstrap{
 		StaticResources: model.StaticResources{

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -532,7 +532,7 @@ func TestClusterManager_AssembleEndpointsAssignsDeterministicID(t *testing.T) {
 
 	// Generated prefix indicates the deterministic helper, not the legacy
 	// random UUID fallback.
-	assert.Contains(t, firstEPs[0].ID, "generated-")
+	assert.Contains(t, firstEPs[0].ID, "pixiu-generated-endpoint-")
 
 	// Endpoints differing only by port must not collide within the same cluster.
 	assert.NotEqual(t, firstEPs[0].ID, firstEPs[1].ID)
@@ -582,7 +582,7 @@ func TestClusterManager_AssembleEndpointsCollapseDuplicateGenerated(t *testing.T
 	// share the same generated identifier.
 	assert.Equal(t, endpoints[0].ID, endpoints[1].ID,
 		"endpoints with identical hash material must collapse to the same ID")
-	assert.Contains(t, endpoints[0].ID, "generated-")
+	assert.Contains(t, endpoints[0].ID, "pixiu-generated-endpoint-")
 }
 
 func testClusterManager(clusters ...*model.ClusterConfig) *ClusterManager {


### PR DESCRIPTION
❗️Breaking change
### Description
Replaces the random-UUID endpoint identity used by the Nacos LLM registry
and the static cluster-config bootstrap with a deterministic SHA-256-based
scheme, so `endpoint.ID` is stable across process restarts and Nacos
re-subscriptions. Two related bugs in the same Nacos function — `Port`
being overwritten with 0 when `metadata["port"]` fails to parse, and
`Address` not falling back to `instance.Ip` / `instance.Port` — are fixed
along the way.

### Why

`endpoint.ID` is the index key for many runtime and observability paths.
With a random-UUID fallback, every process restart (and every Nacos
re-subscription) produces a fresh ID for the same physical endpoint:

| Path                                                                | What happens after restart                                                          |
| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| Prometheus metrics with `endpoint` label                            | label values change; each endpoint becomes multiple broken lines in Grafana         |
| Logs correlated by `endpoint.ID`                                    | pre- and post-restart logs no longer link, SRE loses the thread on every restart    |
| `ClusterManager.PickNextEndpoint(curEndpointID)`                    | uses `endpoint.ID` as a retry cursor — every in-flight retry chain drops on restart |
| LLM health-check / circuit-breaker state (indexed by `endpoint.ID`) | treated as a brand-new endpoint, health and breaker state reset to zero             |

This is the kind of bug that doesn't surface in functional tests
(service runs, requests succeed) but bleeds operationally — operators
see endpoints "mysteriously disappearing and reappearing" in dashboards
and end up patching by manually setting `metadata["id"]` on every Nacos
instance. That patches the symptom. This PR removes the cause.

### Root Cause

The relevant `uuid.GenerateUUID()` fallbacks (pre-PR):

```go
// pkg/adapter/llmregistry/registry/nacos/listener.go (before)
if id, ok := instance.Metadata["id"]; ok {
    ret.ID = id
} else {
    ret.ID, _ = uuid.GenerateUUID()   // fresh random UUID every restart
}
```

```go
// pkg/server/cluster_manager.go (before)
if endpoint.ID == "" {
    endpoint.ID, _ = uuid.GenerateUUID()   // same problem in the static-config path
}
```

Neither call site consulted `instance.InstanceId` (Nacos already
provides a stable identifier), and neither used any content-addressable
hash of the endpoint's defining attributes. In the Nacos path the
problem also fires on every re-subscription, not only on restart,
because each callback re-derives `endpoint.ID` from scratch.

Two unrelated bugs sit in the same `generateEndpoint` block:

- `metadata["port"]` parse failure logs a warning but still writes the
  parser's zero result into `Address.Port`, silently zeroing a valid port.
- `Address.Address` / `Address.Port` are populated only from
  `metadata["ip"]` / `metadata["port"]`, so instances that publish only
  `instance.Ip` / `instance.Port` (no metadata overrides) produce
  endpoints with an empty address.

### PR Goal

Make endpoint identity a function of the endpoint's defining attributes
— cluster name, address, provider, API key — instead of a function of
when the process happened to start. Keep behavior consistent between the
Nacos LLM registry path and the static cluster-config bootstrap path so
operators see the same identity rules regardless of registry source.

### Success Criteria

- A Nacos instance carrying `metadata["id"]` continues to use that ID.
- A Nacos instance carrying `InstanceId` but no `metadata["id"]` uses
  `InstanceId` (one upgrade-time shift, then stable forever).
- A Nacos instance carrying neither produces `generated-<sha8>` derived
  from `(metadata["cluster"], address, provider, api_key)`, identical
  across restarts and re-subscriptions.
- A static-config endpoint with empty `id:` produces the same
  deterministic identifier on every boot.
- Renaming an endpoint (`metadata["name"]`) does not change its ID.
- Two endpoints differing only by credential do not collide.
- The raw API key never appears in the generated ID (SHA-256 is one-way).
- `metadata["port"]` parse error preserves the baseline `instance.Port`.
- `Address` baselines from `instance.Ip` / `instance.Port` before
  metadata overrides.

### Upgrade-visible behavior change ⚠

| Source                                | Before           | After              |
| ------------------------------------- | ---------------- | ------------------ |
| Nacos instance with `metadata["id"]`  | `metadata["id"]` | unchanged          |
| Nacos instance with `InstanceId` only | random UUID      | `InstanceId`       |
| Nacos instance without either         | random UUID      | `generated-<sha8>` |
| Static config endpoint with empty ID  | random UUID      | `generated-<sha8>` |

Operators must rebuild any dashboards, log queries, or runbooks keyed on
`endpoint.ID`. On the first deploy after upgrade, downstream consumers
of `OnAddEndpoint` / `OnRemoveEndpoint` will see one round of
remove-then-add per endpoint whose ID changes shape.

There is no runtime opt-out for this behavior change — the migration is
one-shot and reviewers should confirm this is acceptable for their
deployment before merging.

### Known limitations

- **Static endpoint collapse.** Two static endpoints with empty `id:`
  that share the same `(cluster_name, address, provider, api_key)` now
  collapse to a single identifier. They were already indistinguishable
  to the picker; the previous random IDs offered no real separation.
  `assembleClusterEndpoints` logs a `warn` naming both slice positions
  and the shared ID when this happens, so the misconfiguration is
  visible. Set an explicit `id:` to keep them distinct.
- **Nacos instances without `metadata["cluster"]`.** The cluster-name
  component falls back to the empty string, so endpoints across
  different Nacos services sharing `(address, provider, api_key)` will
  collide. Set `metadata.cluster` on the Nacos side to prevent this.

### Paths this PR should affect

- `pkg/model/cluster.go`
- `pkg/model/cluster_test.go`
- `pkg/adapter/llmregistry/registry/nacos/listener.go`
- `pkg/adapter/llmregistry/registry/nacos/listener_test.go`
- `pkg/server/cluster_manager.go`
- `pkg/server/cluster_manager_test.go`
- `go.mod` (drops `hashicorp/go-uuid` from direct dependencies)

### Revise

- **Adding `model.GenerateEndpointID(clusterName, endpoint)`**: returns
  `"generated-<8-byte-hex>"` where the 8 bytes are the leading bytes of
  `sha256(clusterName ‖ address ‖ provider ‖ apiKey)`. Documented design
  notes cover the 64-bit truncation rationale, the empty-clusterName
  edge case, and the deliberate inclusion of the API key.
- **Changing Nacos `generateEndpoint`**: three-tier identity lookup —
  `metadata["id"]` → `instance.InstanceId` → `GenerateEndpointID`. Stops
  zeroing `Address.Port` on `metadata["port"]` parse failure. Seeds
  `Address.Address` / `Address.Port` from `instance.Ip` /
  `instance.Port` before metadata overrides apply.
- **Changing `assembleClusterEndpoints`**: empty `endpoint.ID` is filled
  by `GenerateEndpointID(cluster.Name, endpoint)` instead of
  `uuid.GenerateUUID()`. Updates the comment that incorrectly claimed
  the ID was the endpoint index. Logs a `warn` (with both slice
  positions and the shared ID) whenever two endpoints in the same
  cluster end up with the same generated ID, so the documented collapse
  behavior is loud rather than silent.
- **Hardening `endpointIDMaterial` contract**: the helper now carries a
  comment stating it MUST NOT depend on `endpoint.Name`, because two
  call sites rely on that — `assembleClusterEndpoints` derives the ID
  before assigning a default Name, and the rename-invariance test
  enforces it.
- **Adding regression tests**: deterministic-across-calls, rename
  invariance, credential-difference distinction, address-difference
  distinction, cluster-difference distinction, raw-key non-leakage,
  Nacos `InstanceId` fallback, Nacos generated-hash fallback,
  cross-rename ID stability, static-config endpoint collapse,
  explicit-ID preservation.
- **Removing `hashicorp/go-uuid`** from direct dependencies in `go.mod`;
  it remains transitively pulled in.