### PR TITLE
fix(mcp): clear Content-Length header 

### DIFF
--- a/pkg/filter/mcp/mcpserver/filter_sse_test.go
+++ b/pkg/filter/mcp/mcpserver/filter_sse_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
 	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
+	"github.com/apache/dubbo-go-pixiu/pkg/client"
 	"github.com/apache/dubbo-go-pixiu/pkg/filter/mcp/mcpserver/transport"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )

--- a/pkg/filter/mcp/mcpserver/filter_sse_test.go
+++ b/pkg/filter/mcp/mcpserver/filter_sse_test.go
@@ -380,3 +380,47 @@ func createTestContext(req *http.Request, recorder *httptest.ResponseRecorder) *
 		Params:  make(map[string]any),
 	}
 }
+
+// TestSendMCPResponse_ClearsContentLength verifies that sendMCPResponse
+// clears the stale Content-Length header (which was copied from the backend
+// response by buildTargetResponse) before returning filter.Continue on the
+// JSON path. Without this, the larger MCP-wrapped body would exceed the
+// declared Content-Length and Go's net/http would abort the connection.
+func TestSendMCPResponse_ClearsContentLength(t *testing.T) {
+	mcpFilter := createTestFilter(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	rec := httptest.NewRecorder()
+	ctx := createTestContext(req, rec)
+	mcpCtx := NewMCPContext(ctx)
+
+	// Simulate what buildTargetResponse does: set a stale Content-Length
+	// from a hypothetical backend response (e.g. backend returned 47 bytes).
+	rec.Header().Set("Content-Length", "47")
+
+	// Build a response whose wrapped JSON body will be larger than 47 bytes.
+	resp := mcpFilter.responseBuilder.ToolCallSuccess(
+		"test-id",
+		`{"name":"test","age":30}`,
+	)
+
+	status := mcpFilter.sendMCPResponse(mcpCtx, resp)
+
+	// Must return Continue for the JSON path (no active SSE session).
+	if status != filter.Continue {
+		t.Fatalf("expected filter.Continue, got %v", status)
+	}
+
+	// The stale Content-Length header must be cleared.
+	if cl := rec.Header().Get("Content-Length"); cl != "" {
+		t.Errorf("Content-Length should have been cleared, but got %q", cl)
+	}
+
+	// Sanity: the wrapped body must be larger than the old Content-Length,
+	// otherwise the test scenario is not meaningful.
+	if unary, ok := ctx.TargetResp.(*client.UnaryResponse); ok {
+		if len(unary.Data) <= 47 {
+			t.Errorf("wrapped body too short for test (%d bytes)", len(unary.Data))
+		}
+	}
+}

--- a/pkg/filter/mcp/mcpserver/handlers.go
+++ b/pkg/filter/mcp/mcpserver/handlers.go
@@ -613,6 +613,7 @@ func (f *MCPServerFilter) sendMCPResponse(ctx *MCPContext, response mcp.JSONRPCR
 	ctx.TargetResp = &client.UnaryResponse{Data: mcpResponseBody}
 	ctx.StatusCode(http.StatusOK)
 	ctx.AddHeader(constant.HeaderKeyContextType, constant.HeaderValueApplicationJson)
+	ctx.ClearContentLengthHeader()
 
 	logger.Debugf("[dubbo-go-pixiu] mcp server successfully wrapped backend response in MCP format")
 	return filter.Continue


### PR DESCRIPTION
**What this PR does**:

When the MCP filter wraps a backend response into MCP JSON‑RPC format (`sendMCPResponse`, JSON path), the new response body is larger than the original. However, the old `Content-Length` header from the backend response was still copied to the `ResponseWriter`. This caused Go's `net/http` to report `http: wrote more than the declared Content-Length` and forcibly close the connection.

This PR clears the stale `Content-Length` header by calling `ctx.ClearContentLengthHeader()` before returning `filter.Continue` in `sendMCPResponse`. This allows `net/http` to automatically calculate the correct `Content-Length` from the actual response body, consistent with how `sendJSONResponse` and `ErrorHandler.sendResponse` already handle this situation.

**Which issue(s) this PR fixes**:

Fixes #(https://github.com/apache/dubbo-go-pixiu-samples/issues/142)

**Special notes for your reviewer**:

- This fix only affects the JSON path (`sendMCPResponse`). The SSE transport path is unchanged and continues to work normally.
- All existing `tools/call` tests pass after this change.
- Verified manually with MCP Inspector: `tools/call` returns a valid JSON‑RPC response.

**Does this PR introduce a user-facing change?**:

```release-note
NONE