### PR TITLE
feat(cluster):introduce healthy endpoint snapshot 

### DIFF
--- a/pkg/adapter/llmregistry/registry/nacos/listener.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener.go
@@ -19,7 +19,6 @@ package nacos
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -322,14 +321,19 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 // Lookup order:
 //  1. instance.Metadata["id"] (operator override)
 //  2. instance.InstanceId (nacos-assigned identity, stable for a registration)
-//  3. model.GenerateEndpointID(metadata["cluster"], endpoint)
-//  4. fallback when cluster metadata is missing: a deterministic key built
-//     from ServiceName + ClusterName + address, prefixed with the constant
-//     nacosMissingClusterFallbackPrefix so the synthesized identity is
-//     visible in logs/dashboards. A warn is logged once per call so an
-//     operator can fix the metadata; without it, two instances at the
-//     same address from different services would alias to the same
-//     generated- ID (clusterName == "" in the hash material).
+//  3. model.GenerateEndpointID(metadata["cluster"], endpoint) — covers the
+//     normal LLM registry flow where adapter routes by metadata["cluster"]
+//
+// When metadata["cluster"] is missing, this function still returns the
+// generated- ID with an empty cluster name in the hash, but logs a warn
+// pointing the operator at the downstream behavior: the LLM registry
+// adapter (Adapter.OnAddEndpoint) explicitly skips endpoints that lack
+// metadata["cluster"] (see pkg/adapter/llmregistry/registrycenter.go).
+// In other words, an endpoint reaching this branch will not be admitted
+// into any runtime cluster regardless of the ID we synthesize, so we do
+// not try to disambiguate cross-service collisions here — the
+// disambiguation is the adapter's job and currently is "drop". If that
+// adapter contract relaxes, this function will need a real fallback.
 func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) string {
 	if id := strings.TrimSpace(instance.Metadata["id"]); id != "" {
 		return id
@@ -338,32 +342,20 @@ func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) str
 		return instanceID
 	}
 	clusterMeta := strings.TrimSpace(instance.Metadata["cluster"])
-	if clusterMeta != "" {
-		return model.GenerateEndpointID(clusterMeta, endpoint)
+	if clusterMeta == "" {
+		address := ""
+		if endpoint != nil {
+			address = endpoint.Address.GetAddress()
+		}
+		logger.Warnf(
+			"[dubbo-go-pixiu] nacos instance (service=%s, cluster=%s, addr=%s) is missing metadata[\"cluster\"]; "+
+				"the LLM registry adapter will skip this endpoint. Set metadata[\"cluster\"] (or "+
+				"metadata[\"id\"]) on the nacos registration to admit it into a runtime cluster.",
+			instance.ServiceName, instance.ClusterName, address,
+		)
 	}
-	address := ""
-	if endpoint != nil {
-		address = endpoint.Address.GetAddress()
-	}
-	fallback := fmt.Sprintf("%s%s/%s/%s",
-		nacosMissingClusterFallbackPrefix,
-		instance.ServiceName,
-		instance.ClusterName,
-		address,
-	)
-	logger.Warnf(
-		"[dubbo-go-pixiu] nacos instance %q (service=%s, cluster=%s, addr=%s) is missing metadata[\"cluster\"]; "+
-			"endpoint ID falls back to %q. Set metadata[\"cluster\"] (or metadata[\"id\"]) so cross-cluster instances "+
-			"at the same address do not alias.",
-		instance.InstanceId, instance.ServiceName, instance.ClusterName, address, fallback,
-	)
-	return fallback
+	return model.GenerateEndpointID(clusterMeta, endpoint)
 }
-
-// nacosMissingClusterFallbackPrefix marks endpoint IDs synthesized by
-// nacosEndpointID when the nacos instance lacks metadata["cluster"]. The
-// prefix lets operators grep for misconfigured registrations.
-const nacosMissingClusterFallbackPrefix = "nacos-no-cluster-"
 
 func generateInstance(ss nacosModel.SubscribeService) nacosModel.Instance {
 	return nacosModel.Instance{

--- a/pkg/adapter/llmregistry/registry/nacos/listener.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener.go
@@ -19,6 +19,7 @@ package nacos
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -317,6 +318,18 @@ func generateEndpoint(instance nacosModel.Instance) *model.Endpoint {
 	return ret
 }
 
+// nacosEndpointID resolves a stable endpoint ID for a nacos instance.
+// Lookup order:
+//  1. instance.Metadata["id"] (operator override)
+//  2. instance.InstanceId (nacos-assigned identity, stable for a registration)
+//  3. model.GenerateEndpointID(metadata["cluster"], endpoint)
+//  4. fallback when cluster metadata is missing: a deterministic key built
+//     from ServiceName + ClusterName + address, prefixed with the constant
+//     nacosMissingClusterFallbackPrefix so the synthesized identity is
+//     visible in logs/dashboards. A warn is logged once per call so an
+//     operator can fix the metadata; without it, two instances at the
+//     same address from different services would alias to the same
+//     generated- ID (clusterName == "" in the hash material).
 func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) string {
 	if id := strings.TrimSpace(instance.Metadata["id"]); id != "" {
 		return id
@@ -324,12 +337,33 @@ func nacosEndpointID(instance nacosModel.Instance, endpoint *model.Endpoint) str
 	if instanceID := strings.TrimSpace(instance.InstanceId); instanceID != "" {
 		return instanceID
 	}
-	clusterName := strings.TrimSpace(instance.Metadata["cluster"])
-	if clusterName == "" {
-		clusterName = strings.TrimSpace(instance.ClusterName)
+	clusterMeta := strings.TrimSpace(instance.Metadata["cluster"])
+	if clusterMeta != "" {
+		return model.GenerateEndpointID(clusterMeta, endpoint)
 	}
-	return model.GenerateEndpointID(clusterName, endpoint)
+	address := ""
+	if endpoint != nil {
+		address = endpoint.Address.GetAddress()
+	}
+	fallback := fmt.Sprintf("%s%s/%s/%s",
+		nacosMissingClusterFallbackPrefix,
+		instance.ServiceName,
+		instance.ClusterName,
+		address,
+	)
+	logger.Warnf(
+		"[dubbo-go-pixiu] nacos instance %q (service=%s, cluster=%s, addr=%s) is missing metadata[\"cluster\"]; "+
+			"endpoint ID falls back to %q. Set metadata[\"cluster\"] (or metadata[\"id\"]) so cross-cluster instances "+
+			"at the same address do not alias.",
+		instance.InstanceId, instance.ServiceName, instance.ClusterName, address, fallback,
+	)
+	return fallback
 }
+
+// nacosMissingClusterFallbackPrefix marks endpoint IDs synthesized by
+// nacosEndpointID when the nacos instance lacks metadata["cluster"]. The
+// prefix lets operators grep for misconfigured registrations.
+const nacosMissingClusterFallbackPrefix = "nacos-no-cluster-"
 
 func generateInstance(ss nacosModel.SubscribeService) nacosModel.Instance {
 	return nacosModel.Instance{

--- a/pkg/adapter/llmregistry/registry/nacos/listener_test.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener_test.go
@@ -490,6 +490,60 @@ func TestServiceCallbackKeepsNacosInstancesWithoutMetadataIDDistinct(t *testing.
 	assert.Contains(t, adapterListener.removedEndpoints, "nacos-instance-a")
 }
 
+// TestNacosEndpointIDFallbackDifferentiatesServicesWithoutClusterMetadata
+// covers the case where nacosEndpointID has neither metadata["id"], nor an
+// InstanceId, nor metadata["cluster"] to feed into the deterministic hash.
+// Two such instances at the same address (e.g. registered against different
+// nacos services in the same DC) must not alias to the same endpoint ID. The
+// fallback derives identity from ServiceName + ClusterName + address.
+func TestNacosEndpointIDFallbackDifferentiatesServicesWithoutClusterMetadata(t *testing.T) {
+	// Instance A: service "alpha", cluster "DEFAULT", same IP/port as B.
+	instanceA := nacosModel.Instance{
+		// InstanceId intentionally empty; metadata has neither "id" nor "cluster".
+		Ip:          "10.0.0.1",
+		Port:        18080,
+		ServiceName: "alpha",
+		ClusterName: "DEFAULT",
+		Metadata:    map[string]string{"llm-meta.api_key": "key-shared"},
+	}
+	endpointA := generateEndpoint(instanceA)
+
+	// Instance B: different service, same address + credential.
+	instanceB := nacosModel.Instance{
+		Ip:          "10.0.0.1",
+		Port:        18080,
+		ServiceName: "bravo",
+		ClusterName: "DEFAULT",
+		Metadata:    map[string]string{"llm-meta.api_key": "key-shared"},
+	}
+	endpointB := generateEndpoint(instanceB)
+
+	assert.NotEqual(t, endpointA.ID, endpointB.ID,
+		"nacos instances at the same address but registered against different services "+
+			"must not alias to the same generated- ID just because metadata[\"cluster\"] is missing")
+	assert.Contains(t, endpointA.ID, nacosMissingClusterFallbackPrefix,
+		"fallback ID must be visibly tagged so misconfigured registrations are greppable")
+	assert.Contains(t, endpointB.ID, nacosMissingClusterFallbackPrefix)
+}
+
+// TestNacosEndpointIDFallbackStableForSameInstance ensures the fallback
+// ID is deterministic: re-generating from the same nacos instance returns
+// the same ID, so dashboards and snapshot inheritance keep working.
+func TestNacosEndpointIDFallbackStableForSameInstance(t *testing.T) {
+	instance := nacosModel.Instance{
+		Ip:          "10.0.0.1",
+		Port:        18080,
+		ServiceName: "alpha",
+		ClusterName: "DEFAULT",
+		Metadata:    map[string]string{},
+	}
+
+	first := generateEndpoint(instance).ID
+	second := generateEndpoint(instance).ID
+	assert.Equal(t, first, second)
+	assert.Contains(t, first, nacosMissingClusterFallbackPrefix)
+}
+
 func TestLifecycle(t *testing.T) {
 	l, _, _ := testSetup()
 

--- a/pkg/adapter/llmregistry/registry/nacos/listener_test.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener_test.go
@@ -211,7 +211,7 @@ func TestGenerateEndpoint(t *testing.T) {
 		assert.NotContains(t, first.ID, "key-a")
 	})
 
-	t.Run("Missing metadata cluster falls back to Nacos cluster name", func(t *testing.T) {
+	t.Run("Missing metadata cluster falls back to empty cluster hash", func(t *testing.T) {
 		build := func(clusterName string) nacosModel.Instance {
 			return nacosModel.Instance{
 				Ip:          "127.0.0.1",
@@ -230,7 +230,7 @@ func TestGenerateEndpoint(t *testing.T) {
 		assert.NotNil(t, clusterA)
 		assert.NotNil(t, clusterB)
 		assert.Contains(t, clusterA.ID, "pixiu-generated-endpoint-")
-		assert.NotEqual(t, clusterA.ID, clusterB.ID)
+		assert.Equal(t, clusterA.ID, clusterB.ID)
 	})
 }
 
@@ -510,7 +510,7 @@ func TestNacosEndpointIDMissingClusterFallsBackToEmptyClusterHash(t *testing.T) 
 	}
 
 	endpoint := generateEndpoint(instance)
-	assert.True(t, strings.HasPrefix(endpoint.ID, "generated-"),
+	assert.True(t, strings.HasPrefix(endpoint.ID, "pixiu-generated-endpoint-"),
 		"missing metadata[\"cluster\"] falls through to model.GenerateEndpointID with empty cluster")
 
 	// Deterministic: re-generating from the same instance returns the same ID.

--- a/pkg/adapter/llmregistry/registry/nacos/listener_test.go
+++ b/pkg/adapter/llmregistry/registry/nacos/listener_test.go
@@ -19,6 +19,7 @@ package nacos
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -490,15 +491,16 @@ func TestServiceCallbackKeepsNacosInstancesWithoutMetadataIDDistinct(t *testing.
 	assert.Contains(t, adapterListener.removedEndpoints, "nacos-instance-a")
 }
 
-// TestNacosEndpointIDFallbackDifferentiatesServicesWithoutClusterMetadata
-// covers the case where nacosEndpointID has neither metadata["id"], nor an
-// InstanceId, nor metadata["cluster"] to feed into the deterministic hash.
-// Two such instances at the same address (e.g. registered against different
-// nacos services in the same DC) must not alias to the same endpoint ID. The
-// fallback derives identity from ServiceName + ClusterName + address.
-func TestNacosEndpointIDFallbackDifferentiatesServicesWithoutClusterMetadata(t *testing.T) {
-	// Instance A: service "alpha", cluster "DEFAULT", same IP/port as B.
-	instanceA := nacosModel.Instance{
+// TestNacosEndpointIDMissingClusterFallsBackToEmptyClusterHash ensures that
+// when a nacos instance has no metadata["id"], no InstanceId, and no
+// metadata["cluster"], nacosEndpointID returns a generated- ID derived
+// with an empty cluster name. The downstream LLM registry adapter
+// (Adapter.OnAddEndpoint) drops such endpoints, so we do not attempt to
+// disambiguate cross-service collisions here. The contract this test
+// locks: the function does not invent a synthesized fallback prefix and
+// does not pretend an unreachable endpoint will be admitted.
+func TestNacosEndpointIDMissingClusterFallsBackToEmptyClusterHash(t *testing.T) {
+	instance := nacosModel.Instance{
 		// InstanceId intentionally empty; metadata has neither "id" nor "cluster".
 		Ip:          "10.0.0.1",
 		Port:        18080,
@@ -506,42 +508,28 @@ func TestNacosEndpointIDFallbackDifferentiatesServicesWithoutClusterMetadata(t *
 		ClusterName: "DEFAULT",
 		Metadata:    map[string]string{"llm-meta.api_key": "key-shared"},
 	}
-	endpointA := generateEndpoint(instanceA)
 
-	// Instance B: different service, same address + credential.
-	instanceB := nacosModel.Instance{
-		Ip:          "10.0.0.1",
-		Port:        18080,
-		ServiceName: "bravo",
-		ClusterName: "DEFAULT",
-		Metadata:    map[string]string{"llm-meta.api_key": "key-shared"},
+	endpoint := generateEndpoint(instance)
+	assert.True(t, strings.HasPrefix(endpoint.ID, "generated-"),
+		"missing metadata[\"cluster\"] falls through to model.GenerateEndpointID with empty cluster")
+
+	// Deterministic: re-generating from the same instance returns the same ID.
+	assert.Equal(t, endpoint.ID, generateEndpoint(instance).ID)
+
+	// Acknowledged limitation: at this code level we cannot tell two
+	// instances apart that share address+credential and both lack
+	// metadata["cluster"]. They alias to the same generated- ID. The LLM
+	// registry adapter skips them before the alias has any runtime effect.
+	collidingInstance := nacosModel.Instance{
+		Ip:          instance.Ip,
+		Port:        instance.Port,
+		ServiceName: "bravo", // different service, but the adapter ignores ServiceName for ID
+		ClusterName: instance.ClusterName,
+		Metadata:    instance.Metadata,
 	}
-	endpointB := generateEndpoint(instanceB)
-
-	assert.NotEqual(t, endpointA.ID, endpointB.ID,
-		"nacos instances at the same address but registered against different services "+
-			"must not alias to the same generated- ID just because metadata[\"cluster\"] is missing")
-	assert.Contains(t, endpointA.ID, nacosMissingClusterFallbackPrefix,
-		"fallback ID must be visibly tagged so misconfigured registrations are greppable")
-	assert.Contains(t, endpointB.ID, nacosMissingClusterFallbackPrefix)
-}
-
-// TestNacosEndpointIDFallbackStableForSameInstance ensures the fallback
-// ID is deterministic: re-generating from the same nacos instance returns
-// the same ID, so dashboards and snapshot inheritance keep working.
-func TestNacosEndpointIDFallbackStableForSameInstance(t *testing.T) {
-	instance := nacosModel.Instance{
-		Ip:          "10.0.0.1",
-		Port:        18080,
-		ServiceName: "alpha",
-		ClusterName: "DEFAULT",
-		Metadata:    map[string]string{},
-	}
-
-	first := generateEndpoint(instance).ID
-	second := generateEndpoint(instance).ID
-	assert.Equal(t, first, second)
-	assert.Contains(t, first, nacosMissingClusterFallbackPrefix)
+	assert.Equal(t, endpoint.ID, generateEndpoint(collidingInstance).ID,
+		"two instances missing metadata[\"cluster\"] at the same address will alias here; "+
+			"disambiguation is the adapter's job (currently: drop)")
 }
 
 func TestLifecycle(t *testing.T) {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -39,7 +39,6 @@ type Cluster struct {
 	// without health checks.
 	Config             *model.ClusterConfig
 	healthMu           sync.Mutex
-	legacyPickMu       sync.Mutex
 	acceptHealthEvents bool
 	endpoints          atomic.Pointer[EndpointSnapshot]
 }
@@ -85,20 +84,8 @@ func (c *Cluster) AddEndpoint(endpoint *model.Endpoint) {
 	}
 }
 
-// LegacyPickLock returns the runtime-scoped lock for legacy load balancer picks.
-func (c *Cluster) LegacyPickLock() sync.Locker {
-	if c == nil {
-		return nil
-	}
-	return &c.legacyPickMu
-}
-
 func (c *Cluster) EndpointSnapshot() *EndpointSnapshot {
-	snapshot := c.endpoints.Load()
-	if snapshot == nil {
-		return emptyEndpointSnapshot
-	}
-	return snapshot
+	return c.endpoints.Load()
 }
 
 func (c *Cluster) RefreshEndpoints() {
@@ -179,9 +166,6 @@ func (c *Cluster) UpdateEndpointAddressHealth(endpointAddress string, healthy bo
 // SnapshotForRuntimeReplacement freezes health updates on this runtime and
 // returns the final snapshot that a replacement runtime should inherit.
 func (c *Cluster) SnapshotForRuntimeReplacement() *EndpointSnapshot {
-	if c == nil {
-		return nil
-	}
 	c.healthMu.Lock()
 	defer c.healthMu.Unlock()
 	c.acceptHealthEvents = false
@@ -215,16 +199,6 @@ type EndpointSnapshot struct {
 	consistentHashOnce   sync.Once
 	consistentHash       model.LbConsistentHashView
 	consistentHashConfig model.ConsistentHash
-}
-
-var emptyEndpointSnapshot = &EndpointSnapshot{
-	all:                 []*model.Endpoint{},
-	healthy:             []*model.Endpoint{},
-	endpointByID:        map[string]*model.Endpoint{},
-	healthyEndpointByID: map[string]*model.Endpoint{},
-	addressByID:         map[string]string{},
-	healthyByID:         map[string]bool{},
-	healthyByAddress:    map[string]bool{},
 }
 
 // newEndpointSnapshot builds an EndpointSnapshot from config plus the

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -227,6 +227,25 @@ var emptyEndpointSnapshot = &EndpointSnapshot{
 	healthyByAddress:    map[string]bool{},
 }
 
+// newEndpointSnapshot builds an EndpointSnapshot from config plus the
+// previous snapshot it should inherit runtime state from. Endpoints are
+// deep-cloned, so any subsequent mutation on the config side stays
+// invisible to the request path.
+//
+// Sharing contract (issue #905):
+//
+//   - The returned snapshot owns its endpoints, addressByID, and
+//     healthyBy* maps. Callers reading via *ForPick accessors must not
+//     mutate or retain anything beyond a single pick.
+//   - withEndpointHealthForIDs derives a successor snapshot that REUSES
+//     unchanged *Endpoint pointers and the prior addressByID map for
+//     allocation efficiency. This is safe only because *Endpoint and
+//     the underlying maps are treated as read-only after publication.
+//     Any code path that mutates them in place will leak state across
+//     all snapshots alive at the time of the mutation. The
+//     ZeroCopySnapshotLoadBalancer marker on load balancers exists
+//     precisely to opt into this contract; do not introduce new
+//     in-place mutation on snapshot-owned objects.
 func newEndpointSnapshot(config *model.ClusterConfig, previous *EndpointSnapshot, inheritRuntimeHealth bool) *EndpointSnapshot {
 	var endpoints []*model.Endpoint
 	clusterName := ""

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -239,8 +239,11 @@ var emptyEndpointSnapshot = &EndpointSnapshot{
 //     mutate or retain anything beyond a single pick.
 //   - withEndpointHealthForIDs derives a successor snapshot that REUSES
 //     unchanged *Endpoint pointers and the prior addressByID map for
-//     allocation efficiency. This is safe only because *Endpoint and
-//     the underlying maps are treated as read-only after publication.
+//     allocation efficiency. addressByID is safe to share only because it
+//     maps immutable endpoint IDs to immutable GetAddress strings and is
+//     never mutated after the original snapshot is published. This is safe
+//     only because *Endpoint and the underlying maps are treated as
+//     read-only after publication.
 //     Any code path that mutates them in place will leak state across
 //     all snapshots alive at the time of the mutation. The
 //     ZeroCopySnapshotLoadBalancer marker on load balancers exists

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -18,23 +18,50 @@
 package cluster
 
 import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/cluster/healthcheck"
+	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 
 type Cluster struct {
 	HealthCheck *healthcheck.HealthChecker
-	Config      *model.ClusterConfig
+	// Config is the desired cluster configuration. Runtime picks read the
+	// published EndpointSnapshot, so direct edits to Config.Endpoints or
+	// Endpoint.UnHealthy are not observed by PickEndpoint immediately. Publish
+	// membership/address changes with RefreshEndpoints; publish runtime health
+	// changes with UpdateEndpointHealth, or RefreshEndpoints for clusters
+	// without health checks.
+	Config             *model.ClusterConfig
+	healthMu           sync.Mutex
+	legacyPickMu       sync.Mutex
+	acceptHealthEvents bool
+	endpoints          atomic.Pointer[EndpointSnapshot]
 }
 
 func NewCluster(clusterConfig *model.ClusterConfig) *Cluster {
+	return NewClusterWithEndpointSnapshot(clusterConfig, nil)
+}
+
+func NewClusterWithEndpointSnapshot(clusterConfig *model.ClusterConfig, previous *EndpointSnapshot) *Cluster {
 	c := &Cluster{
-		Config: clusterConfig,
+		Config:             clusterConfig,
+		acceptHealthEvents: true,
 	}
+	c.RefreshEndpointsFrom(previous)
 
 	// only handle one health checker
 	if len(c.Config.HealthChecks) != 0 {
-		c.HealthCheck = healthcheck.CreateHealthCheck(clusterConfig, c.Config.HealthChecks[0])
+		c.HealthCheck = healthcheck.CreateHealthCheckWithCallback(
+			clusterConfig,
+			c.Config.HealthChecks[0],
+			c.handleEndpointHealth,
+		)
 		c.HealthCheck.Start()
 	}
 	return c
@@ -56,4 +83,471 @@ func (c *Cluster) AddEndpoint(endpoint *model.Endpoint) {
 	if c.HealthCheck != nil {
 		c.HealthCheck.StartOne(endpoint)
 	}
+}
+
+// LegacyPickLock returns the runtime-scoped lock for legacy load balancer picks.
+func (c *Cluster) LegacyPickLock() sync.Locker {
+	if c == nil {
+		return nil
+	}
+	return &c.legacyPickMu
+}
+
+func (c *Cluster) EndpointSnapshot() *EndpointSnapshot {
+	snapshot := c.endpoints.Load()
+	if snapshot == nil {
+		return emptyEndpointSnapshot
+	}
+	return snapshot
+}
+
+func (c *Cluster) RefreshEndpoints() {
+	c.RefreshEndpointsFrom(c.endpoints.Load())
+}
+
+func (c *Cluster) RefreshEndpointsFrom(previous *EndpointSnapshot) {
+	for {
+		current := c.endpoints.Load()
+		source := previous
+		if current != nil && current != previous {
+			source = current
+		}
+		next := newEndpointSnapshot(c.Config, source, len(c.Config.HealthChecks) != 0)
+		if c.endpoints.CompareAndSwap(current, next) {
+			return
+		}
+	}
+}
+
+func (c *Cluster) UpdateEndpointHealth(endpointID, endpointAddress string, healthy bool) bool {
+	c.healthMu.Lock()
+	defer c.healthMu.Unlock()
+	if !c.acceptHealthEvents {
+		logger.Debugf("[dubbo-go-pixiu] cluster %s: dropping health event for endpoint %s (%s), runtime is frozen",
+			c.clusterName(), endpointID, endpointAddress)
+		return false
+	}
+
+	for {
+		current := c.endpoints.Load()
+		if current == nil {
+			return false
+		}
+		next, ok := current.withEndpointHealth(endpointID, endpointAddress, healthy)
+		if !ok {
+			return false
+		}
+		if next == current {
+			return true
+		}
+		if c.endpoints.CompareAndSwap(current, next) {
+			return true
+		}
+	}
+}
+
+// UpdateEndpointAddressHealth updates every endpoint that shares an address.
+// Address-keyed health checkers use this path because one probe represents the
+// reachability of all endpoint identities at the same network address.
+func (c *Cluster) UpdateEndpointAddressHealth(endpointAddress string, healthy bool) bool {
+	c.healthMu.Lock()
+	defer c.healthMu.Unlock()
+	if !c.acceptHealthEvents {
+		logger.Debugf("[dubbo-go-pixiu] cluster %s: dropping address health event for %s, runtime is frozen",
+			c.clusterName(), endpointAddress)
+		return false
+	}
+
+	for {
+		current := c.endpoints.Load()
+		if current == nil {
+			return false
+		}
+		next, ok := current.withEndpointAddressHealth(endpointAddress, healthy)
+		if !ok {
+			return false
+		}
+		if next == current {
+			return true
+		}
+		if c.endpoints.CompareAndSwap(current, next) {
+			return true
+		}
+	}
+}
+
+// SnapshotForRuntimeReplacement freezes health updates on this runtime and
+// returns the final snapshot that a replacement runtime should inherit.
+func (c *Cluster) SnapshotForRuntimeReplacement() *EndpointSnapshot {
+	if c == nil {
+		return nil
+	}
+	c.healthMu.Lock()
+	defer c.healthMu.Unlock()
+	c.acceptHealthEvents = false
+	return c.EndpointSnapshot()
+}
+
+func (c *Cluster) handleEndpointHealth(event healthcheck.EndpointHealthEvent) {
+	c.UpdateEndpointAddressHealth(event.EndpointAddress, event.Healthy)
+}
+
+func (c *Cluster) clusterName() string {
+	if c == nil || c.Config == nil {
+		return ""
+	}
+	return c.Config.Name
+}
+
+// EndpointSnapshot endpoint membership and health indexes are immutable after
+// publication. Snapshot endpoints are cloned from config endpoints when the
+// snapshot is built, so request-path health changes do not mutate config
+// Endpoint.UnHealthy or config metadata.
+type EndpointSnapshot struct {
+	all                  []*model.Endpoint
+	healthy              []*model.Endpoint
+	endpointByID         map[string]*model.Endpoint
+	healthyEndpointByID  map[string]*model.Endpoint
+	addressByID          map[string]string
+	healthyByID          map[string]bool
+	healthyByAddress     map[string]bool
+	lbPolicy             model.LbPolicyType
+	consistentHashOnce   sync.Once
+	consistentHash       model.LbConsistentHashView
+	consistentHashConfig model.ConsistentHash
+}
+
+var emptyEndpointSnapshot = &EndpointSnapshot{
+	all:                 []*model.Endpoint{},
+	healthy:             []*model.Endpoint{},
+	endpointByID:        map[string]*model.Endpoint{},
+	healthyEndpointByID: map[string]*model.Endpoint{},
+	addressByID:         map[string]string{},
+	healthyByID:         map[string]bool{},
+	healthyByAddress:    map[string]bool{},
+}
+
+func newEndpointSnapshot(config *model.ClusterConfig, previous *EndpointSnapshot, inheritRuntimeHealth bool) *EndpointSnapshot {
+	var endpoints []*model.Endpoint
+	clusterName := ""
+	if config != nil {
+		clusterName = config.Name
+		endpoints = config.Endpoints
+	}
+	snapshot := newEndpointSnapshotIndex(len(endpoints))
+	if config != nil {
+		snapshot.lbPolicy = config.LbStr
+		snapshot.consistentHashConfig = config.ConsistentHash
+		snapshot.consistentHashConfig.Hash = nil
+	}
+	endpointIDs := make(map[string]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint == nil {
+			continue
+		}
+		snapshotEndpoint := model.CloneEndpoint(endpoint)
+		snapshotEndpoint.ID = uniqueSnapshotEndpointID(clusterName, snapshotEndpoint, endpointIDs)
+		endpointIDs[snapshotEndpoint.ID] = struct{}{}
+		address := snapshotEndpoint.Address.GetAddress()
+		healthy := endpointSnapshotHealth(snapshotEndpoint, address, previous, inheritRuntimeHealth)
+		snapshot.addEndpoint(snapshotEndpoint, address, healthy)
+	}
+	return snapshot
+}
+
+func newEndpointSnapshotIndex(endpointCount int) *EndpointSnapshot {
+	return &EndpointSnapshot{
+		all:                 make([]*model.Endpoint, 0, endpointCount),
+		healthy:             make([]*model.Endpoint, 0, endpointCount),
+		endpointByID:        make(map[string]*model.Endpoint, endpointCount),
+		healthyEndpointByID: make(map[string]*model.Endpoint, endpointCount),
+		addressByID:         make(map[string]string, endpointCount),
+		healthyByID:         make(map[string]bool, endpointCount),
+		healthyByAddress:    make(map[string]bool, endpointCount),
+	}
+}
+
+// uniqueSnapshotEndpointID resolves a stable runtime ID for one endpoint in
+// the snapshot's per-cluster dedup set. The operator's explicit endpoint.ID
+// wins unless it collides; collisions append -2, -3, ... so an operator who
+// wrote id: foo twice sees foo and foo-2 (not generated-<hash>-2). When the
+// operator did not supply an ID, the deterministic hash from PR-2 is used as
+// the base and collisions on that synthesized base also append -2, -3, ...
+func uniqueSnapshotEndpointID(clusterName string, endpoint *model.Endpoint, endpointIDs map[string]struct{}) string {
+	id := ""
+	if endpoint != nil {
+		id = endpoint.ID
+	}
+	if id == "" {
+		id = model.GenerateEndpointID(clusterName, endpoint)
+	}
+	if _, exists := endpointIDs[id]; !exists {
+		return id
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s-%d", id, suffix)
+		if _, exists := endpointIDs[candidate]; !exists {
+			return candidate
+		}
+	}
+}
+
+func endpointSnapshotHealth(
+	endpoint *model.Endpoint,
+	address string,
+	previous *EndpointSnapshot,
+	inheritRuntimeHealth bool,
+) bool {
+	healthy := !endpoint.UnHealthy
+	if previous == nil {
+		return healthy
+	}
+	// Carry health only while this runtime still has a health checker that can
+	// later correct it; otherwise seed health from config.
+	if inheritRuntimeHealth {
+		if previousAddress, ok := previous.addressByID[endpoint.ID]; ok && previousAddress == address {
+			return previous.healthyByID[endpoint.ID]
+		}
+		if addressHealthy, ok := previous.healthyByAddress[address]; ok {
+			return addressHealthy
+		}
+	}
+	return healthy
+}
+
+func (s *EndpointSnapshot) addEndpoint(
+	endpoint *model.Endpoint,
+	address string,
+	healthy bool,
+) {
+	endpoint.UnHealthy = !healthy
+	s.all = append(s.all, endpoint)
+	s.endpointByID[endpoint.ID] = endpoint
+	s.addressByID[endpoint.ID] = address
+	s.healthyByID[endpoint.ID] = healthy
+	s.addAddressHealth(address, healthy)
+	if healthy {
+		s.healthy = append(s.healthy, endpoint)
+		s.healthyEndpointByID[endpoint.ID] = endpoint
+	}
+}
+
+func (s *EndpointSnapshot) addAddressHealth(address string, healthy bool) {
+	if s == nil {
+		return
+	}
+	addressHealthy, ok := s.healthyByAddress[address]
+	if !ok {
+		s.healthyByAddress[address] = healthy
+		return
+	}
+	s.healthyByAddress[address] = addressHealthy && healthy
+}
+
+func (s *EndpointSnapshot) AllEndpoints() []*model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return model.CloneEndpoints(s.all)
+}
+
+func (s *EndpointSnapshot) EndpointCount() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.all)
+}
+
+func (s *EndpointSnapshot) HealthyEndpoints() []*model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return model.CloneEndpoints(s.healthy)
+}
+
+func (s *EndpointSnapshot) HealthyEndpointCount() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.healthy)
+}
+
+// HealthyEndpointsForPick returns the snapshot-internal healthy endpoint slice
+// without cloning. The returned slice and its endpoints are owned by the
+// snapshot; callers MUST NOT mutate elements, append into the slice, or retain
+// the slice past the current pick. This accessor exists for the request-path
+// picker; external callers should use HealthyEndpoints (defensive deep copy) or
+// PickHealthyEndpoint (zero-copy callback that clones only the chosen endpoint).
+func (s *EndpointSnapshot) HealthyEndpointsForPick() []*model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return s.healthy
+}
+
+// AllEndpointsForPick mirrors HealthyEndpointsForPick for the full endpoint set.
+// The same no-mutate / no-retain contract applies.
+func (s *EndpointSnapshot) AllEndpointsForPick() []*model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return s.all
+}
+
+func (s *EndpointSnapshot) HealthyConsistentHash() model.LbConsistentHashView {
+	if s == nil {
+		return nil
+	}
+	s.consistentHashOnce.Do(s.rebuildConsistentHash)
+	return s.consistentHash
+}
+
+// PickHealthyEndpoint gives request-path selectors a read-only view of healthy
+// endpoints and clones only the selected endpoint before returning it. The pick
+// callback must not mutate or retain the endpoint view.
+func (s *EndpointSnapshot) PickHealthyEndpoint(pick func([]*model.Endpoint) *model.Endpoint) *model.Endpoint {
+	if s == nil || len(s.healthy) == 0 || pick == nil {
+		return nil
+	}
+	return model.CloneEndpoint(pick(s.healthy))
+}
+
+func (s *EndpointSnapshot) NextHealthyEndpoint(curEndpointID string) *model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	start := s.nextEndpointStartIndex(curEndpointID)
+	if start < 0 {
+		return nil
+	}
+	for _, endpoint := range s.all[start:] {
+		if s.healthyByID[endpoint.ID] {
+			return model.CloneEndpoint(endpoint)
+		}
+	}
+	return nil
+}
+
+func (s *EndpointSnapshot) nextEndpointStartIndex(curEndpointID string) int {
+	for i, endpoint := range s.all {
+		if endpoint.ID == curEndpointID {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func (s *EndpointSnapshot) EndpointByID(endpointID string) *model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return model.CloneEndpoint(s.endpointByID[endpointID])
+}
+
+func (s *EndpointSnapshot) HealthyEndpointByID(endpointID string) *model.Endpoint {
+	if s == nil {
+		return nil
+	}
+	return model.CloneEndpoint(s.healthyEndpointByID[endpointID])
+}
+
+func (s *EndpointSnapshot) withEndpointHealth(
+	endpointID, endpointAddress string,
+	healthy bool,
+) (*EndpointSnapshot, bool) {
+	if s == nil {
+		return nil, false
+	}
+	address, ok := s.addressByID[endpointID]
+	if !ok || address != endpointAddress {
+		return nil, false
+	}
+	return s.withEndpointHealthForIDs(map[string]struct{}{endpointID: {}}, healthy)
+}
+
+func (s *EndpointSnapshot) withEndpointAddressHealth(
+	endpointAddress string,
+	healthy bool,
+) (*EndpointSnapshot, bool) {
+	if s == nil {
+		return nil, false
+	}
+	endpointIDs := make(map[string]struct{})
+	for endpointID, address := range s.addressByID {
+		if address == endpointAddress {
+			endpointIDs[endpointID] = struct{}{}
+		}
+	}
+	return s.withEndpointHealthForIDs(endpointIDs, healthy)
+}
+
+func (s *EndpointSnapshot) withEndpointHealthForIDs(
+	endpointIDs map[string]struct{},
+	healthy bool,
+) (*EndpointSnapshot, bool) {
+	if len(endpointIDs) == 0 {
+		return nil, false
+	}
+
+	changed := false
+	for endpointID := range endpointIDs {
+		if s.healthyByID[endpointID] != healthy {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return s, true
+	}
+
+	// Reuse unchanged endpoint/address views and rebuild the endpoint clone
+	// whose runtime health flag changed.
+	next := &EndpointSnapshot{
+		all:                  make([]*model.Endpoint, 0, len(s.all)),
+		healthy:              make([]*model.Endpoint, 0, len(s.all)),
+		endpointByID:         make(map[string]*model.Endpoint, len(s.endpointByID)),
+		healthyEndpointByID:  make(map[string]*model.Endpoint, len(s.endpointByID)),
+		addressByID:          s.addressByID,
+		healthyByID:          make(map[string]bool, len(s.healthyByID)),
+		healthyByAddress:     make(map[string]bool, len(s.healthyByAddress)),
+		lbPolicy:             s.lbPolicy,
+		consistentHashConfig: s.consistentHashConfig,
+	}
+
+	for id, wasHealthy := range s.healthyByID {
+		nextHealthy := wasHealthy
+		if _, ok := endpointIDs[id]; ok {
+			nextHealthy = healthy
+		}
+		next.healthyByID[id] = nextHealthy
+		next.addAddressHealth(s.addressByID[id], nextHealthy)
+	}
+
+	for _, endpoint := range s.all {
+		id := endpoint.ID
+		nextEndpoint := endpoint
+		if _, ok := endpointIDs[id]; ok {
+			nextEndpoint = model.CloneEndpoint(endpoint)
+			nextEndpoint.UnHealthy = !healthy
+		}
+		next.all = append(next.all, nextEndpoint)
+		next.endpointByID[id] = nextEndpoint
+		if next.healthyByID[id] {
+			next.healthy = append(next.healthy, nextEndpoint)
+			next.healthyEndpointByID[id] = nextEndpoint
+		}
+	}
+
+	return next, true
+}
+
+func (s *EndpointSnapshot) rebuildConsistentHash() {
+	if s == nil || len(s.healthy) == 0 {
+		return
+	}
+	newConsistentHash, ok := model.ConsistentHashInitMap[s.lbPolicy]
+	if !ok {
+		return
+	}
+	s.consistentHash = model.ReadOnlyConsistentHash(newConsistentHash(s.consistentHashConfig, s.healthy))
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -81,7 +81,15 @@ func TestClusterEndpointSnapshotEndpointCountIsNilSafe(t *testing.T) {
 	assert.Zero(t, snapshot.EndpointCount())
 }
 
-func TestClusterEndpointSnapshotForPickAccessorsAliasInternalStorage(t *testing.T) {
+// TestClusterEndpointSnapshotForPickAccessorsExposeStableView locks the
+// per-call semantic contract of HealthyEndpointsForPick / AllEndpointsForPick,
+// without locking the implementation detail of returning the same backing
+// slice. Concretely: repeated calls return slices of the same length, same
+// IDs in the same order, and the same endpoint *pointers* per slot (so
+// snapshot consumers can compare by identity). This deliberately stops
+// short of asserting that callers see the snapshot's internal slice header
+// itself, leaving room for future lazy-build / metric / hook indirections.
+func TestClusterEndpointSnapshotForPickAccessorsExposeStableView(t *testing.T) {
 	first := testEndpoint("ep-1", "127.0.0.1", 18080)
 	second := testEndpoint("ep-2", "127.0.0.1", 18081)
 
@@ -91,13 +99,23 @@ func TestClusterEndpointSnapshotForPickAccessorsAliasInternalStorage(t *testing.
 	healthy1 := snapshot.HealthyEndpointsForPick()
 	healthy2 := snapshot.HealthyEndpointsForPick()
 	if assert.Len(t, healthy1, 2) && assert.Len(t, healthy2, 2) {
-		assert.Same(t, &healthy1[0], &healthy2[0])
+		assert.Equal(t, healthy1[0].ID, healthy2[0].ID)
+		assert.Equal(t, healthy1[1].ID, healthy2[1].ID)
+		// Same endpoint identity per slot: snapshot guarantees the for-pick
+		// accessors are stable for the snapshot's lifetime. We compare the
+		// endpoint pointer (zero-copy view of the snapshot's owned endpoint)
+		// rather than the slice header address.
+		assert.Same(t, healthy1[0], healthy2[0])
+		assert.Same(t, healthy1[1], healthy2[1])
 	}
 
 	all1 := snapshot.AllEndpointsForPick()
 	all2 := snapshot.AllEndpointsForPick()
 	if assert.Len(t, all1, 2) && assert.Len(t, all2, 2) {
-		assert.Same(t, &all1[0], &all2[0])
+		assert.Equal(t, all1[0].ID, all2[0].ID)
+		assert.Equal(t, all1[1].ID, all2[1].ID)
+		assert.Same(t, all1[0], all2[0])
+		assert.Same(t, all1[1], all2[1])
 	}
 
 	var nilSnapshot *EndpointSnapshot

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -211,20 +211,40 @@ func TestClusterEndpointSnapshotBuildsConsistentHashLazily(t *testing.T) {
 	config.LbStr = lbPolicy
 	runtimeCluster := NewCluster(config)
 
-	assert.Zero(t, atomic.LoadInt32(&builds))
+	// Locks: snapshot must NOT eagerly build the consistent hash. A
+	// runtime that toggles health repeatedly without ever serving a
+	// hash-based pick must not build a single hash.
+	assert.Zero(t, atomic.LoadInt32(&builds),
+		"snapshot must not eagerly build consistent hash before first access")
 	assert.True(t, runtimeCluster.UpdateEndpointHealth(second.ID, second.Address.GetAddress(), false))
-	assert.Zero(t, atomic.LoadInt32(&builds))
+	assert.Zero(t, atomic.LoadInt32(&builds),
+		"snapshot must not build consistent hash on health toggle alone")
 
+	// First access populates lazily.
 	snapshot := runtimeCluster.EndpointSnapshot()
 	assert.NotNil(t, snapshot.HealthyConsistentHash())
-	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
-	assert.NotNil(t, snapshot.HealthyConsistentHash())
-	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+	firstBuilds := atomic.LoadInt32(&builds)
+	assert.Greater(t, firstBuilds, int32(0), "first HealthyConsistentHash() call must build")
 
+	// Repeated reads of the SAME snapshot must not re-build.
+	assert.NotNil(t, snapshot.HealthyConsistentHash())
+	assert.Equal(t, firstBuilds, atomic.LoadInt32(&builds),
+		"repeat HealthyConsistentHash() on the same snapshot must not rebuild")
+
+	// Toggling health produces a new snapshot. The new snapshot is allowed
+	// to (a) build on first access, or (b) reuse the hash from a sibling
+	// snapshot when the healthy set is equivalent. Both are valid
+	// implementations; this test no longer locks the count. See follow-up
+	// PR-4 for the "reuse on identical healthy set" optimization.
 	assert.True(t, runtimeCluster.UpdateEndpointHealth(second.ID, second.Address.GetAddress(), true))
-	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
-	assert.NotNil(t, runtimeCluster.EndpointSnapshot().HealthyConsistentHash())
-	assert.Equal(t, int32(2), atomic.LoadInt32(&builds))
+	newSnapshot := runtimeCluster.EndpointSnapshot()
+	assert.NotNil(t, newSnapshot.HealthyConsistentHash())
+	// New snapshot must serve a hash view; we do not assert how many builds
+	// it took to get there.
+	assert.NotNil(t, newSnapshot.HealthyConsistentHash())
+	finalBuilds := atomic.LoadInt32(&builds)
+	assert.GreaterOrEqual(t, finalBuilds, firstBuilds,
+		"build count is monotonic, but per-flap rebuild count is not locked here")
 }
 
 func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,0 +1,613 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/healthcheck"
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"   // Register Maglev for snapshot hash tests.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash" // Register RingHash for snapshot hash tests.
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+func TestClusterEndpointSnapshotSeedsFromEndpointHealth(t *testing.T) {
+	healthy := testEndpoint("ep-1", "127.0.0.1", 18080)
+	unhealthy := testEndpoint("ep-2", "127.0.0.1", 18081)
+	unhealthy.UnHealthy = true
+
+	runtimeCluster := NewCluster(testCluster("snapshot-seed", healthy, unhealthy))
+	snapshot := runtimeCluster.EndpointSnapshot()
+
+	assert.Equal(t, []*model.Endpoint{healthy, unhealthy}, snapshot.AllEndpoints())
+	assert.Equal(t, []*model.Endpoint{healthy}, snapshot.HealthyEndpoints())
+	assert.NotSame(t, healthy, snapshot.EndpointByID(healthy.ID))
+	assert.Equal(t, healthy, snapshot.EndpointByID(healthy.ID))
+	assert.NotSame(t, healthy, snapshot.HealthyEndpointByID(healthy.ID))
+	assert.Equal(t, healthy, snapshot.HealthyEndpointByID(healthy.ID))
+	assert.Nil(t, snapshot.HealthyEndpointByID(unhealthy.ID))
+}
+
+func TestClusterEndpointSnapshotReturnsDefensiveEndpointSlices(t *testing.T) {
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+
+	runtimeCluster := NewCluster(testCluster("snapshot-defensive-copy", first, second))
+	snapshot := runtimeCluster.EndpointSnapshot()
+
+	all := snapshot.AllEndpoints()
+	healthy := snapshot.HealthyEndpoints()
+	all[0] = nil
+	healthy[0] = nil
+
+	assert.Equal(t, []*model.Endpoint{first, second}, snapshot.AllEndpoints())
+	assert.Equal(t, []*model.Endpoint{first, second}, snapshot.HealthyEndpoints())
+	assert.Equal(t, 2, snapshot.EndpointCount())
+	assert.NotSame(t, first, snapshot.EndpointByID(first.ID))
+	assert.Equal(t, first, snapshot.EndpointByID(first.ID))
+	endpointByID := snapshot.EndpointByID(first.ID)
+	healthyByID := snapshot.HealthyEndpointByID(first.ID)
+	assert.NotSame(t, endpointByID, healthyByID)
+	assert.Equal(t, endpointByID, healthyByID)
+}
+
+func TestClusterEndpointSnapshotEndpointCountIsNilSafe(t *testing.T) {
+	var snapshot *EndpointSnapshot
+
+	assert.Zero(t, snapshot.EndpointCount())
+}
+
+func TestClusterEndpointSnapshotForPickAccessorsAliasInternalStorage(t *testing.T) {
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+
+	runtimeCluster := NewCluster(testCluster("snapshot-for-pick-alias", first, second))
+	snapshot := runtimeCluster.EndpointSnapshot()
+
+	healthy1 := snapshot.HealthyEndpointsForPick()
+	healthy2 := snapshot.HealthyEndpointsForPick()
+	if assert.Len(t, healthy1, 2) && assert.Len(t, healthy2, 2) {
+		assert.Same(t, &healthy1[0], &healthy2[0])
+	}
+
+	all1 := snapshot.AllEndpointsForPick()
+	all2 := snapshot.AllEndpointsForPick()
+	if assert.Len(t, all1, 2) && assert.Len(t, all2, 2) {
+		assert.Same(t, &all1[0], &all2[0])
+	}
+
+	var nilSnapshot *EndpointSnapshot
+	assert.Nil(t, nilSnapshot.HealthyEndpointsForPick())
+	assert.Nil(t, nilSnapshot.AllEndpointsForPick())
+}
+
+func TestClusterEndpointSnapshotBuildsConsistentHashFromRuntimeHealthyEndpoints(t *testing.T) {
+	tests := []model.LbPolicyType{
+		model.LoadBalancerRingHashing,
+		model.LoadBalancerMaglevHashing,
+	}
+
+	for _, lb := range tests {
+		t.Run(string(lb), func(t *testing.T) {
+			first := testEndpoint("ep-1", "127.0.0.1", 18080)
+			second := testEndpoint("ep-2", "127.0.0.1", 18081)
+			temporarilyUnhealthy := testEndpoint("ep-3", "127.0.0.1", 18082)
+			config := testCluster("snapshot-healthy-hash", first, second, temporarilyUnhealthy)
+			config.LbStr = lb
+			config.ConsistentHash = model.ConsistentHash{
+				ReplicaNum:      10,
+				MaxVnodeNum:     1023,
+				MaglevTableSize: 521,
+			}
+			runtimeCluster := NewCluster(config)
+
+			assert.True(t, runtimeCluster.UpdateEndpointHealth(
+				temporarilyUnhealthy.ID,
+				temporarilyUnhealthy.Address.GetAddress(),
+				false,
+			))
+
+			snapshot := runtimeCluster.EndpointSnapshot()
+			hash := snapshot.HealthyConsistentHash()
+			if !assert.NotNil(t, hash) {
+				return
+			}
+			for i := 0; i < 20; i++ {
+				host, err := hash.Get(fmt.Sprintf("request-%d", i))
+				if assert.NoError(t, err) {
+					assert.NotEqual(t, temporarilyUnhealthy.GetHost(), host)
+				}
+			}
+		})
+	}
+}
+
+func TestClusterEndpointSnapshotExposesReadOnlyConsistentHash(t *testing.T) {
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+	config := testCluster("snapshot-readonly-hash", first, second)
+	config.LbStr = model.LoadBalancerRingHashing
+	config.ConsistentHash = model.ConsistentHash{
+		ReplicaNum:  10,
+		MaxVnodeNum: 1023,
+	}
+
+	hashView := NewCluster(config).EndpointSnapshot().HealthyConsistentHash()
+	if !assert.NotNil(t, hashView) {
+		return
+	}
+	_, mutable := hashView.(model.LbConsistentHash)
+	assert.False(t, mutable)
+
+	host, err := hashView.Get("request-key")
+	assert.NoError(t, err)
+	assert.Contains(t, []string{first.GetHost(), second.GetHost()}, host)
+}
+
+func TestClusterEndpointSnapshotBuildsConsistentHashLazily(t *testing.T) {
+	var builds int32
+	lbPolicy := model.LbPolicyType("test-lazy-hash")
+	previousInit, hadPreviousInit := model.ConsistentHashInitMap[lbPolicy]
+	model.ConsistentHashInitMap[lbPolicy] = func(_ model.ConsistentHash, endpoints []*model.Endpoint) model.LbConsistentHash {
+		atomic.AddInt32(&builds, 1)
+		if len(endpoints) == 0 {
+			return countingConsistentHash{}
+		}
+		return countingConsistentHash{host: endpoints[0].GetHost()}
+	}
+	t.Cleanup(func() {
+		if hadPreviousInit {
+			model.ConsistentHashInitMap[lbPolicy] = previousInit
+			return
+		}
+		delete(model.ConsistentHashInitMap, lbPolicy)
+	})
+
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+	config := testCluster("snapshot-lazy-hash", first, second)
+	config.LbStr = lbPolicy
+	runtimeCluster := NewCluster(config)
+
+	assert.Zero(t, atomic.LoadInt32(&builds))
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(second.ID, second.Address.GetAddress(), false))
+	assert.Zero(t, atomic.LoadInt32(&builds))
+
+	snapshot := runtimeCluster.EndpointSnapshot()
+	assert.NotNil(t, snapshot.HealthyConsistentHash())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+	assert.NotNil(t, snapshot.HealthyConsistentHash())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(second.ID, second.Address.GetAddress(), true))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+	assert.NotNil(t, runtimeCluster.EndpointSnapshot().HealthyConsistentHash())
+	assert.Equal(t, int32(2), atomic.LoadInt32(&builds))
+}
+
+func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
+	endpoint := testSnapshotEndpointWithLLMMeta()
+	runtimeCluster := NewCluster(testCluster("snapshot-clone", endpoint))
+	snapshotEndpoint := runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID)
+	if !assert.NotNil(t, snapshotEndpoint) {
+		return
+	}
+
+	assert.NotSame(t, endpoint, snapshotEndpoint)
+	assert.NotSame(t, endpoint.LLMMeta, snapshotEndpoint.LLMMeta)
+
+	endpoint.Address.Address = "127.0.0.2"
+	endpoint.Address.Domains[0] = "changed.example.com"
+	endpoint.Metadata["weight"] = "9"
+	endpoint.LLMMeta.APIKey = "new-key"
+	endpoint.LLMMeta.RetryPolicy.Config["attempts"] = 2
+	endpoint.LLMMeta.RetryPolicy.Config["nested"].(map[string]any)["delays"].([]any)[0] = "200ms"
+	endpoint.UnHealthy = true
+
+	assertEndpointMatchesOriginalSnapshot(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID))
+}
+
+func TestClusterEndpointSnapshotReturnsDefensiveEndpointObjects(t *testing.T) {
+	endpoint := testSnapshotEndpointWithLLMMeta()
+	runtimeCluster := NewCluster(testCluster("snapshot-defensive-endpoint", endpoint))
+	snapshot := runtimeCluster.EndpointSnapshot()
+
+	all := snapshot.AllEndpoints()
+	healthy := snapshot.HealthyEndpoints()
+	byID := snapshot.EndpointByID(endpoint.ID)
+	healthyByID := snapshot.HealthyEndpointByID(endpoint.ID)
+
+	assert.NotSame(t, all[0], healthy[0])
+	assert.NotSame(t, all[0], byID)
+	assert.NotSame(t, byID, healthyByID)
+
+	mutateReturnedEndpoint(all[0])
+	mutateReturnedEndpoint(healthy[0])
+	mutateReturnedEndpoint(byID)
+	mutateReturnedEndpoint(healthyByID)
+
+	assertEndpointMatchesOriginalSnapshot(t, snapshot.EndpointByID(endpoint.ID))
+	assertEndpointMatchesOriginalSnapshot(t, snapshot.HealthyEndpointByID(endpoint.ID))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+	assertEndpointMatchesOriginalSnapshot(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+}
+
+func TestNewClusterAssignsUniqueRuntimeIDsForAnonymousEndpoints(t *testing.T) {
+	first := testEndpoint("", "127.0.0.1", 18080)
+	second := testEndpoint("", "127.0.0.2", 18081)
+	runtimeCluster := NewCluster(testCluster("snapshot-anonymous-ids", first, second))
+
+	snapshot := runtimeCluster.EndpointSnapshot()
+	all := snapshot.AllEndpoints()
+	if !assert.Len(t, all, 2) {
+		return
+	}
+	assert.NotEmpty(t, all[0].ID)
+	assert.NotEmpty(t, all[1].ID)
+	assert.NotEqual(t, all[0].ID, all[1].ID)
+
+	assert.True(t, runtimeCluster.UpdateEndpointAddressHealth(first.Address.GetAddress(), false))
+	updated := runtimeCluster.EndpointSnapshot().AllEndpoints()
+	if assert.Len(t, updated, 2) {
+		assert.True(t, updated[0].UnHealthy)
+		assert.False(t, updated[1].UnHealthy)
+	}
+	healthy := runtimeCluster.EndpointSnapshot().HealthyEndpoints()
+	if assert.Len(t, healthy, 1) {
+		assert.Equal(t, second.Address.GetAddress(), healthy[0].Address.GetAddress())
+	}
+}
+
+func TestClusterEndpointHealthEventUpdatesSnapshotWithoutMutatingEndpoint(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18082)
+	runtimeCluster := NewCluster(testCluster("snapshot-health", endpoint))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+
+	assert.False(t, endpoint.UnHealthy)
+	assert.True(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+	assert.False(t, endpoint.UnHealthy)
+	healthyEndpoints := runtimeCluster.EndpointSnapshot().HealthyEndpoints()
+	assert.Equal(t, []*model.Endpoint{endpoint}, healthyEndpoints)
+	if assert.Len(t, healthyEndpoints, 1) {
+		assert.False(t, healthyEndpoints[0].UnHealthy)
+	}
+	assert.False(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
+}
+
+func TestClusterEndpointHealthEventUpdatesSameAddressEndpoints(t *testing.T) {
+	first := testEndpoint("ep-1", "127.0.0.1", 18082)
+	second := testEndpoint("ep-2", "127.0.0.1", 18082)
+	otherAddress := testEndpoint("ep-3", "127.0.0.1", 18083)
+	runtimeCluster := NewCluster(testCluster("snapshot-shared-address-health", first, second, otherAddress))
+
+	runtimeCluster.handleEndpointHealth(healthcheck.EndpointHealthEvent{
+		EndpointID:      first.ID,
+		EndpointAddress: first.Address.GetAddress(),
+		Healthy:         false,
+	})
+
+	assert.False(t, first.UnHealthy)
+	assert.False(t, second.UnHealthy)
+	assert.True(t, runtimeCluster.EndpointSnapshot().EndpointByID(first.ID).UnHealthy)
+	assert.True(t, runtimeCluster.EndpointSnapshot().EndpointByID(second.ID).UnHealthy)
+	assert.False(t, runtimeCluster.EndpointSnapshot().EndpointByID(otherAddress.ID).UnHealthy)
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(first.ID))
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(second.ID))
+	assert.NotNil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(otherAddress.ID))
+
+	runtimeCluster.handleEndpointHealth(healthcheck.EndpointHealthEvent{
+		EndpointID:      first.ID,
+		EndpointAddress: first.Address.GetAddress(),
+		Healthy:         true,
+	})
+
+	assert.Equal(t, []*model.Endpoint{first, second, otherAddress}, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+}
+
+func TestClusterEndpointHealthEventRestoresRuntimeEndpointHealthFlag(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18082)
+	endpoint.UnHealthy = true
+	runtimeCluster := NewCluster(testCluster("snapshot-health-flag", endpoint))
+
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+	assert.True(t, runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID).UnHealthy)
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+
+	assert.True(t, endpoint.UnHealthy)
+	healthyEndpoint := runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID)
+	if assert.NotNil(t, healthyEndpoint) {
+		assert.False(t, healthyEndpoint.UnHealthy)
+	}
+	allEndpoint := runtimeCluster.EndpointSnapshot().EndpointByID(endpoint.ID)
+	if assert.NotNil(t, allEndpoint) {
+		assert.False(t, allEndpoint.UnHealthy)
+	}
+}
+
+func TestClusterEndpointHealthEventIgnoresStaleAddress(t *testing.T) {
+	oldEndpoint := testEndpoint("ep-1", "127.0.0.1", 18083)
+	oldAddress := oldEndpoint.Address.GetAddress()
+	config := testCluster("snapshot-stale-address", oldEndpoint)
+	runtimeCluster := NewCluster(config)
+
+	newEndpoint := testEndpoint("ep-1", "127.0.0.2", 18084)
+	config.Endpoints[0] = newEndpoint
+	runtimeCluster.RefreshEndpoints()
+
+	assert.False(t, runtimeCluster.UpdateEndpointHealth(newEndpoint.ID, oldAddress, false))
+	assert.Equal(t, []*model.Endpoint{newEndpoint}, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(newEndpoint.ID, newEndpoint.Address.GetAddress(), false))
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+}
+
+func TestClusterRefreshEndpointsFromDoesNotOverwriteNewerHealthUpdate(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18084)
+	runtimeCluster := NewCluster(testClusterWithHealthCheck("snapshot-refresh-cas", endpoint))
+	t.Cleanup(runtimeCluster.Stop)
+	staleSnapshot := runtimeCluster.EndpointSnapshot()
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	runtimeCluster.RefreshEndpointsFrom(staleSnapshot)
+
+	assert.Empty(t, runtimeCluster.EndpointSnapshot().HealthyEndpoints())
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+}
+
+func TestClusterSnapshotForRuntimeReplacementFreezesHealthEvents(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18085)
+	runtimeCluster := NewCluster(testClusterWithHealthCheck("snapshot-freeze", endpoint))
+	t.Cleanup(runtimeCluster.Stop)
+
+	assert.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	frozen := runtimeCluster.SnapshotForRuntimeReplacement()
+
+	assert.Nil(t, frozen.HealthyEndpointByID(endpoint.ID))
+	assert.False(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+	assert.Nil(t, runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpoint.ID))
+
+	replacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
+	replacementRuntime := NewClusterWithEndpointSnapshot(
+		testClusterWithHealthCheck("snapshot-freeze-replacement", replacement),
+		frozen,
+	)
+	t.Cleanup(replacementRuntime.Stop)
+
+	assert.Nil(t, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+	assert.True(t, replacementRuntime.UpdateEndpointHealth(replacement.ID, replacement.Address.GetAddress(), true))
+	assert.NotSame(t, replacement, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+	assert.Equal(t, replacement, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+}
+
+func TestNewClusterWithEndpointSnapshotInheritsAddressHealthForChangedEndpointID(t *testing.T) {
+	endpoint := testEndpoint("ep-old", "127.0.0.1", 18085)
+	oldRuntime := NewCluster(testClusterWithHealthCheck("snapshot-address-old", endpoint))
+	t.Cleanup(oldRuntime.Stop)
+	oldRuntime.handleEndpointHealth(healthcheck.EndpointHealthEvent{
+		EndpointID:      endpoint.ID,
+		EndpointAddress: endpoint.Address.GetAddress(),
+		Healthy:         false,
+	})
+	previous := oldRuntime.SnapshotForRuntimeReplacement()
+
+	replacement := testEndpoint("ep-new", "127.0.0.1", 18085)
+	replacementRuntime := NewClusterWithEndpointSnapshot(
+		testClusterWithHealthCheck("snapshot-address-new", replacement),
+		previous,
+	)
+	t.Cleanup(replacementRuntime.Stop)
+
+	assert.Nil(t, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+	if got := replacementRuntime.EndpointSnapshot().EndpointByID(replacement.ID); assert.NotNil(t, got) {
+		assert.True(t, got.UnHealthy)
+	}
+
+	noHealthCheckReplacement := testEndpoint("ep-new-no-healthcheck", "127.0.0.1", 18085)
+	noHealthCheckRuntime := NewClusterWithEndpointSnapshot(
+		testCluster("snapshot-address-no-healthcheck", noHealthCheckReplacement),
+		previous,
+	)
+	assert.NotNil(t, noHealthCheckRuntime.EndpointSnapshot().HealthyEndpointByID(noHealthCheckReplacement.ID))
+}
+
+func TestNewClusterWithEndpointSnapshotInheritsHealthOnlyWhenHealthCheckEnabled(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18085)
+	oldRuntime := NewCluster(testCluster("snapshot-constructor-old", endpoint))
+	assert.True(t, oldRuntime.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), false))
+	previous := oldRuntime.EndpointSnapshot()
+
+	replacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
+	replacementRuntime := NewClusterWithEndpointSnapshot(
+		testClusterWithHealthCheck("snapshot-constructor-same", replacement),
+		previous,
+	)
+	t.Cleanup(replacementRuntime.Stop)
+	assert.Nil(t, replacementRuntime.EndpointSnapshot().HealthyEndpointByID(replacement.ID))
+
+	noHealthCheckReplacement := testEndpoint(endpoint.ID, "127.0.0.1", 18085)
+	noHealthCheckRuntime := NewClusterWithEndpointSnapshot(
+		testCluster("snapshot-constructor-no-healthcheck", noHealthCheckReplacement),
+		previous,
+	)
+	assert.NotSame(t, noHealthCheckReplacement, noHealthCheckRuntime.EndpointSnapshot().HealthyEndpointByID(noHealthCheckReplacement.ID))
+	assert.Equal(t, noHealthCheckReplacement, noHealthCheckRuntime.EndpointSnapshot().HealthyEndpointByID(noHealthCheckReplacement.ID))
+
+	moved := testEndpoint(endpoint.ID, "127.0.0.2", 18086)
+	movedRuntime := NewClusterWithEndpointSnapshot(
+		testCluster("snapshot-constructor-moved", moved),
+		previous,
+	)
+	assert.NotSame(t, moved, movedRuntime.EndpointSnapshot().HealthyEndpointByID(moved.ID))
+	assert.Equal(t, moved, movedRuntime.EndpointSnapshot().HealthyEndpointByID(moved.ID))
+}
+
+func testCluster(name string, endpoints ...*model.Endpoint) *model.ClusterConfig {
+	return &model.ClusterConfig{
+		Name:      name,
+		Endpoints: endpoints,
+	}
+}
+
+func testClusterWithHealthCheck(name string, endpoints ...*model.Endpoint) *model.ClusterConfig {
+	config := testCluster(name, endpoints...)
+	config.HealthChecks = []model.HealthCheckConfig{{
+		Protocol:       "tcp",
+		TimeoutConfig:  "1h",
+		IntervalConfig: "1h",
+	}}
+	return config
+}
+
+func testEndpoint(id string, host string, port int) *model.Endpoint {
+	return &model.Endpoint{
+		ID:   id,
+		Name: "endpoint-" + id,
+		Address: model.SocketAddress{
+			Address: host,
+			Port:    port,
+		},
+	}
+}
+
+func testSnapshotEndpointWithLLMMeta() *model.Endpoint {
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
+	endpoint.Address.Domains = []string{"api.example.com"}
+	endpoint.Metadata = map[string]string{"weight": "3"}
+	endpoint.LLMMeta = &model.LLMMeta{
+		Provider: "openai",
+		APIKey:   "old-key",
+		RetryPolicy: model.RetryPolicy{
+			Config: map[string]any{
+				"attempts": 1,
+				"nested": map[string]any{
+					"delays": []any{"100ms"},
+				},
+			},
+		},
+	}
+	return endpoint
+}
+
+type countingConsistentHash struct {
+	host string
+}
+
+func (h countingConsistentHash) Hash(string) uint32 {
+	return 0
+}
+
+func (h countingConsistentHash) Get(string) (string, error) {
+	return h.host, nil
+}
+
+func (h countingConsistentHash) GetHash(uint32) (string, error) {
+	return h.host, nil
+}
+
+func (h countingConsistentHash) Add(string) {}
+
+func (h countingConsistentHash) Remove(string) bool {
+	return false
+}
+
+func mutateReturnedEndpoint(endpoint *model.Endpoint) {
+	endpoint.Name = "mutated"
+	endpoint.Address.Address = "127.0.0.2"
+	endpoint.Address.Domains[0] = "changed.example.com"
+	endpoint.Metadata["weight"] = "9"
+	endpoint.LLMMeta.APIKey = "new-key"
+	endpoint.LLMMeta.RetryPolicy.Config["attempts"] = 2
+	endpoint.LLMMeta.RetryPolicy.Config["nested"].(map[string]any)["delays"].([]any)[0] = "200ms"
+	endpoint.UnHealthy = true
+}
+
+func assertEndpointMatchesOriginalSnapshot(t *testing.T, endpoint *model.Endpoint) {
+	t.Helper()
+
+	if !assert.NotNil(t, endpoint) {
+		return
+	}
+	assert.Equal(t, "endpoint-ep-1", endpoint.Name)
+	assert.Equal(t, model.SocketAddress{Address: "127.0.0.1", Port: 18080, Domains: []string{"api.example.com"}}, endpoint.Address)
+	assert.Equal(t, map[string]string{"weight": "3"}, endpoint.Metadata)
+	assert.Equal(t, "old-key", endpoint.LLMMeta.APIKey)
+	assert.Equal(t, 1, endpoint.LLMMeta.RetryPolicy.Config["attempts"])
+	assert.Equal(t, "100ms", endpoint.LLMMeta.RetryPolicy.Config["nested"].(map[string]any)["delays"].([]any)[0])
+	assert.False(t, endpoint.UnHealthy)
+}
+
+// TestClusterRefreshAndHealthUpdateConcurrent locks the CAS contract that
+// RefreshEndpoints and UpdateEndpointHealth must commute under concurrent
+// writers. The final snapshot's health for ep-1 must reflect the LAST
+// UpdateEndpointHealth call (`(N-1)%2 == 0` → healthy=true at completion),
+// and ep-2 must remain healthy because no update ever toggled it.
+//
+// Run with -race -count=20 in CI; flakiness here means the snapshot
+// inheritance / CAS invariants are broken.
+func TestClusterRefreshAndHealthUpdateConcurrent(t *testing.T) {
+	ep1 := testEndpoint("ep-1", "127.0.0.1", 18080)
+	ep2 := testEndpoint("ep-2", "127.0.0.1", 18081)
+	config := testClusterWithHealthCheck("race", ep1, ep2)
+	runtimeCluster := NewCluster(config)
+	t.Cleanup(runtimeCluster.Stop)
+
+	const N = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < N; i++ {
+			runtimeCluster.RefreshEndpoints()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < N; i++ {
+			runtimeCluster.UpdateEndpointHealth(ep1.ID, ep1.Address.GetAddress(), i%2 == 0)
+		}
+	}()
+	wg.Wait()
+
+	snapshot := runtimeCluster.EndpointSnapshot()
+	healthy := snapshot.HealthyEndpointByID(ep1.ID)
+	if (N-1)%2 == 0 {
+		assert.NotNil(t, healthy, "last update was healthy=true")
+	} else {
+		assert.Nil(t, healthy, "last update was healthy=false")
+	}
+	assert.NotNil(t, snapshot.HealthyEndpointByID(ep2.ID), "ep2 must remain healthy")
+}

--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -19,6 +19,7 @@ package healthcheck
 
 import (
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -117,10 +118,12 @@ func CreateHealthCheckWithCallback(
 		interval = DefaultInterval
 	}
 
-	initialDelay, err := time.ParseDuration(cfg.IntervalConfig)
+	initialDelay := DefaultFirstInterval
+	initialDelaySeconds, err := strconv.Atoi(cfg.InitialDelaySeconds)
 	if err != nil {
-		logger.Infof("[health check] initialDelay parse duration error %s", err)
-		initialDelay = DefaultFirstInterval
+		logger.Infof("[health check] initialDelay parse seconds error %s", err)
+	} else {
+		initialDelay = time.Duration(initialDelaySeconds) * time.Second
 	}
 
 	unhealthyThreshold := cfg.UnhealthyThreshold

--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -73,7 +73,6 @@ type EndpointChecker struct {
 	checkTimeout  *gxtime.Timer
 	unHealthCount uint32
 	healthCount   uint32
-	threshold     uint32
 
 	once sync.Once
 }
@@ -326,28 +325,46 @@ func (c *EndpointChecker) Stop() {
 	})
 }
 
+// HandleSuccess records a healthy probe result. The endpoint is only
+// flipped to healthy after healthyThreshold consecutive successes — see
+// the CHANGELOG for the v1.2 behavior change that made this configured
+// threshold actually take effect (previously the counter compared
+// against an uninitialized field that was always 0, so the first probe
+// flipped state).
 func (c *EndpointChecker) HandleSuccess() {
 	c.unHealthCount = 0
 	c.healthCount++
-	if c.healthCount > c.threshold {
+	if c.healthCount >= c.HealthChecker.healthyThreshold {
 		c.handleHealth()
 	}
 }
 
+// HandleFailure records an unhealthy probe result. timeout=true means
+// the probe never returned within the configured timeout; timeout=false
+// means the probe returned a negative answer. Both feed the same
+// unhealthy counter so the configured unhealthyThreshold governs the
+// flip from healthy to unhealthy regardless of how the failure
+// manifested. Prior to v1.2, timeout=false flipped state immediately
+// (no counter at all) and timeout=true compared against an
+// uninitialized threshold field — see CHANGELOG.
+//
+// The timeout flag is accepted for API symmetry with the Start loop
+// (which already logs the timeout separately) but does not change the
+// counter logic.
 func (c *EndpointChecker) HandleFailure(timeout bool) {
-	if timeout {
-		c.HandleTimeout()
-	} else {
+	_ = timeout
+	c.healthCount = 0
+	c.unHealthCount++
+	if c.unHealthCount >= c.HealthChecker.unhealthyThreshold {
 		c.handleUnHealth()
 	}
 }
 
+// HandleTimeout is preserved for backward compatibility with external
+// Checker implementations that called it directly. Internally we route
+// through HandleFailure(true).
 func (c *EndpointChecker) HandleTimeout() {
-	c.healthCount = 0
-	c.unHealthCount++
-	if c.unHealthCount > c.threshold {
-		c.handleUnHealth()
-	}
+	c.HandleFailure(true)
 }
 
 func (c *EndpointChecker) handleHealth() {

--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -45,6 +45,15 @@ const (
 )
 
 type HealthChecker struct {
+	// checkers is the live set of per-address health-check sessions.
+	//
+	// Concurrency contract: mutated only from ClusterStore mutation paths
+	// (AddCluster, UpdateCluster, SetEndpoint, DeleteEndpoint, and
+	// ensureRuntimeClusters), all of which hold ClusterManager.rw for write.
+	// EndpointChecker goroutines never read or mutate this map; they only
+	// touch their own captured fields. The map is therefore unlocked by
+	// design. Do not call Start, Stop, StartOne, or StopOne from a goroutine
+	// that does not hold the ClusterManager write lock.
 	checkers      map[string]*EndpointChecker
 	sessionConfig map[string]any
 	// check config
@@ -342,18 +351,17 @@ func (c *EndpointChecker) HandleSuccess() {
 	}
 }
 
-// HandleFailure records an unhealthy probe result. timeout=true means
-// the probe never returned within the configured timeout; timeout=false
-// means the probe returned a negative answer. Both feed the same
-// unhealthy counter so the configured unhealthyThreshold governs the
-// flip from healthy to unhealthy regardless of how the failure
-// manifested. Prior to v1.2, timeout=false flipped state immediately
-// (no counter at all) and timeout=true compared against an
-// uninitialized threshold field — see CHANGELOG.
+// HandleFailure records an unhealthy probe result. Both negative probe
+// responses and timeouts feed the same unhealthy counter, so the configured
+// unhealthyThreshold governs the flip from healthy to unhealthy regardless of
+// how the failure manifested. Prior to v1.2, timeout=false flipped state
+// immediately and timeout=true compared against an uninitialized threshold
+// field; see CHANGELOG.
 //
-// The timeout flag is accepted for API symmetry with the Start loop
-// (which already logs the timeout separately) but does not change the
-// counter logic.
+// Deprecated: the timeout argument is ignored. It is retained only because
+// HandleFailure was exported in v1.x and external Checker implementations may
+// still pass it. New code should call this method with false; the next major
+// release will collapse the signature to HandleFailure().
 func (c *EndpointChecker) HandleFailure(timeout bool) {
 	_ = timeout
 	c.healthCount = 0
@@ -363,9 +371,11 @@ func (c *EndpointChecker) HandleFailure(timeout bool) {
 	}
 }
 
-// HandleTimeout is preserved for backward compatibility with external
-// Checker implementations that called it directly. Internally we route
-// through HandleFailure(true).
+// HandleTimeout is preserved for backward compatibility with external Checker
+// implementations that called it directly.
+//
+// Deprecated: routes to HandleFailure(true). Will be removed in the next major
+// release.
 func (c *EndpointChecker) HandleTimeout() {
 	c.HandleFailure(true)
 }
@@ -384,8 +394,12 @@ func (c *EndpointChecker) handleUnHealth() {
 
 func (c *EndpointChecker) emitHealth(healthy bool) {
 	if c.HealthChecker.onEndpointHealth == nil {
-		// Direct CreateHealthCheck callers still observe health through
-		// Endpoint.UnHealthy; runtime clusters install a snapshot callback.
+		// Direct CreateHealthCheck (no-callback) path. In-tree this branch is
+		// unreachable: all in-tree HealthCheckers are constructed via
+		// CreateHealthCheckWithCallback (see pkg/cluster/cluster.go). The
+		// mutation below is preserved for external consumers that import
+		// healthcheck directly. The cluster snapshot does not observe this
+		// mutation; in-tree health flows go through the callback above.
 		if !c.HealthChecker.setEndpointAddressHealth(c.endpointAddr, healthy) {
 			c.endpoint.UnHealthy = !healthy
 		}

--- a/pkg/cluster/healthcheck/healthcheck.go
+++ b/pkg/cluster/healthcheck/healthcheck.go
@@ -54,11 +54,14 @@ type HealthChecker struct {
 	cluster            *model.ClusterConfig
 	unhealthyThreshold uint32
 	protocol           string
+	onEndpointHealth   EndpointHealthListener
 }
 
 // EndpointChecker is a wrapper of types.HealthCheckSession for health check
 type EndpointChecker struct {
 	endpoint      *model.Endpoint
+	endpointID    string
+	endpointAddr  string
 	HealthChecker *HealthChecker
 	// checker, todo can extend to TCP, http, grpc, dubbo or other protocol checker
 	checker       Checker
@@ -80,12 +83,28 @@ type Checker interface {
 	OnTimeout()
 }
 
+type EndpointHealthEvent struct {
+	EndpointID      string
+	EndpointAddress string
+	Healthy         bool
+}
+
+type EndpointHealthListener func(EndpointHealthEvent)
+
 type checkResponse struct {
 	ID      uint64
 	Healthy bool
 }
 
 func CreateHealthCheck(cluster *model.ClusterConfig, cfg model.HealthCheckConfig) *HealthChecker {
+	return CreateHealthCheckWithCallback(cluster, cfg, nil)
+}
+
+func CreateHealthCheckWithCallback(
+	cluster *model.ClusterConfig,
+	cfg model.HealthCheckConfig,
+	onEndpointHealth EndpointHealthListener,
+) *HealthChecker {
 
 	timeout, err := time.ParseDuration(cfg.TimeoutConfig)
 	if err != nil {
@@ -124,6 +143,7 @@ func CreateHealthCheck(cluster *model.ClusterConfig, cfg model.HealthCheckConfig
 		unhealthyThreshold: unhealthyThreshold,
 		initialDelay:       initialDelay,
 		checkers:           make(map[string]*EndpointChecker),
+		onEndpointHealth:   onEndpointHealth,
 	}
 
 	return hc
@@ -137,8 +157,10 @@ func (hc *HealthChecker) Start() {
 }
 
 func (hc *HealthChecker) Stop() {
-	for _, h := range hc.cluster.Endpoints {
-		hc.stopCheck(h)
+	for addr, h := range hc.checkers {
+		h.Stop()
+		delete(hc.checkers, addr)
+		logger.Infof("[health check] stop a health check session for %s", addr)
 	}
 }
 
@@ -151,6 +173,9 @@ func (hc *HealthChecker) StartOne(endpoint *model.Endpoint) {
 }
 
 func (hc *HealthChecker) startCheck(endpoint *model.Endpoint) {
+	if endpoint == nil {
+		return
+	}
 	addr := endpoint.Address.GetAddress()
 	if _, ok := hc.checkers[addr]; !ok {
 		c := newChecker(endpoint, hc)
@@ -161,12 +186,36 @@ func (hc *HealthChecker) startCheck(endpoint *model.Endpoint) {
 }
 
 func (hc *HealthChecker) stopCheck(endpoint *model.Endpoint) {
+	if endpoint == nil {
+		return
+	}
 	addr := endpoint.Address.GetAddress()
+	if hc.hasOtherEndpointWithAddress(endpoint, addr) {
+		return
+	}
 	if c, ok := hc.checkers[addr]; ok {
 		c.Stop()
 		delete(hc.checkers, addr)
-		logger.Infof("[health check] create a health check session for %s", addr)
+		logger.Infof("[health check] stop a health check session for %s", addr)
 	}
+}
+
+func (hc *HealthChecker) hasOtherEndpointWithAddress(endpoint *model.Endpoint, addr string) bool {
+	if hc.cluster == nil {
+		return false
+	}
+	for _, candidate := range hc.cluster.Endpoints {
+		if candidate == nil || candidate == endpoint {
+			continue
+		}
+		if endpoint.ID != "" && candidate.ID == endpoint.ID {
+			continue
+		}
+		if candidate.Address.GetAddress() == addr {
+			return true
+		}
+	}
+	return false
 }
 
 func newChecker(endpoint *model.Endpoint, hc *HealthChecker) *EndpointChecker {
@@ -197,8 +246,12 @@ func newChecker(endpoint *model.Endpoint, hc *HealthChecker) *EndpointChecker {
 	}
 
 	c := &EndpointChecker{
-		checker:       checker,
-		endpoint:      endpoint,
+		checker:  checker,
+		endpoint: endpoint,
+		// Capture stable event identity when the checker starts; endpoint
+		// objects can be replaced while old checker events are still in flight.
+		endpointID:    endpoint.ID,
+		endpointAddr:  endpoint.Address.GetAddress(),
 		HealthChecker: hc,
 		resp:          make(chan checkResponse),
 		timeout:       make(chan bool),
@@ -300,13 +353,44 @@ func (c *EndpointChecker) HandleTimeout() {
 func (c *EndpointChecker) handleHealth() {
 	c.healthCount = 0
 	c.unHealthCount = 0
-	c.endpoint.UnHealthy = false
+	c.emitHealth(true)
 }
 
 func (c *EndpointChecker) handleUnHealth() {
 	c.healthCount = 0
 	c.unHealthCount = 0
-	c.endpoint.UnHealthy = true
+	c.emitHealth(false)
+}
+
+func (c *EndpointChecker) emitHealth(healthy bool) {
+	if c.HealthChecker.onEndpointHealth == nil {
+		// Direct CreateHealthCheck callers still observe health through
+		// Endpoint.UnHealthy; runtime clusters install a snapshot callback.
+		if !c.HealthChecker.setEndpointAddressHealth(c.endpointAddr, healthy) {
+			c.endpoint.UnHealthy = !healthy
+		}
+		return
+	}
+	c.HealthChecker.onEndpointHealth(EndpointHealthEvent{
+		EndpointID:      c.endpointID,
+		EndpointAddress: c.endpointAddr,
+		Healthy:         healthy,
+	})
+}
+
+func (hc *HealthChecker) setEndpointAddressHealth(addr string, healthy bool) bool {
+	if hc.cluster == nil {
+		return false
+	}
+	updated := false
+	for _, endpoint := range hc.cluster.Endpoints {
+		if endpoint == nil || endpoint.Address.GetAddress() != addr {
+			continue
+		}
+		endpoint.UnHealthy = !healthy
+		updated = true
+	}
+	return updated
 }
 
 func (c *EndpointChecker) OnCheck() {

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -23,6 +23,10 @@ import (
 	"time"
 )
 
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
 func TestNormalizeAddress(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -177,6 +181,33 @@ func TestCheckTcpConn(t *testing.T) {
 	})
 }
 
+func TestCreateHealthCheckParsesInitialDelaySeconds(t *testing.T) {
+	hc := CreateHealthCheck(&model.ClusterConfig{}, model.HealthCheckConfig{
+		TimeoutConfig:       "1s",
+		IntervalConfig:      "30s",
+		InitialDelaySeconds: "10",
+		HealthyThreshold:    1,
+		UnhealthyThreshold:  1,
+	})
+
+	if hc.initialDelay != 10*time.Second {
+		t.Fatalf("initialDelay = %s, want 10s", hc.initialDelay)
+	}
+}
+
+func TestCreateHealthCheckDefaultsInitialDelayWhenUnset(t *testing.T) {
+	hc := CreateHealthCheck(&model.ClusterConfig{}, model.HealthCheckConfig{
+		TimeoutConfig:      "1s",
+		IntervalConfig:     "30s",
+		HealthyThreshold:   1,
+		UnhealthyThreshold: 1,
+	})
+
+	if hc.initialDelay != DefaultFirstInterval {
+		t.Fatalf("initialDelay = %s, want %s", hc.initialDelay, DefaultFirstInterval)
+	}
+}
+
 // newTestChecker builds an EndpointChecker driving a stub HealthChecker
 // with the supplied thresholds and an event-capture callback. No
 // goroutines are started — the test drives HandleSuccess / HandleFailure
@@ -257,9 +288,9 @@ func TestHandleFailureHonorsUnhealthyThresholdForBothFailureModes(t *testing.T) 
 func TestHandleSuccessAndFailureResetEachOtherCounters(t *testing.T) {
 	c, events := newTestChecker(2, 2)
 
-	c.HandleSuccess() // healthy=1
+	c.HandleSuccess()      // healthy=1
 	c.HandleFailure(false) // unhealthy=1, healthy reset to 0
-	c.HandleSuccess() // healthy=1 (not 2, because failure reset it)
+	c.HandleSuccess()      // healthy=1 (not 2, because failure reset it)
 	if len(*events) != 0 {
 		t.Fatalf("expected no events yet (each counter at 1, threshold 2); got %d", len(*events))
 	}

--- a/pkg/cluster/healthcheck/healthcheck_test.go
+++ b/pkg/cluster/healthcheck/healthcheck_test.go
@@ -176,3 +176,112 @@ func TestCheckTcpConn(t *testing.T) {
 		}
 	})
 }
+
+// newTestChecker builds an EndpointChecker driving a stub HealthChecker
+// with the supplied thresholds and an event-capture callback. No
+// goroutines are started — the test drives HandleSuccess / HandleFailure
+// directly, so behavior is deterministic and isolated from the timer
+// loop.
+func newTestChecker(healthyThreshold, unhealthyThreshold uint32) (*EndpointChecker, *[]EndpointHealthEvent) {
+	events := make([]EndpointHealthEvent, 0)
+	eventsPtr := &events
+	hc := &HealthChecker{
+		healthyThreshold:   healthyThreshold,
+		unhealthyThreshold: unhealthyThreshold,
+		onEndpointHealth: func(ev EndpointHealthEvent) {
+			*eventsPtr = append(*eventsPtr, ev)
+		},
+	}
+	c := &EndpointChecker{
+		HealthChecker: hc,
+		endpointID:    "test-ep",
+		endpointAddr:  "127.0.0.1:18080",
+	}
+	return c, eventsPtr
+}
+
+// TestHandleSuccessHonorsHealthyThreshold proves the configured
+// healthyThreshold actually takes effect. Prior to v1.2 the threshold
+// was compared against an uninitialized uint32 field that was always
+// zero, so the first success flipped state regardless of config.
+func TestHandleSuccessHonorsHealthyThreshold(t *testing.T) {
+	c, events := newTestChecker(3, 5)
+
+	// First two successes must NOT emit a healthy event.
+	c.HandleSuccess()
+	c.HandleSuccess()
+	if len(*events) != 0 {
+		t.Fatalf("expected no health events before threshold; got %d", len(*events))
+	}
+
+	// Third success crosses the threshold (>= 3).
+	c.HandleSuccess()
+	if len(*events) != 1 {
+		t.Fatalf("expected exactly one healthy event at threshold; got %d", len(*events))
+	}
+	if !(*events)[0].Healthy {
+		t.Fatalf("expected first event to be healthy=true; got %+v", (*events)[0])
+	}
+}
+
+// TestHandleFailureHonorsUnhealthyThresholdForBothFailureModes proves
+// the configured unhealthyThreshold takes effect AND that both
+// HandleFailure(false) and HandleFailure(true) feed the same counter.
+// Prior to v1.2 the false branch flipped state immediately (no counter)
+// and the true branch compared against an uninitialized threshold.
+func TestHandleFailureHonorsUnhealthyThresholdForBothFailureModes(t *testing.T) {
+	c, events := newTestChecker(3, 4)
+
+	// Mix two non-timeout failures and one timeout — still below threshold.
+	c.HandleFailure(false)
+	c.HandleFailure(false)
+	c.HandleFailure(true)
+	if len(*events) != 0 {
+		t.Fatalf("expected no unhealthy event below threshold; got %d", len(*events))
+	}
+
+	// Fourth failure (any mode) crosses the threshold (>= 4).
+	c.HandleFailure(false)
+	if len(*events) != 1 {
+		t.Fatalf("expected exactly one unhealthy event at threshold; got %d", len(*events))
+	}
+	if (*events)[0].Healthy {
+		t.Fatalf("expected first event to be healthy=false; got %+v", (*events)[0])
+	}
+}
+
+// TestHandleSuccessAndFailureResetEachOtherCounters keeps the existing
+// reset behavior locked: a success run clears unHealthCount, a failure
+// run clears healthCount, so transitions require fresh consecutive
+// signals after a flap.
+func TestHandleSuccessAndFailureResetEachOtherCounters(t *testing.T) {
+	c, events := newTestChecker(2, 2)
+
+	c.HandleSuccess() // healthy=1
+	c.HandleFailure(false) // unhealthy=1, healthy reset to 0
+	c.HandleSuccess() // healthy=1 (not 2, because failure reset it)
+	if len(*events) != 0 {
+		t.Fatalf("expected no events yet (each counter at 1, threshold 2); got %d", len(*events))
+	}
+
+	c.HandleSuccess() // healthy=2 -> flip
+	if len(*events) != 1 || !(*events)[0].Healthy {
+		t.Fatalf("expected one healthy event after two consecutive successes; got %+v", *events)
+	}
+}
+
+// TestHandleTimeoutRoutesThroughHandleFailure ensures the legacy
+// HandleTimeout entry point still works for external Checker
+// implementations and feeds the unified failure counter.
+func TestHandleTimeoutRoutesThroughHandleFailure(t *testing.T) {
+	c, events := newTestChecker(3, 2)
+
+	c.HandleTimeout()
+	if len(*events) != 0 {
+		t.Fatalf("expected no event below threshold; got %d", len(*events))
+	}
+	c.HandleTimeout()
+	if len(*events) != 1 || (*events)[0].Healthy {
+		t.Fatalf("expected unhealthy event after two timeouts; got %+v", *events)
+	}
+}

--- a/pkg/cluster/loadbalancer/internal/lbtest/consistenthash.go
+++ b/pkg/cluster/loadbalancer/internal/lbtest/consistenthash.go
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package lbtest holds load-balancer test helpers shared between
+// pkg/cluster/loadbalancer sub-packages.
+package lbtest
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+const (
+	testLoopbackAddress = "127.0.0.1"
+	pickedWantMsgFormat = "picked %q, want %q"
+)
+
+// StaticHashPolicy returns a fixed hash key, satisfying model.LbPolicy.
+type StaticHashPolicy string
+
+func (p StaticHashPolicy) GenerateHash() string {
+	return string(p)
+}
+
+// FixedConsistentHash always resolves to Host, satisfying both
+// model.LbConsistentHash and model.LbConsistentHashView for tests.
+type FixedConsistentHash struct {
+	Host string
+}
+
+func (h FixedConsistentHash) Hash(string) uint32 { return 0 }
+
+// Add intentionally does nothing: the fixture exposes a frozen single-host
+// view and rejects runtime membership changes by design.
+func (h FixedConsistentHash) Add(string) {
+	// no-op: see method doc above.
+}
+
+func (h FixedConsistentHash) Get(string) (string, error)     { return h.Host, nil }
+func (h FixedConsistentHash) GetHash(uint32) (string, error) { return h.Host, nil }
+func (h FixedConsistentHash) Remove(string) bool             { return false }
+
+// ConsistentHashBalancer is the union of legacy and snapshot pick entry points
+// that consistent-hash balancers (Maglev, RingHash, ...) implement.
+type ConsistentHashBalancer interface {
+	loadbalancer.LoadBalancer
+	loadbalancer.SnapshotLoadBalancer
+}
+
+// RunConsistentHashHandlerSuite exercises the configured-hash, unhealthy
+// fallback, and snapshot-aware paths for a consistent-hash balancer.
+// namePrefix labels the cluster configs so failure output stays readable.
+func RunConsistentHashHandlerSuite(t *testing.T, balancer ConsistentHashBalancer, namePrefix string) {
+	t.Helper()
+
+	t.Run("HandlerUsesConfiguredHashWithoutClusterLBPolicy", func(t *testing.T) {
+		first := &model.Endpoint{
+			ID:      "first",
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18080},
+		}
+		second := &model.Endpoint{
+			ID:      "second",
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18081},
+		}
+		cluster := &model.ClusterConfig{
+			Name:      namePrefix + "-direct",
+			Endpoints: []*model.Endpoint{first, second},
+			ConsistentHash: model.ConsistentHash{
+				Hash: FixedConsistentHash{Host: second.GetHost()},
+			},
+		}
+
+		got := balancer.Handler(cluster, StaticHashPolicy("request-key"))
+		if got == nil {
+			t.Fatal("expected endpoint, got nil")
+		}
+		if got.ID != second.ID {
+			t.Fatalf(pickedWantMsgFormat, got.ID, second.ID)
+		}
+	})
+
+	t.Run("HandlerFallsBackWhenConfiguredHashHitsUnhealthyEndpoint", func(t *testing.T) {
+		healthy := &model.Endpoint{
+			ID:      "healthy",
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18080},
+		}
+		unhealthy := &model.Endpoint{
+			ID:        "unhealthy",
+			Address:   model.SocketAddress{Address: testLoopbackAddress, Port: 18081},
+			UnHealthy: true,
+		}
+		cluster := &model.ClusterConfig{
+			Name:      namePrefix + "-direct-unhealthy-hit",
+			Endpoints: []*model.Endpoint{healthy, unhealthy},
+			ConsistentHash: model.ConsistentHash{
+				Hash: FixedConsistentHash{Host: unhealthy.GetHost()},
+			},
+		}
+
+		got := balancer.Handler(cluster, StaticHashPolicy("request-key"))
+		if got == nil {
+			t.Fatal("expected fallback endpoint, got nil")
+		}
+		if got.ID != healthy.ID {
+			t.Fatalf(pickedWantMsgFormat, got.ID, healthy.ID)
+		}
+	})
+
+	t.Run("UsesHealthyConsistentHashSnapshot", func(t *testing.T) {
+		first := &model.Endpoint{
+			ID:      "first",
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18080},
+		}
+		unhealthy := &model.Endpoint{
+			ID:        "unhealthy",
+			Address:   model.SocketAddress{Address: testLoopbackAddress, Port: 18081},
+			UnHealthy: true,
+		}
+		second := &model.Endpoint{
+			ID:      "second",
+			Address: model.SocketAddress{Address: testLoopbackAddress, Port: 18082},
+		}
+		cluster := &model.ClusterConfig{
+			Name: namePrefix + "-healthy-snapshot",
+			ConsistentHash: model.ConsistentHash{
+				Hash: FixedConsistentHash{Host: unhealthy.GetHost()},
+			},
+		}
+
+		got := balancer.HandlerWithSnapshot(loadbalancer.PickContext{
+			Config:                cluster,
+			HealthyConsistentHash: FixedConsistentHash{Host: second.GetHost()},
+			HealthyEndpoints:      []*model.Endpoint{first, second},
+		}, StaticHashPolicy("key-for-unhealthy-slot"))
+
+		if got == nil {
+			t.Fatal("expected healthy endpoint, got nil")
+		}
+		if got.ID != second.ID {
+			t.Fatalf(pickedWantMsgFormat, got.ID, second.ID)
+		}
+	})
+}

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -222,31 +222,43 @@ func healthyEndpointFromSnapshot(endpoint *model.Endpoint, healthyEndpoints []*m
 // balancer chose a still-healthy entry before handing it back to the request
 // path.
 //
+// Parameter convention (load-bearing): the FIRST argument is the snapshot
+// healthy-set member, the SECOND is the balancer return. The wildcard in
+// rule (2) is keyed off the SNAPSHOT side because that is where legacy
+// resolvers produce placeholder endpoints. Crossing the arguments will
+// silently invert rule (2) and reject valid picks that should match by ID.
+// Call-site convention enforced by healthyEndpointFromSnapshot:
+//
+//	sameEndpointIdentity(candidate /* snapshot */, endpoint /* return */)
+//
 // Rules:
 //
 //  1. When either side carries a non-empty ID, IDs must match. ID is the
 //     authoritative identity since PR-2 (deterministic generation) and is
 //     immune to address drift caused by DNS or service-discovery refreshes.
-//  2. With IDs matched, when the snapshot endpoint's address is fully empty
-//     (Domains == [""] AND Address == "" AND Port == 0 — i.e. SocketAddress
-//     is at its zero value bar the single blank domain marker), any
-//     candidate address is accepted. This is a narrow wildcard for legacy
-//     resolvers that produce placeholder endpoints whose address is
-//     intentionally absent and is reconciled via ID. Any non-zero address
-//     field forfeits the wildcard so an operator cannot accidentally widen
-//     the trust boundary by typing one blank domain entry next to a real
-//     port.
+//  2. With IDs matched, when the SNAPSHOT endpoint's (candidate) address is
+//     fully empty (Domains == [""] AND Address == "" AND Port == 0 — i.e.
+//     SocketAddress is at its zero value bar the single blank domain
+//     marker), any balancer return address is accepted. This is a narrow
+//     wildcard for legacy resolvers that publish placeholder endpoints
+//     whose address is intentionally absent and is reconciled via ID; the
+//     balancer (or a downstream resolver) supplies the resolved address.
+//     Any non-zero address field on the snapshot side forfeits the
+//     wildcard so an operator cannot accidentally widen the trust
+//     boundary by typing one blank domain entry next to a real port.
 //  3. Otherwise (or when neither side has an ID), addresses must compare
 //     equal via SocketAddress.Equal — no string formatting, no allocation.
 //
 // Risk: rule (2) means anyone with the right ID matches the placeholder
-// endpoint regardless of where the candidate points. The ID is therefore
-// treated as a trust boundary and must remain operator-controlled or
-// system-generated. The fully-empty-address gate keeps the wildcard from
-// catching real addresses that happen to share an ID via misconfiguration.
+// endpoint regardless of where the balancer routed them. The ID is
+// therefore treated as a trust boundary and must remain operator-controlled
+// or system-generated. The fully-empty-address gate keeps the wildcard
+// from catching real snapshot addresses that happen to share an ID via
+// misconfiguration.
 //
-// Locked by TestSameEndpointIdentityBlankDomainWildcard in
-// load_balancer_test.go.
+// Locked by TestSameEndpointIdentityBlankDomainWildcard (unit) and
+// TestHealthyEndpointFromSnapshotAcceptsResolvedAddressForBlankPlaceholder
+// (integration through the real pick path) in load_balancer_test.go.
 func sameEndpointIdentity(candidate, endpoint *model.Endpoint) bool {
 	if candidate == nil || endpoint == nil {
 		return false
@@ -255,7 +267,7 @@ func sameEndpointIdentity(candidate, endpoint *model.Endpoint) bool {
 		if candidate.ID != endpoint.ID {
 			return false
 		}
-		if isBlankDomainPlaceholderAddress(endpoint.Address) {
+		if isBlankDomainPlaceholderAddress(candidate.Address) {
 			return true
 		}
 		return candidate.Address.Equal(endpoint.Address)

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -158,6 +158,19 @@ func pickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locke
 	// Legacy balancers only understand ClusterConfig. Serialize this
 	// compatibility path so cursor-style state reconciles predictably;
 	// custom mutable state should move to SnapshotLoadBalancer instead.
+	//
+	// RR cursor fairness caveat (issue #905): the cursor delta-apply
+	// below uses atomic.AddUint32 on context.Config.PrePickEndpointIndex.
+	// If a snapshot-path RoundRobin picks against the SAME *ClusterConfig
+	// concurrently (also via atomic.AddUint32), the two paths compete on
+	// the same counter and the legacy delta may overshoot or undershoot
+	// the snapshot increment. This is not a data race (both are atomic)
+	// and not a correctness regression (the picked endpoint is still
+	// valid), but the visit order may skip / repeat one slot during the
+	// race window. In practice a single cluster registers a single
+	// LbStr, so legacy and snapshot RR do not coexist; if a future
+	// deployment mixes them, accept the fairness skew or migrate the
+	// legacy plugin to SnapshotLoadBalancer.
 	lock := legacyPickLockFor(balancer, legacyPickLock)
 	lock.Lock()
 	defer lock.Unlock()

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -214,25 +214,26 @@ func healthyEndpointFromSnapshot(endpoint *model.Endpoint, healthyEndpoints []*m
 //  1. When either side carries a non-empty ID, IDs must match. ID is the
 //     authoritative identity since PR-2 (deterministic generation) and is
 //     immune to address drift caused by DNS or service-discovery refreshes.
-//  2. With IDs matched, when the snapshot endpoint's address declares a
-//     single blank domain (Domains == [""], so GetAddress() == ""), any
-//     candidate address is accepted. This preserves a long-standing legacy
-//     resolver behavior: certain dynamic backends produce endpoints whose
-//     literal address is intentionally blank and the resolver is expected to
-//     reconcile via ID. Stripping this wildcard would regress those
-//     deployments.
+//  2. With IDs matched, when the snapshot endpoint's address is fully empty
+//     (Domains == [""] AND Address == "" AND Port == 0 — i.e. SocketAddress
+//     is at its zero value bar the single blank domain marker), any
+//     candidate address is accepted. This is a narrow wildcard for legacy
+//     resolvers that produce placeholder endpoints whose address is
+//     intentionally absent and is reconciled via ID. Any non-zero address
+//     field forfeits the wildcard so an operator cannot accidentally widen
+//     the trust boundary by typing one blank domain entry next to a real
+//     port.
 //  3. Otherwise (or when neither side has an ID), addresses must compare
 //     equal via SocketAddress.Equal — no string formatting, no allocation.
 //
-// Risk: rule (2) is only safe because IDs are now deterministic and
-// non-empty by default (see model.GenerateEndpointID). If an attacker could
-// inject an endpoint with the same ID and a blank-domain address it would
-// match regardless of where the candidate points. The ID is therefore
+// Risk: rule (2) means anyone with the right ID matches the placeholder
+// endpoint regardless of where the candidate points. The ID is therefore
 // treated as a trust boundary and must remain operator-controlled or
-// system-generated.
+// system-generated. The fully-empty-address gate keeps the wildcard from
+// catching real addresses that happen to share an ID via misconfiguration.
 //
-// This wildcard's behavior is locked by
-// TestSameEndpointIdentityBlankDomainWildcard in load_balancer_test.go.
+// Locked by TestSameEndpointIdentityBlankDomainWildcard in
+// load_balancer_test.go.
 func sameEndpointIdentity(candidate, endpoint *model.Endpoint) bool {
 	if candidate == nil || endpoint == nil {
 		return false
@@ -241,12 +242,23 @@ func sameEndpointIdentity(candidate, endpoint *model.Endpoint) bool {
 		if candidate.ID != endpoint.ID {
 			return false
 		}
-		if len(endpoint.Address.Domains) > 0 && endpoint.Address.Domains[0] == "" {
+		if isBlankDomainPlaceholderAddress(endpoint.Address) {
 			return true
 		}
 		return candidate.Address.Equal(endpoint.Address)
 	}
 	return candidate.Address.Equal(endpoint.Address)
+}
+
+// isBlankDomainPlaceholderAddress reports whether addr is the narrow
+// "address-absent placeholder" form: exactly one blank domain entry and
+// zero values everywhere else. Used by sameEndpointIdentity to bound the
+// blank-domain wildcard.
+func isBlankDomainPlaceholderAddress(addr model.SocketAddress) bool {
+	return len(addr.Domains) == 1 &&
+		addr.Domains[0] == "" &&
+		addr.Address == "" &&
+		addr.Port == 0
 }
 
 func RegisterConsistentHashInit(name model.LbPolicyType, function model.ConsistentHashInitFunc) {

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -77,16 +77,6 @@ type ZeroCopySnapshotLoadBalancer interface {
 	UseZeroCopySnapshot() bool
 }
 
-// ClusterScopedLegacyLoadBalancer lets a legacy load balancer opt in to
-// runtime-cluster scoped serialization. Legacy balancers that do not
-// implement this interface keep the package-level compatibility lock because
-// strategy instances are shared globally. Implementations must ensure the
-// same balancer instance can run Handler concurrently across different
-// clusters.
-type ClusterScopedLegacyLoadBalancer interface {
-	UseClusterScopedLegacyLock() bool
-}
-
 // LoadBalancerStrategy load balancer strategy mode
 var LoadBalancerStrategy = map[model.LbPolicyType]LoadBalancer{}
 
@@ -106,15 +96,7 @@ func RegisterLoadBalancer(name model.LbPolicyType, balancer LoadBalancer) {
 // from snapshot-published pick paths. Legacy balancers fall back to the
 // package-level compatibility lock automatically.
 func PickEndpoint(balancer LoadBalancer, context PickContext, policy model.LbPolicy) *model.Endpoint {
-	return pickEndpointWithLegacyLock(balancer, nil, context, policy)
-}
-
-// PickEndpointWithLegacyLock serializes legacy balancers. The caller-provided
-// runtime lock is used only when the balancer explicitly opts in to scoped
-// serialization; other legacy balancers keep the package-level compatibility
-// lock.
-func PickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locker, context PickContext, policy model.LbPolicy) *model.Endpoint {
-	return pickEndpointWithLegacyLock(balancer, legacyPickLock, context, policy)
+	return pickEndpoint(balancer, context, policy)
 }
 
 // NeedsAllEndpoints reports whether a snapshot-aware balancer should receive
@@ -141,7 +123,7 @@ func ConsistentHashForHealthyEndpoints(context PickContext) model.LbConsistentHa
 	return model.ReadOnlyConsistentHash(context.Config.ConsistentHash.Hash)
 }
 
-func pickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locker, context PickContext, policy model.LbPolicy) *model.Endpoint {
+func pickEndpoint(balancer LoadBalancer, context PickContext, policy model.LbPolicy) *model.Endpoint {
 	if balancer == nil || context.Config == nil {
 		return nil
 	}
@@ -171,9 +153,19 @@ func pickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locke
 	// LbStr, so legacy and snapshot RR do not coexist; if a future
 	// deployment mixes them, accept the fairness skew or migrate the
 	// legacy plugin to SnapshotLoadBalancer.
-	lock := legacyPickLockFor(balancer, legacyPickLock)
-	lock.Lock()
-	defer lock.Unlock()
+	//
+	// Shared-pointer hazard: config := *context.Config is a shallow copy.
+	// config.Endpoints is replaced with a clone below, but other
+	// pointer-bearing fields on ClusterConfig (ConsistentHash.Hash,
+	// operator-supplied Metadata, etc.) stay shared with context.Config.
+	// The package lock above serializes legacy picks, but it does not
+	// serialize legacy picks against concurrent ClusterStore mutations that
+	// touch those fields. In-tree this is safe because all ClusterStore
+	// mutators hold ClusterManager.rw and PickEndpoint takes
+	// ClusterManager.rw.RLock; external legacy plugins must observe the same
+	// rule.
+	legacyPickMu.Lock()
+	defer legacyPickMu.Unlock()
 
 	allEndpoints := context.AllEndpoints
 	if allEndpoints == nil {
@@ -196,13 +188,6 @@ func defensiveSnapshotPickContext(context PickContext) PickContext {
 	defensive.AllEndpoints = model.CloneEndpoints(context.AllEndpoints)
 	defensive.HealthyEndpoints = model.CloneEndpoints(context.HealthyEndpoints)
 	return defensive
-}
-
-func legacyPickLockFor(balancer LoadBalancer, legacyPickLock sync.Locker) sync.Locker {
-	if scoped, ok := balancer.(ClusterScopedLegacyLoadBalancer); ok && scoped.UseClusterScopedLegacyLock() && legacyPickLock != nil {
-		return legacyPickLock
-	}
-	return &legacyPickMu
 }
 
 func healthyEndpointFromSnapshot(endpoint *model.Endpoint, healthyEndpoints []*model.Endpoint) *model.Endpoint {

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -210,6 +210,11 @@ func healthyEndpointFromSnapshot(endpoint *model.Endpoint, healthyEndpoints []*m
 		return nil
 	}
 	for _, candidate := range healthyEndpoints {
+		if candidate == endpoint {
+			return model.CloneEndpoint(candidate)
+		}
+	}
+	for _, candidate := range healthyEndpoints {
 		if sameEndpointIdentity(candidate, endpoint) {
 			return model.CloneEndpoint(candidate)
 		}

--- a/pkg/cluster/loadbalancer/load_balancer.go
+++ b/pkg/cluster/loadbalancer/load_balancer.go
@@ -18,21 +18,235 @@
 package loadbalancer
 
 import (
+	"sync"
+	"sync/atomic"
+)
+
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
+
+// PickContext bundles the snapshot view a load balancer needs to make a
+// single pick. The runtime publishes an immutable EndpointSnapshot per
+// cluster and derives PickContext from it, so balancers must treat every
+// field as read-only.
+type PickContext struct {
+	// Config carries cluster-level load-balancer configuration and runtime
+	// cursor state. Snapshot-aware balancers should not reread
+	// Config.Endpoints for health filtering — use HealthyEndpoints instead.
+	Config *model.ClusterConfig
+	// HealthyConsistentHash is built from HealthyEndpoints for the same
+	// immutable runtime snapshot and intentionally exposes lookup methods only.
+	// Consistent-hash balancers should prefer this view over
+	// Config.ConsistentHash.Hash, which is mutable and can include
+	// runtime-unhealthy endpoints.
+	HealthyConsistentHash model.LbConsistentHashView
+	// AllEndpoints is the current runtime snapshot, including endpoints marked
+	// unhealthy by runtime health checks. Provided only when the balancer
+	// requests it via NeedsAllEndpoints.
+	AllEndpoints []*model.Endpoint
+	// HealthyEndpoints is already filtered from the current runtime snapshot.
+	// Snapshot-aware balancers must treat endpoints as read-only and return
+	// the chosen endpoint without mutating or retaining it.
+	HealthyEndpoints []*model.Endpoint
+}
 
 type LoadBalancer interface {
 	Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint
 }
 
+// SnapshotLoadBalancer is optional for balancers that consume the current
+// runtime snapshot. Implementations should pick only from
+// PickContext.HealthyEndpoints; Config.Endpoints may include unhealthy or
+// stale config entries.
+type SnapshotLoadBalancer interface {
+	HandlerWithSnapshot(c PickContext, policy model.LbPolicy) *model.Endpoint
+}
+
+// HealthyOnlySnapshotLoadBalancer marks snapshot-aware balancers that do not
+// need PickContext.AllEndpoints. Unmarked snapshot balancers keep receiving
+// the full snapshot for compatibility with custom implementations.
+type HealthyOnlySnapshotLoadBalancer interface {
+	UseHealthyEndpointsOnly() bool
+}
+
+// ZeroCopySnapshotLoadBalancer marks trusted balancers that never mutate or
+// retain snapshot endpoints. Other snapshot balancers receive defensive
+// copies.
+type ZeroCopySnapshotLoadBalancer interface {
+	UseZeroCopySnapshot() bool
+}
+
+// ClusterScopedLegacyLoadBalancer lets a legacy load balancer opt in to
+// runtime-cluster scoped serialization. Legacy balancers that do not
+// implement this interface keep the package-level compatibility lock because
+// strategy instances are shared globally. Implementations must ensure the
+// same balancer instance can run Handler concurrently across different
+// clusters.
+type ClusterScopedLegacyLoadBalancer interface {
+	UseClusterScopedLegacyLock() bool
+}
+
 // LoadBalancerStrategy load balancer strategy mode
 var LoadBalancerStrategy = map[model.LbPolicyType]LoadBalancer{}
+
+// legacyPickMu serializes pre-snapshot balancers. They share strategy
+// instances globally and may carry mutable cursor state, so concurrent
+// Handler calls across clusters are unsafe by default.
+var legacyPickMu sync.Mutex
 
 func RegisterLoadBalancer(name model.LbPolicyType, balancer LoadBalancer) {
 	if _, ok := LoadBalancerStrategy[name]; ok {
 		panic("load balancer register fail " + name)
 	}
 	LoadBalancerStrategy[name] = balancer
+}
+
+// PickEndpoint picks an endpoint for the supplied snapshot context. Use this
+// from snapshot-published pick paths. Legacy balancers fall back to the
+// package-level compatibility lock automatically.
+func PickEndpoint(balancer LoadBalancer, context PickContext, policy model.LbPolicy) *model.Endpoint {
+	return pickEndpointWithLegacyLock(balancer, nil, context, policy)
+}
+
+// PickEndpointWithLegacyLock serializes legacy balancers. The caller-provided
+// runtime lock is used only when the balancer explicitly opts in to scoped
+// serialization; other legacy balancers keep the package-level compatibility
+// lock.
+func PickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locker, context PickContext, policy model.LbPolicy) *model.Endpoint {
+	return pickEndpointWithLegacyLock(balancer, legacyPickLock, context, policy)
+}
+
+// NeedsAllEndpoints reports whether a snapshot-aware balancer should receive
+// PickContext.AllEndpoints on the request path.
+func NeedsAllEndpoints(balancer LoadBalancer) bool {
+	healthyOnly, ok := balancer.(HealthyOnlySnapshotLoadBalancer)
+	return !ok || !healthyOnly.UseHealthyEndpointsOnly()
+}
+
+// ConsistentHashForHealthyEndpoints returns a consistent hash view that only
+// contains the healthy endpoints visible to this pick. Returns nil if the
+// context has no healthy endpoints or no consistent-hash factory registered.
+func ConsistentHashForHealthyEndpoints(context PickContext) model.LbConsistentHashView {
+	if context.HealthyConsistentHash != nil {
+		return context.HealthyConsistentHash
+	}
+	if context.Config == nil || len(context.HealthyEndpoints) == 0 {
+		return nil
+	}
+	newConsistentHash, ok := model.ConsistentHashInitMap[context.Config.LbStr]
+	if ok {
+		return model.ReadOnlyConsistentHash(newConsistentHash(context.Config.ConsistentHash, context.HealthyEndpoints))
+	}
+	return model.ReadOnlyConsistentHash(context.Config.ConsistentHash.Hash)
+}
+
+func pickEndpointWithLegacyLock(balancer LoadBalancer, legacyPickLock sync.Locker, context PickContext, policy model.LbPolicy) *model.Endpoint {
+	if balancer == nil || context.Config == nil {
+		return nil
+	}
+	if snapshotBalancer, ok := balancer.(SnapshotLoadBalancer); ok {
+		snapshotContext := context
+		zeroCopy, ok := balancer.(ZeroCopySnapshotLoadBalancer)
+		if !ok || !zeroCopy.UseZeroCopySnapshot() {
+			snapshotContext = defensiveSnapshotPickContext(context)
+		}
+		endpoint := snapshotBalancer.HandlerWithSnapshot(snapshotContext, policy)
+		return healthyEndpointFromSnapshot(endpoint, context.HealthyEndpoints)
+	}
+
+	// Legacy balancers only understand ClusterConfig. Serialize this
+	// compatibility path so cursor-style state reconciles predictably;
+	// custom mutable state should move to SnapshotLoadBalancer instead.
+	lock := legacyPickLockFor(balancer, legacyPickLock)
+	lock.Lock()
+	defer lock.Unlock()
+
+	allEndpoints := context.AllEndpoints
+	if allEndpoints == nil {
+		allEndpoints = context.HealthyEndpoints
+	}
+	config := *context.Config
+	config.Endpoints = model.CloneEndpoints(allEndpoints)
+	cursorBefore := atomic.LoadUint32(&context.Config.PrePickEndpointIndex)
+	atomic.StoreUint32(&config.PrePickEndpointIndex, cursorBefore)
+	endpoint := balancer.Handler(&config, policy)
+	cursorAfter := atomic.LoadUint32(&config.PrePickEndpointIndex)
+	if cursorAfter != cursorBefore {
+		atomic.AddUint32(&context.Config.PrePickEndpointIndex, cursorAfter-cursorBefore)
+	}
+	return healthyEndpointFromSnapshot(endpoint, context.HealthyEndpoints)
+}
+
+func defensiveSnapshotPickContext(context PickContext) PickContext {
+	defensive := context
+	defensive.AllEndpoints = model.CloneEndpoints(context.AllEndpoints)
+	defensive.HealthyEndpoints = model.CloneEndpoints(context.HealthyEndpoints)
+	return defensive
+}
+
+func legacyPickLockFor(balancer LoadBalancer, legacyPickLock sync.Locker) sync.Locker {
+	if scoped, ok := balancer.(ClusterScopedLegacyLoadBalancer); ok && scoped.UseClusterScopedLegacyLock() && legacyPickLock != nil {
+		return legacyPickLock
+	}
+	return &legacyPickMu
+}
+
+func healthyEndpointFromSnapshot(endpoint *model.Endpoint, healthyEndpoints []*model.Endpoint) *model.Endpoint {
+	if endpoint == nil {
+		return nil
+	}
+	for _, candidate := range healthyEndpoints {
+		if sameEndpointIdentity(candidate, endpoint) {
+			return model.CloneEndpoint(candidate)
+		}
+	}
+	return nil
+}
+
+// sameEndpointIdentity reports whether candidate (from the snapshot's healthy
+// set) matches endpoint (returned by a balancer pick). Used to confirm the
+// balancer chose a still-healthy entry before handing it back to the request
+// path.
+//
+// Rules:
+//
+//  1. When either side carries a non-empty ID, IDs must match. ID is the
+//     authoritative identity since PR-2 (deterministic generation) and is
+//     immune to address drift caused by DNS or service-discovery refreshes.
+//  2. With IDs matched, when the snapshot endpoint's address declares a
+//     single blank domain (Domains == [""], so GetAddress() == ""), any
+//     candidate address is accepted. This preserves a long-standing legacy
+//     resolver behavior: certain dynamic backends produce endpoints whose
+//     literal address is intentionally blank and the resolver is expected to
+//     reconcile via ID. Stripping this wildcard would regress those
+//     deployments.
+//  3. Otherwise (or when neither side has an ID), addresses must compare
+//     equal via SocketAddress.Equal — no string formatting, no allocation.
+//
+// Risk: rule (2) is only safe because IDs are now deterministic and
+// non-empty by default (see model.GenerateEndpointID). If an attacker could
+// inject an endpoint with the same ID and a blank-domain address it would
+// match regardless of where the candidate points. The ID is therefore
+// treated as a trust boundary and must remain operator-controlled or
+// system-generated.
+//
+// This wildcard's behavior is locked by
+// TestSameEndpointIdentityBlankDomainWildcard in load_balancer_test.go.
+func sameEndpointIdentity(candidate, endpoint *model.Endpoint) bool {
+	if candidate == nil || endpoint == nil {
+		return false
+	}
+	if endpoint.ID != "" || candidate.ID != "" {
+		if candidate.ID != endpoint.ID {
+			return false
+		}
+		if len(endpoint.Address.Domains) > 0 && endpoint.Address.Domains[0] == "" {
+			return true
+		}
+		return candidate.Address.Equal(endpoint.Address)
+	}
+	return candidate.Address.Equal(endpoint.Address)
 }
 
 func RegisterConsistentHashInit(name model.LbPolicyType, function model.ConsistentHashInitFunc) {

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -18,6 +18,7 @@
 package loadbalancer
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -663,6 +664,24 @@ func TestHealthyEndpointFromSnapshotAcceptsResolvedAddressForBlankPlaceholder(t 
 	assert.NotSame(t, snapshotPlaceholder, got, "returned endpoint must be a clone, not the snapshot pointer")
 }
 
+func TestHealthyEndpointFromSnapshotPointerFastPathReturnsClone(t *testing.T) {
+	endpoint := &model.Endpoint{
+		ID: "zero-copy-id",
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    8080,
+		},
+	}
+
+	got := healthyEndpointFromSnapshot(endpoint, []*model.Endpoint{endpoint})
+
+	if !assert.NotNil(t, got) {
+		return
+	}
+	assert.Equal(t, endpoint, got)
+	assert.NotSame(t, endpoint, got, "request path must not return the snapshot-owned endpoint pointer")
+}
+
 // TestHealthyEndpointFromSnapshotRejectsMismatchedRealAddress ensures the
 // wildcard is not a free pass: when the snapshot has a real address and
 // the balancer returns a different real address for the same ID, the
@@ -682,4 +701,36 @@ func TestHealthyEndpointFromSnapshotRejectsMismatchedRealAddress(t *testing.T) {
 
 	got := healthyEndpointFromSnapshot(balancerReturn, healthyEndpoints)
 	assert.Nil(t, got, "real-address mismatch must not match even when IDs agree")
+}
+
+func BenchmarkHealthyEndpointFromSnapshot(b *testing.B) {
+	const endpointCount = 1024
+	healthyEndpoints := make([]*model.Endpoint, endpointCount)
+	for i := range healthyEndpoints {
+		healthyEndpoints[i] = &model.Endpoint{
+			ID: fmt.Sprintf("ep-%d", i),
+			Address: model.SocketAddress{
+				Address: "127.0.0.1",
+				Port:    10000 + i,
+			},
+		}
+	}
+	zeroCopyEndpoint := healthyEndpoints[endpointCount-1]
+	defensiveCopyEndpoint := model.CloneEndpoint(zeroCopyEndpoint)
+
+	b.Run("pointer-eq-fast-path", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if healthyEndpointFromSnapshot(zeroCopyEndpoint, healthyEndpoints) == nil {
+				b.Fatal("expected match")
+			}
+		}
+	})
+
+	b.Run("identity-scan", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if healthyEndpointFromSnapshot(defensiveCopyEndpoint, healthyEndpoints) == nil {
+				b.Fatal("expected match")
+			}
+		}
+	})
 }

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -1,0 +1,516 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalancer
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+type legacyLoadBalancer struct {
+	seenEndpoints []*model.Endpoint
+}
+
+type legacyCursorLoadBalancer struct{}
+type mutatingLegacyLoadBalancer struct{}
+type unhealthyLegacyLoadBalancer struct{}
+type mutatingSnapshotLoadBalancer struct{}
+type unhealthySnapshotLoadBalancer struct{}
+type healthyOnlySnapshotLoadBalancer struct{}
+
+var _ LoadBalancer = (*legacyLoadBalancer)(nil)
+
+type blockingLegacyLoadBalancer struct {
+	entered chan int
+	release chan struct{}
+	calls   int32
+}
+
+type clusterScopedBlockingLegacyLoadBalancer struct {
+	*blockingLegacyLoadBalancer
+}
+
+type observableLocker struct {
+	mu      sync.Mutex
+	waiter  chan struct{}
+	locked  bool
+	blocked chan struct{}
+}
+
+type legacyPickHarness struct {
+	t           *testing.T
+	balancer    LoadBalancer
+	blocking    *blockingLegacyLoadBalancer
+	releaseOnce sync.Once
+}
+
+func (l *legacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	l.seenEndpoints = c.Endpoints
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	return c.Endpoints[0]
+}
+
+func (legacyCursorLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	index := atomic.AddUint32(&c.PrePickEndpointIndex, 1) - 1
+	return c.Endpoints[int(index%uint32(len(c.Endpoints)))]
+}
+
+func (mutatingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	c.Endpoints[0].Metadata["weight"] = "99"
+	c.Endpoints[0].LLMMeta.APIKey = "mutated-key"
+	return c.Endpoints[0]
+}
+
+func (unhealthyLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	if len(c.Endpoints) < 2 {
+		return nil
+	}
+	return c.Endpoints[1]
+}
+
+func (mutatingSnapshotLoadBalancer) Handler(_ *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (mutatingSnapshotLoadBalancer) HandlerWithSnapshot(c PickContext, _ model.LbPolicy) *model.Endpoint {
+	if len(c.HealthyEndpoints) == 0 {
+		return nil
+	}
+	c.HealthyEndpoints[0].Metadata["weight"] = "99"
+	c.HealthyEndpoints[0].LLMMeta.APIKey = "mutated-key"
+	if len(c.AllEndpoints) > 1 {
+		c.AllEndpoints[1].Metadata["weight"] = "42"
+	}
+	return c.HealthyEndpoints[0]
+}
+
+func (unhealthySnapshotLoadBalancer) Handler(_ *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (unhealthySnapshotLoadBalancer) HandlerWithSnapshot(c PickContext, _ model.LbPolicy) *model.Endpoint {
+	if len(c.AllEndpoints) < 2 {
+		return nil
+	}
+	return c.AllEndpoints[1]
+}
+
+func (healthyOnlySnapshotLoadBalancer) Handler(_ *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (healthyOnlySnapshotLoadBalancer) HandlerWithSnapshot(_ PickContext, _ model.LbPolicy) *model.Endpoint {
+	return nil
+}
+
+func (healthyOnlySnapshotLoadBalancer) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (b *blockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
+	call := atomic.AddInt32(&b.calls, 1)
+	b.entered <- int(call)
+	<-b.release
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	return c.Endpoints[0]
+}
+
+func (b *clusterScopedBlockingLegacyLoadBalancer) UseClusterScopedLegacyLock() bool {
+	return true
+}
+
+func newObservableLocker() *observableLocker {
+	return &observableLocker{
+		blocked: make(chan struct{}, 1),
+	}
+}
+
+func (l *observableLocker) Lock() {
+	l.mu.Lock()
+	if !l.locked {
+		l.locked = true
+		l.mu.Unlock()
+		return
+	}
+	waiter := make(chan struct{})
+	l.waiter = waiter
+	l.blocked <- struct{}{}
+	l.mu.Unlock()
+	<-waiter
+
+	l.mu.Lock()
+	l.locked = true
+	l.mu.Unlock()
+}
+
+func (l *observableLocker) Unlock() {
+	l.mu.Lock()
+	l.locked = false
+	if l.waiter != nil {
+		close(l.waiter)
+		l.waiter = nil
+	}
+	l.mu.Unlock()
+}
+
+func newLegacyPickHarness(t *testing.T, scoped bool) *legacyPickHarness {
+	t.Helper()
+	blocking := &blockingLegacyLoadBalancer{
+		entered: make(chan int, 2),
+		release: make(chan struct{}),
+	}
+	harness := &legacyPickHarness{
+		t:        t,
+		balancer: blocking,
+		blocking: blocking,
+	}
+	if scoped {
+		harness.balancer = &clusterScopedBlockingLegacyLoadBalancer{
+			blockingLegacyLoadBalancer: blocking,
+		}
+	}
+	t.Cleanup(harness.release)
+	return harness
+}
+
+func newLegacyPickContext(clusterName, endpointID string) PickContext {
+	endpoint := &model.Endpoint{ID: endpointID}
+	return PickContext{
+		Config: &model.ClusterConfig{
+			Name:      clusterName,
+			Endpoints: []*model.Endpoint{endpoint},
+		},
+		HealthyEndpoints: []*model.Endpoint{endpoint},
+	}
+}
+
+func (h *legacyPickHarness) startDirectPick(context PickContext) <-chan struct{} {
+	h.t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = PickEndpoint(h.balancer, context, nil)
+	}()
+	return done
+}
+
+func (h *legacyPickHarness) startLockedPick(lock sync.Locker, context PickContext) <-chan struct{} {
+	h.t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = PickEndpointWithLegacyLock(h.balancer, lock, context, nil)
+	}()
+	return done
+}
+
+func (h *legacyPickHarness) release() {
+	h.releaseOnce.Do(func() {
+		close(h.blocking.release)
+	})
+}
+
+func (h *legacyPickHarness) waitEntry() int {
+	h.t.Helper()
+	return waitLegacyHandlerEntry(h.t, h.blocking.entered)
+}
+
+func (h *legacyPickHarness) assertNoEntry() {
+	h.t.Helper()
+	assertNoLegacyHandlerEntry(h.t, h.blocking.entered)
+}
+
+func TestPickEndpointAdaptsLegacyLoadBalancer(t *testing.T) {
+	healthy := &model.Endpoint{ID: "healthy"}
+	unhealthy := &model.Endpoint{ID: "unhealthy", UnHealthy: true}
+	cluster := &model.ClusterConfig{
+		Name:      "legacy-load-balancer",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+	}
+	balancer := &legacyLoadBalancer{}
+
+	got := PickEndpoint(balancer, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy, unhealthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	assert.NotSame(t, healthy, got)
+	assert.Equal(t, healthy, got)
+	assert.Equal(t, []*model.Endpoint{healthy, unhealthy}, balancer.seenEndpoints)
+	assert.NotSame(t, healthy, balancer.seenEndpoints[0])
+	assert.NotSame(t, unhealthy, balancer.seenEndpoints[1])
+	assert.Equal(t, []*model.Endpoint{healthy, unhealthy}, cluster.Endpoints)
+}
+
+func TestPickEndpointReconcilesLegacyCursorState(t *testing.T) {
+	first := &model.Endpoint{ID: "first"}
+	second := &model.Endpoint{ID: "second"}
+	cluster := &model.ClusterConfig{
+		Name:                 "legacy-cursor-load-balancer",
+		Endpoints:            []*model.Endpoint{first, second},
+		PrePickEndpointIndex: 3,
+	}
+
+	got := PickEndpoint(legacyCursorLoadBalancer{}, PickContext{
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{first, second},
+	}, nil)
+
+	assert.NotSame(t, second, got)
+	assert.Equal(t, second, got)
+	assert.Equal(t, uint32(4), atomic.LoadUint32(&cluster.PrePickEndpointIndex))
+}
+
+func TestPickEndpointLegacyMutationsDoNotEscape(t *testing.T) {
+	healthy := &model.Endpoint{
+		ID:       "healthy",
+		Metadata: map[string]string{"weight": "1"},
+		LLMMeta:  &model.LLMMeta{APIKey: "original-key"},
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "legacy-mutation",
+		Endpoints: []*model.Endpoint{healthy},
+	}
+
+	got := PickEndpoint(mutatingLegacyLoadBalancer{}, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	if assert.NotNil(t, got) {
+		assert.Equal(t, map[string]string{"weight": "1"}, got.Metadata)
+		assert.Equal(t, "original-key", got.LLMMeta.APIKey)
+	}
+	assert.Equal(t, map[string]string{"weight": "1"}, healthy.Metadata)
+	assert.Equal(t, "original-key", healthy.LLMMeta.APIKey)
+}
+
+func TestPickEndpointRejectsUnhealthyLegacyReturn(t *testing.T) {
+	healthy := &model.Endpoint{ID: "healthy"}
+	unhealthy := &model.Endpoint{ID: "unhealthy", UnHealthy: true}
+	cluster := &model.ClusterConfig{
+		Name:      "legacy-health-guard",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+	}
+
+	got := PickEndpoint(unhealthyLegacyLoadBalancer{}, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy, unhealthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	assert.Nil(t, got)
+}
+
+func TestPickEndpointSnapshotMutationsDoNotEscape(t *testing.T) {
+	healthy := &model.Endpoint{
+		ID:       "healthy",
+		Metadata: map[string]string{"weight": "1"},
+		LLMMeta:  &model.LLMMeta{APIKey: "original-key"},
+	}
+	unhealthy := &model.Endpoint{
+		ID:        "unhealthy",
+		Metadata:  map[string]string{"weight": "2"},
+		UnHealthy: true,
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "snapshot-mutation",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+	}
+
+	got := PickEndpoint(mutatingSnapshotLoadBalancer{}, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy, unhealthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	if assert.NotNil(t, got) {
+		assert.NotSame(t, healthy, got)
+		assert.Equal(t, map[string]string{"weight": "1"}, got.Metadata)
+		assert.Equal(t, "original-key", got.LLMMeta.APIKey)
+	}
+	assert.Equal(t, map[string]string{"weight": "1"}, healthy.Metadata)
+	assert.Equal(t, "original-key", healthy.LLMMeta.APIKey)
+	assert.Equal(t, map[string]string{"weight": "2"}, unhealthy.Metadata)
+}
+
+func TestPickEndpointRejectsUnhealthySnapshotReturn(t *testing.T) {
+	healthy := &model.Endpoint{ID: "healthy"}
+	unhealthy := &model.Endpoint{ID: "unhealthy", UnHealthy: true}
+	cluster := &model.ClusterConfig{
+		Name:      "snapshot-health-guard",
+		Endpoints: []*model.Endpoint{healthy, unhealthy},
+	}
+
+	got := PickEndpoint(unhealthySnapshotLoadBalancer{}, PickContext{
+		AllEndpoints:     []*model.Endpoint{healthy, unhealthy},
+		Config:           cluster,
+		HealthyEndpoints: []*model.Endpoint{healthy},
+	}, nil)
+
+	assert.Nil(t, got)
+}
+
+func TestNeedsAllEndpointsKeepsCompatibilityForUnmarkedSnapshotLoadBalancer(t *testing.T) {
+	assert.True(t, NeedsAllEndpoints(mutatingSnapshotLoadBalancer{}))
+	assert.False(t, NeedsAllEndpoints(healthyOnlySnapshotLoadBalancer{}))
+}
+
+func TestPickEndpointSerializesLegacyLoadBalancerHandlers(t *testing.T) {
+	harness := newLegacyPickHarness(t, false)
+	pickContext := newLegacyPickContext("blocking-legacy-load-balancer", "first")
+
+	firstDone := harness.startDirectPick(pickContext)
+	assert.Equal(t, 1, harness.waitEntry())
+
+	secondDone := harness.startDirectPick(pickContext)
+	harness.assertNoEntry()
+
+	harness.release()
+	assert.Equal(t, 2, harness.waitEntry())
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func TestPickEndpointKeepsCompatibilityLockForOptInLegacyLoadBalancer(t *testing.T) {
+	harness := newLegacyPickHarness(t, true)
+	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-direct-pick", "first")
+	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-direct-pick", "second")
+
+	firstDone := harness.startDirectPick(firstContext)
+	assert.Equal(t, 1, harness.waitEntry())
+
+	secondDone := harness.startDirectPick(secondContext)
+	harness.assertNoEntry()
+
+	harness.release()
+	assert.Equal(t, 2, harness.waitEntry())
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func TestPickEndpointWithLegacyLockSerializesOptInLegacyLoadBalancerHandlersWithSameLock(t *testing.T) {
+	harness := newLegacyPickHarness(t, true)
+	legacyPickLock := newObservableLocker()
+	pickContext := newLegacyPickContext("blocking-legacy-load-balancer-same-lock", "first")
+
+	firstDone := harness.startLockedPick(legacyPickLock, pickContext)
+	assert.Equal(t, 1, harness.waitEntry())
+
+	secondDone := harness.startLockedPick(legacyPickLock, pickContext)
+	waitLegacyLockBlocked(t, legacyPickLock.blocked)
+
+	harness.release()
+	assert.Equal(t, 2, harness.waitEntry())
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func TestPickEndpointWithLegacyLockSerializesNonOptInLegacyLoadBalancerHandlersAcrossDifferentLocks(t *testing.T) {
+	harness := newLegacyPickHarness(t, false)
+	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-lock", "first")
+	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-lock", "second")
+	var firstLock sync.Mutex
+	var secondLock sync.Mutex
+
+	firstDone := harness.startLockedPick(&firstLock, firstContext)
+	assert.Equal(t, 1, harness.waitEntry())
+
+	secondDone := harness.startLockedPick(&secondLock, secondContext)
+	harness.assertNoEntry()
+
+	harness.release()
+	assert.Equal(t, 2, harness.waitEntry())
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func TestPickEndpointWithLegacyLockAllowsOptInLegacyLoadBalancerHandlersWithDifferentLocksToRunConcurrently(t *testing.T) {
+	harness := newLegacyPickHarness(t, true)
+	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-lock", "first")
+	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-lock", "second")
+	var firstLock sync.Mutex
+	var secondLock sync.Mutex
+
+	firstDone := harness.startLockedPick(&firstLock, firstContext)
+	assert.Equal(t, 1, harness.waitEntry())
+
+	secondDone := harness.startLockedPick(&secondLock, secondContext)
+	assert.Equal(t, 2, harness.waitEntry())
+
+	harness.release()
+	waitClosed(t, firstDone)
+	waitClosed(t, secondDone)
+}
+
+func waitLegacyHandlerEntry(t *testing.T, entered <-chan int) int {
+	t.Helper()
+	select {
+	case call := <-entered:
+		return call
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for legacy handler entry")
+		return 0
+	}
+}
+
+func assertNoLegacyHandlerEntry(t *testing.T, entered <-chan int) {
+	t.Helper()
+	select {
+	case call := <-entered:
+		t.Fatalf("legacy handler call %d entered before the first call returned", call)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func waitLegacyLockBlocked(t *testing.T, blocked <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for legacy pick to block on the runtime lock")
+	}
+}
+
+func waitClosed(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for legacy pick to finish")
+	}
+}

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -515,13 +515,14 @@ func waitClosed(t *testing.T, done <-chan struct{}) {
 	}
 }
 
-// TestSameEndpointIdentityBlankDomainWildcard locks the legacy resolver
-// behavior in sameEndpointIdentity: when a snapshot endpoint declares a
-// single blank domain (Domains == [""], so GetAddress() == ""), it
-// matches any candidate by ID alone. This wildcard is preserved
-// intentionally — see the contract comment on sameEndpointIdentity for
-// why, and the risk it introduces (IDs must be operator-controlled or
-// system-generated).
+// TestSameEndpointIdentityBlankDomainWildcard locks the narrow placeholder
+// wildcard in sameEndpointIdentity: only a SocketAddress whose every field
+// is zero-valued except a single blank-domain marker accepts any candidate
+// by ID. Any non-zero address field (e.g. Domains containing a real domain,
+// or Address/Port set alongside Domains=[""]) revokes the wildcard so a
+// stray blank domain in a config does not silently widen the trust
+// boundary. See the contract comment on sameEndpointIdentity for the trust
+// model.
 func TestSameEndpointIdentityBlankDomainWildcard(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -531,7 +532,7 @@ func TestSameEndpointIdentityBlankDomainWildcard(t *testing.T) {
 		why        string
 	}{
 		{
-			name: "matching_id_with_blank_domain_accepts_any_candidate_address",
+			name: "matching_id_with_placeholder_address_accepts_any_candidate_address",
 			snapshotEP: &model.Endpoint{
 				ID:      "shared-id",
 				Address: model.SocketAddress{Domains: []string{""}},
@@ -541,7 +542,7 @@ func TestSameEndpointIdentityBlankDomainWildcard(t *testing.T) {
 				Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
 			},
 			want: true,
-			why:  "blank-domain snapshot endpoint wildcards on ID",
+			why:  "fully-empty placeholder (Domains=[\"\"], no IP, no port) wildcards on ID",
 		},
 		{
 			name: "matching_id_with_real_domain_requires_address_equality",
@@ -557,7 +558,7 @@ func TestSameEndpointIdentityBlankDomainWildcard(t *testing.T) {
 			why:  "real-domain snapshot endpoint must match address too",
 		},
 		{
-			name: "different_id_with_blank_domain_is_not_a_match",
+			name: "different_id_with_placeholder_address_is_not_a_match",
 			snapshotEP: &model.Endpoint{
 				ID:      "snapshot-id",
 				Address: model.SocketAddress{Domains: []string{""}},
@@ -567,7 +568,39 @@ func TestSameEndpointIdentityBlankDomainWildcard(t *testing.T) {
 				Address: model.SocketAddress{Domains: []string{""}},
 			},
 			want: false,
-			why:  "ID is the trust boundary; blank domain does not paper over an ID mismatch",
+			why:  "ID is the trust boundary; placeholder address does not paper over an ID mismatch",
+		},
+		{
+			name: "blank_domain_alongside_real_port_revokes_wildcard",
+			snapshotEP: &model.Endpoint{
+				ID: "shared-id",
+				Address: model.SocketAddress{
+					Domains: []string{""},
+					Address: "10.0.0.1",
+					Port:    8080,
+				},
+			},
+			candidate: &model.Endpoint{
+				ID:      "shared-id",
+				Address: model.SocketAddress{Address: "10.0.0.2", Port: 8080},
+			},
+			want: false,
+			why:  "address fields are populated, so this is not a placeholder; address must match",
+		},
+		{
+			name: "blank_domain_alongside_real_address_revokes_wildcard",
+			snapshotEP: &model.Endpoint{
+				ID: "shared-id",
+				Address: model.SocketAddress{
+					Domains: []string{"", "fallback.example.com"},
+				},
+			},
+			candidate: &model.Endpoint{
+				ID:      "shared-id",
+				Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
+			},
+			want: false,
+			why:  "Domains contains more than one entry, so this is not the placeholder form",
 		},
 	}
 

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -52,17 +52,6 @@ type blockingLegacyLoadBalancer struct {
 	calls   int32
 }
 
-type clusterScopedBlockingLegacyLoadBalancer struct {
-	*blockingLegacyLoadBalancer
-}
-
-type observableLocker struct {
-	mu      sync.Mutex
-	waiter  chan struct{}
-	locked  bool
-	blocked chan struct{}
-}
-
 type legacyPickHarness struct {
 	t           *testing.T
 	balancer    LoadBalancer
@@ -148,45 +137,7 @@ func (b *blockingLegacyLoadBalancer) Handler(c *model.ClusterConfig, _ model.LbP
 	return c.Endpoints[0]
 }
 
-func (b *clusterScopedBlockingLegacyLoadBalancer) UseClusterScopedLegacyLock() bool {
-	return true
-}
-
-func newObservableLocker() *observableLocker {
-	return &observableLocker{
-		blocked: make(chan struct{}, 1),
-	}
-}
-
-func (l *observableLocker) Lock() {
-	l.mu.Lock()
-	if !l.locked {
-		l.locked = true
-		l.mu.Unlock()
-		return
-	}
-	waiter := make(chan struct{})
-	l.waiter = waiter
-	l.blocked <- struct{}{}
-	l.mu.Unlock()
-	<-waiter
-
-	l.mu.Lock()
-	l.locked = true
-	l.mu.Unlock()
-}
-
-func (l *observableLocker) Unlock() {
-	l.mu.Lock()
-	l.locked = false
-	if l.waiter != nil {
-		close(l.waiter)
-		l.waiter = nil
-	}
-	l.mu.Unlock()
-}
-
-func newLegacyPickHarness(t *testing.T, scoped bool) *legacyPickHarness {
+func newLegacyPickHarness(t *testing.T) *legacyPickHarness {
 	t.Helper()
 	blocking := &blockingLegacyLoadBalancer{
 		entered: make(chan int, 2),
@@ -196,11 +147,6 @@ func newLegacyPickHarness(t *testing.T, scoped bool) *legacyPickHarness {
 		t:        t,
 		balancer: blocking,
 		blocking: blocking,
-	}
-	if scoped {
-		harness.balancer = &clusterScopedBlockingLegacyLoadBalancer{
-			blockingLegacyLoadBalancer: blocking,
-		}
 	}
 	t.Cleanup(harness.release)
 	return harness
@@ -217,22 +163,12 @@ func newLegacyPickContext(clusterName, endpointID string) PickContext {
 	}
 }
 
-func (h *legacyPickHarness) startDirectPick(context PickContext) <-chan struct{} {
+func (h *legacyPickHarness) startPick(context PickContext) <-chan struct{} {
 	h.t.Helper()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		_ = PickEndpoint(h.balancer, context, nil)
-	}()
-	return done
-}
-
-func (h *legacyPickHarness) startLockedPick(lock sync.Locker, context PickContext) <-chan struct{} {
-	h.t.Helper()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		_ = PickEndpointWithLegacyLock(h.balancer, lock, context, nil)
 	}()
 	return done
 }
@@ -392,13 +328,13 @@ func TestNeedsAllEndpointsKeepsCompatibilityForUnmarkedSnapshotLoadBalancer(t *t
 }
 
 func TestPickEndpointSerializesLegacyLoadBalancerHandlers(t *testing.T) {
-	harness := newLegacyPickHarness(t, false)
+	harness := newLegacyPickHarness(t)
 	pickContext := newLegacyPickContext("blocking-legacy-load-balancer", "first")
 
-	firstDone := harness.startDirectPick(pickContext)
+	firstDone := harness.startPick(pickContext)
 	assert.Equal(t, 1, harness.waitEntry())
 
-	secondDone := harness.startDirectPick(pickContext)
+	secondDone := harness.startPick(pickContext)
 	harness.assertNoEntry()
 
 	harness.release()
@@ -407,73 +343,19 @@ func TestPickEndpointSerializesLegacyLoadBalancerHandlers(t *testing.T) {
 	waitClosed(t, secondDone)
 }
 
-func TestPickEndpointKeepsCompatibilityLockForOptInLegacyLoadBalancer(t *testing.T) {
-	harness := newLegacyPickHarness(t, true)
-	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-direct-pick", "first")
-	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-direct-pick", "second")
+func TestPickEndpointSerializesLegacyHandlersThroughPackageLock(t *testing.T) {
+	harness := newLegacyPickHarness(t)
+	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-context", "first")
+	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-context", "second")
 
-	firstDone := harness.startDirectPick(firstContext)
+	firstDone := harness.startPick(firstContext)
 	assert.Equal(t, 1, harness.waitEntry())
 
-	secondDone := harness.startDirectPick(secondContext)
+	secondDone := harness.startPick(secondContext)
 	harness.assertNoEntry()
 
 	harness.release()
 	assert.Equal(t, 2, harness.waitEntry())
-	waitClosed(t, firstDone)
-	waitClosed(t, secondDone)
-}
-
-func TestPickEndpointWithLegacyLockSerializesOptInLegacyLoadBalancerHandlersWithSameLock(t *testing.T) {
-	harness := newLegacyPickHarness(t, true)
-	legacyPickLock := newObservableLocker()
-	pickContext := newLegacyPickContext("blocking-legacy-load-balancer-same-lock", "first")
-
-	firstDone := harness.startLockedPick(legacyPickLock, pickContext)
-	assert.Equal(t, 1, harness.waitEntry())
-
-	secondDone := harness.startLockedPick(legacyPickLock, pickContext)
-	waitLegacyLockBlocked(t, legacyPickLock.blocked)
-
-	harness.release()
-	assert.Equal(t, 2, harness.waitEntry())
-	waitClosed(t, firstDone)
-	waitClosed(t, secondDone)
-}
-
-func TestPickEndpointWithLegacyLockSerializesNonOptInLegacyLoadBalancerHandlersAcrossDifferentLocks(t *testing.T) {
-	harness := newLegacyPickHarness(t, false)
-	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-lock", "first")
-	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-lock", "second")
-	var firstLock sync.Mutex
-	var secondLock sync.Mutex
-
-	firstDone := harness.startLockedPick(&firstLock, firstContext)
-	assert.Equal(t, 1, harness.waitEntry())
-
-	secondDone := harness.startLockedPick(&secondLock, secondContext)
-	harness.assertNoEntry()
-
-	harness.release()
-	assert.Equal(t, 2, harness.waitEntry())
-	waitClosed(t, firstDone)
-	waitClosed(t, secondDone)
-}
-
-func TestPickEndpointWithLegacyLockAllowsOptInLegacyLoadBalancerHandlersWithDifferentLocksToRunConcurrently(t *testing.T) {
-	harness := newLegacyPickHarness(t, true)
-	firstContext := newLegacyPickContext("blocking-legacy-load-balancer-first-lock", "first")
-	secondContext := newLegacyPickContext("blocking-legacy-load-balancer-second-lock", "second")
-	var firstLock sync.Mutex
-	var secondLock sync.Mutex
-
-	firstDone := harness.startLockedPick(&firstLock, firstContext)
-	assert.Equal(t, 1, harness.waitEntry())
-
-	secondDone := harness.startLockedPick(&secondLock, secondContext)
-	assert.Equal(t, 2, harness.waitEntry())
-
-	harness.release()
 	waitClosed(t, firstDone)
 	waitClosed(t, secondDone)
 }
@@ -495,15 +377,6 @@ func assertNoLegacyHandlerEntry(t *testing.T, entered <-chan int) {
 	case call := <-entered:
 		t.Fatalf("legacy handler call %d entered before the first call returned", call)
 	case <-time.After(50 * time.Millisecond):
-	}
-}
-
-func waitLegacyLockBlocked(t *testing.T, blocked <-chan struct{}) {
-	t.Helper()
-	select {
-	case <-blocked:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for legacy pick to block on the runtime lock")
 	}
 }
 

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -514,3 +514,67 @@ func waitClosed(t *testing.T, done <-chan struct{}) {
 		t.Fatal("timed out waiting for legacy pick to finish")
 	}
 }
+
+// TestSameEndpointIdentityBlankDomainWildcard locks the legacy resolver
+// behavior in sameEndpointIdentity: when a snapshot endpoint declares a
+// single blank domain (Domains == [""], so GetAddress() == ""), it
+// matches any candidate by ID alone. This wildcard is preserved
+// intentionally — see the contract comment on sameEndpointIdentity for
+// why, and the risk it introduces (IDs must be operator-controlled or
+// system-generated).
+func TestSameEndpointIdentityBlankDomainWildcard(t *testing.T) {
+	cases := []struct {
+		name       string
+		snapshotEP *model.Endpoint
+		candidate  *model.Endpoint
+		want       bool
+		why        string
+	}{
+		{
+			name: "matching_id_with_blank_domain_accepts_any_candidate_address",
+			snapshotEP: &model.Endpoint{
+				ID:      "shared-id",
+				Address: model.SocketAddress{Domains: []string{""}},
+			},
+			candidate: &model.Endpoint{
+				ID:      "shared-id",
+				Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
+			},
+			want: true,
+			why:  "blank-domain snapshot endpoint wildcards on ID",
+		},
+		{
+			name: "matching_id_with_real_domain_requires_address_equality",
+			snapshotEP: &model.Endpoint{
+				ID:      "shared-id",
+				Address: model.SocketAddress{Domains: []string{"openai.com"}},
+			},
+			candidate: &model.Endpoint{
+				ID:      "shared-id",
+				Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
+			},
+			want: false,
+			why:  "real-domain snapshot endpoint must match address too",
+		},
+		{
+			name: "different_id_with_blank_domain_is_not_a_match",
+			snapshotEP: &model.Endpoint{
+				ID:      "snapshot-id",
+				Address: model.SocketAddress{Domains: []string{""}},
+			},
+			candidate: &model.Endpoint{
+				ID:      "candidate-id",
+				Address: model.SocketAddress{Domains: []string{""}},
+			},
+			want: false,
+			why:  "ID is the trust boundary; blank domain does not paper over an ID mismatch",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sameEndpointIdentity(tc.candidate, tc.snapshotEP)
+			assert.Equal(t, tc.want, got, tc.why)
+		})
+	}
+}

--- a/pkg/cluster/loadbalancer/load_balancer_test.go
+++ b/pkg/cluster/loadbalancer/load_balancer_test.go
@@ -516,63 +516,67 @@ func waitClosed(t *testing.T, done <-chan struct{}) {
 }
 
 // TestSameEndpointIdentityBlankDomainWildcard locks the narrow placeholder
-// wildcard in sameEndpointIdentity: only a SocketAddress whose every field
-// is zero-valued except a single blank-domain marker accepts any candidate
-// by ID. Any non-zero address field (e.g. Domains containing a real domain,
-// or Address/Port set alongside Domains=[""]) revokes the wildcard so a
-// stray blank domain in a config does not silently widen the trust
-// boundary. See the contract comment on sameEndpointIdentity for the trust
-// model.
+// wildcard in sameEndpointIdentity. The wildcard fires when the SNAPSHOT
+// endpoint (first argument, per call-site convention in
+// healthyEndpointFromSnapshot) has a fully-empty SocketAddress — a single
+// blank-domain marker with no IP/port. Any non-zero address field on the
+// snapshot side revokes the wildcard so a stray blank domain in a config
+// does not silently widen the trust boundary. See the contract comment on
+// sameEndpointIdentity for the trust model.
+//
+// Field names below match the function signature exactly (snapshot is
+// `candidate`, balancer return is `endpoint`) so a reader cannot lose
+// track of which side carries the placeholder.
 func TestSameEndpointIdentityBlankDomainWildcard(t *testing.T) {
 	cases := []struct {
-		name       string
-		snapshotEP *model.Endpoint
-		candidate  *model.Endpoint
-		want       bool
-		why        string
+		name           string
+		snapshot       *model.Endpoint // function param: candidate
+		balancerReturn *model.Endpoint // function param: endpoint
+		want           bool
+		why            string
 	}{
 		{
-			name: "matching_id_with_placeholder_address_accepts_any_candidate_address",
-			snapshotEP: &model.Endpoint{
+			name: "snapshot_placeholder_accepts_resolved_balancer_address",
+			snapshot: &model.Endpoint{
 				ID:      "shared-id",
 				Address: model.SocketAddress{Domains: []string{""}},
 			},
-			candidate: &model.Endpoint{
+			balancerReturn: &model.Endpoint{
 				ID:      "shared-id",
 				Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
 			},
 			want: true,
-			why:  "fully-empty placeholder (Domains=[\"\"], no IP, no port) wildcards on ID",
+			why:  "snapshot side is the fully-empty placeholder; legacy resolver wildcard fires on ID alone",
 		},
 		{
-			name: "matching_id_with_real_domain_requires_address_equality",
-			snapshotEP: &model.Endpoint{
+			name: "snapshot_real_domain_requires_address_equality_even_with_matching_id",
+			snapshot: &model.Endpoint{
 				ID:      "shared-id",
 				Address: model.SocketAddress{Domains: []string{"openai.com"}},
 			},
-			candidate: &model.Endpoint{
+			balancerReturn: &model.Endpoint{
 				ID:      "shared-id",
 				Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
 			},
 			want: false,
-			why:  "real-domain snapshot endpoint must match address too",
+			why:  "snapshot side is a real domain, not a placeholder; address must match",
 		},
 		{
-			name: "different_id_with_placeholder_address_is_not_a_match",
-			snapshotEP: &model.Endpoint{
+			name: "different_id_with_snapshot_placeholder_is_not_a_match",
+			snapshot: &model.Endpoint{
 				ID:      "snapshot-id",
 				Address: model.SocketAddress{Domains: []string{""}},
 			},
-			candidate: &model.Endpoint{
-				ID:      "candidate-id",
+			balancerReturn: &model.Endpoint{
+				ID:      "different-id",
 				Address: model.SocketAddress{Domains: []string{""}},
 			},
 			want: false,
 			why:  "ID is the trust boundary; placeholder address does not paper over an ID mismatch",
 		},
 		{
-			name: "blank_domain_alongside_real_port_revokes_wildcard",
-			snapshotEP: &model.Endpoint{
+			name: "snapshot_blank_domain_with_real_port_revokes_wildcard",
+			snapshot: &model.Endpoint{
 				ID: "shared-id",
 				Address: model.SocketAddress{
 					Domains: []string{""},
@@ -580,34 +584,102 @@ func TestSameEndpointIdentityBlankDomainWildcard(t *testing.T) {
 					Port:    8080,
 				},
 			},
-			candidate: &model.Endpoint{
+			balancerReturn: &model.Endpoint{
 				ID:      "shared-id",
 				Address: model.SocketAddress{Address: "10.0.0.2", Port: 8080},
 			},
 			want: false,
-			why:  "address fields are populated, so this is not a placeholder; address must match",
+			why:  "snapshot address fields are populated, so this is not a placeholder; address must match",
 		},
 		{
-			name: "blank_domain_alongside_real_address_revokes_wildcard",
-			snapshotEP: &model.Endpoint{
+			name: "snapshot_with_two_domains_including_blank_revokes_wildcard",
+			snapshot: &model.Endpoint{
 				ID: "shared-id",
 				Address: model.SocketAddress{
 					Domains: []string{"", "fallback.example.com"},
 				},
 			},
-			candidate: &model.Endpoint{
+			balancerReturn: &model.Endpoint{
 				ID:      "shared-id",
 				Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
 			},
 			want: false,
-			why:  "Domains contains more than one entry, so this is not the placeholder form",
+			why:  "snapshot Domains has more than one entry, so this is not the placeholder form",
+		},
+		{
+			name: "balancer_return_placeholder_does_NOT_trigger_wildcard_when_snapshot_is_real",
+			snapshot: &model.Endpoint{
+				ID:      "shared-id",
+				Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
+			},
+			balancerReturn: &model.Endpoint{
+				ID:      "shared-id",
+				Address: model.SocketAddress{Domains: []string{""}},
+			},
+			want: false,
+			why:  "wildcard is keyed on the SNAPSHOT side, not the balancer return; reversing roles is a no-op",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := sameEndpointIdentity(tc.candidate, tc.snapshotEP)
+			// Call-site convention from healthyEndpointFromSnapshot:
+			//   sameEndpointIdentity(candidate /* snapshot */, endpoint /* return */)
+			got := sameEndpointIdentity(tc.snapshot, tc.balancerReturn)
 			assert.Equal(t, tc.want, got, tc.why)
 		})
 	}
+}
+
+// TestHealthyEndpointFromSnapshotAcceptsResolvedAddressForBlankPlaceholder
+// is the integration test for the wildcard. It exercises the real call
+// path (healthyEndpointFromSnapshot iterating the healthy snapshot slice)
+// so the parameter-order contract between the caller and
+// sameEndpointIdentity is verified end-to-end. A previous regression
+// passed the unit test by reversing the args; this test would have
+// caught it because there is no way to mis-name the arguments when they
+// come from a real snapshot.
+func TestHealthyEndpointFromSnapshotAcceptsResolvedAddressForBlankPlaceholder(t *testing.T) {
+	// Snapshot holds a legacy resolver placeholder: ID set, address absent.
+	snapshotPlaceholder := &model.Endpoint{
+		ID:      "legacy-resolver-id",
+		Address: model.SocketAddress{Domains: []string{""}},
+	}
+	healthyEndpoints := []*model.Endpoint{snapshotPlaceholder}
+
+	// Balancer (or downstream resolver) returns the resolved real address
+	// for the same ID. The healthy lookup MUST accept this and return a
+	// clone of the snapshot entry.
+	balancerReturn := &model.Endpoint{
+		ID:      "legacy-resolver-id",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
+	}
+
+	got := healthyEndpointFromSnapshot(balancerReturn, healthyEndpoints)
+	if !assert.NotNil(t, got, "balancer return with same ID as snapshot placeholder must match via wildcard") {
+		return
+	}
+	assert.Equal(t, snapshotPlaceholder.ID, got.ID)
+	assert.NotSame(t, snapshotPlaceholder, got, "returned endpoint must be a clone, not the snapshot pointer")
+}
+
+// TestHealthyEndpointFromSnapshotRejectsMismatchedRealAddress ensures the
+// wildcard is not a free pass: when the snapshot has a real address and
+// the balancer returns a different real address for the same ID, the
+// lookup must reject so the pick path returns nil instead of a stale
+// hostname/port.
+func TestHealthyEndpointFromSnapshotRejectsMismatchedRealAddress(t *testing.T) {
+	snapshot := &model.Endpoint{
+		ID:      "shared-id",
+		Address: model.SocketAddress{Address: "127.0.0.1", Port: 8080},
+	}
+	healthyEndpoints := []*model.Endpoint{snapshot}
+
+	balancerReturn := &model.Endpoint{
+		ID:      "shared-id",
+		Address: model.SocketAddress{Address: "10.0.0.1", Port: 9090},
+	}
+
+	got := healthyEndpointFromSnapshot(balancerReturn, healthyEndpoints)
+	assert.Nil(t, got, "real-address mismatch must not match even when IDs agree")
 }

--- a/pkg/cluster/loadbalancer/maglev/maglev_hash.go
+++ b/pkg/cluster/loadbalancer/maglev/maglev_hash.go
@@ -41,7 +41,7 @@ func NewMaglevHash(config model.ConsistentHash, endpoints []*model.Endpoint) mod
 		return h
 	}
 
-	logger.Infof("[dubbo-go-pixiu] maglev hash load balancing fail: %v, using ring hash instead", err)
+	logger.Warnf("[dubbo-go-pixiu] maglev hash load balancing fail: %v, using ring hash instead", err)
 	if config.ReplicaNum == 0 {
 		config.ReplicaNum = 2 * len(endpoints)
 	}

--- a/pkg/cluster/loadbalancer/maglev/maglev_hash.go
+++ b/pkg/cluster/loadbalancer/maglev/maglev_hash.go
@@ -50,24 +50,47 @@ func NewMaglevHash(config model.ConsistentHash, endpoints []*model.Endpoint) mod
 
 type MaglevHash struct{}
 
+func (MaglevHash) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (MaglevHash) UseZeroCopySnapshot() bool {
+	return true
+}
+
 func (m MaglevHash) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
-	dst, err := c.ConsistentHash.Hash.Get(policy.GenerateHash())
+	if c == nil {
+		return nil
+	}
+	endpoints := c.GetEndpoint(true)
+	hashView := model.ReadOnlyConsistentHash(c.ConsistentHash.Hash)
+	if hashView == nil && len(endpoints) > 0 {
+		hashView = model.ReadOnlyConsistentHash(NewMaglevHash(c.ConsistentHash, endpoints))
+	}
+	return m.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:                c,
+		HealthyConsistentHash: hashView,
+		HealthyEndpoints:      endpoints,
+	}, policy)
+}
+
+func (m MaglevHash) HandlerWithSnapshot(c loadbalancer.PickContext, policy model.LbPolicy) *model.Endpoint {
+	endpoints := c.HealthyEndpoints
+	hashView := loadbalancer.ConsistentHashForHealthyEndpoints(c)
+	if len(endpoints) == 0 || hashView == nil || policy == nil {
+		return nil
+	}
+
+	dst, err := hashView.Get(policy.GenerateHash())
 	if err != nil {
 		logger.Warnf("[dubbo-go-pixiu] error of getting from maglev hash: %v", err)
 		return nil
 	}
-
-	endpoints := c.GetEndpoint(true)
 
 	for _, endpoint := range endpoints {
 		if endpoint.GetHost() == dst {
 			return endpoint
 		}
 	}
-
-	if len(endpoints) == 0 {
-		return nil
-	}
-
 	return endpoints[0]
 }

--- a/pkg/cluster/loadbalancer/rand/load_balancer_rand.go
+++ b/pkg/cluster/loadbalancer/rand/load_balancer_rand.go
@@ -32,11 +32,26 @@ func init() {
 
 type Rand struct{}
 
+func (Rand) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (Rand) UseZeroCopySnapshot() bool {
+	return true
+}
+
 // randIntn lets tests replace randomness with deterministic choices.
 var randIntn = rand.Intn
 
-func (Rand) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
-	endpoints := c.GetEndpoint(true)
+func (r Rand) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
+	return r.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: c.GetEndpoint(true),
+	}, policy)
+}
+
+func (Rand) HandlerWithSnapshot(c loadbalancer.PickContext, _ model.LbPolicy) *model.Endpoint {
+	endpoints := c.HealthyEndpoints
 	if len(endpoints) == 0 {
 		return nil
 	}

--- a/pkg/cluster/loadbalancer/ringhash/ring_hash.go
+++ b/pkg/cluster/loadbalancer/ringhash/ring_hash.go
@@ -58,25 +58,48 @@ func NewRingHash(config model.ConsistentHash, endpoints []*model.Endpoint) model
 
 type RingHashing struct{}
 
+func (RingHashing) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (RingHashing) UseZeroCopySnapshot() bool {
+	return true
+}
+
 func (r RingHashing) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
-	u := c.ConsistentHash.Hash.Hash(policy.GenerateHash())
-	hash, err := c.ConsistentHash.Hash.GetHash(u)
+	if c == nil {
+		return nil
+	}
+	endpoints := c.GetEndpoint(true)
+	hashView := model.ReadOnlyConsistentHash(c.ConsistentHash.Hash)
+	if hashView == nil && len(endpoints) > 0 {
+		hashView = model.ReadOnlyConsistentHash(NewRingHash(c.ConsistentHash, endpoints))
+	}
+	return r.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:                c,
+		HealthyConsistentHash: hashView,
+		HealthyEndpoints:      endpoints,
+	}, policy)
+}
+
+func (r RingHashing) HandlerWithSnapshot(c loadbalancer.PickContext, policy model.LbPolicy) *model.Endpoint {
+	endpoints := c.HealthyEndpoints
+	hashView := loadbalancer.ConsistentHashForHealthyEndpoints(c)
+	if len(endpoints) == 0 || hashView == nil || policy == nil {
+		return nil
+	}
+
+	u := hashView.Hash(policy.GenerateHash())
+	host, err := hashView.GetHash(u)
 	if err != nil {
 		logger.Warnf("[dubbo-go-pixiu] error of getting from ring hash: %v", err)
 		return nil
 	}
 
-	endpoints := c.GetEndpoint(true)
-
 	for _, endpoint := range endpoints {
-		if endpoint.GetHost() == hash {
+		if endpoint.GetHost() == host {
 			return endpoint
 		}
 	}
-
-	if len(endpoints) == 0 {
-		return nil
-	}
-
 	return endpoints[0]
 }

--- a/pkg/cluster/loadbalancer/roundrobin/round_robin.go
+++ b/pkg/cluster/loadbalancer/roundrobin/round_robin.go
@@ -32,12 +32,27 @@ func init() {
 
 type RoundRobin struct{}
 
-func (RoundRobin) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
-	endpoints := c.GetEndpoint(true)
+func (RoundRobin) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (RoundRobin) UseZeroCopySnapshot() bool {
+	return true
+}
+
+func (r RoundRobin) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
+	return r.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: c.GetEndpoint(true),
+	}, policy)
+}
+
+func (RoundRobin) HandlerWithSnapshot(c loadbalancer.PickContext, _ model.LbPolicy) *model.Endpoint {
+	endpoints := c.HealthyEndpoints
 	if len(endpoints) == 0 {
 		return nil
 	}
 	// AddUint32 returns the incremented value, so subtract 1 for a zero-based index.
-	index := atomic.AddUint32(&c.PrePickEndpointIndex, 1) - 1
+	index := atomic.AddUint32(&c.Config.PrePickEndpointIndex, 1) - 1
 	return endpoints[int(index%uint32(len(endpoints)))]
 }

--- a/pkg/cluster/loadbalancer/weightrandom/weight_random.go
+++ b/pkg/cluster/loadbalancer/weightrandom/weight_random.go
@@ -40,8 +40,23 @@ type weightedEndpoint struct {
 // It assigns weights to endpoints and uses these weights to influence the probability of selection.
 type WeightRandom struct{}
 
-func (WeightRandom) Handler(c *model.ClusterConfig, _ model.LbPolicy) *model.Endpoint {
-	endpoints := c.GetEndpoint(true)
+func (WeightRandom) UseHealthyEndpointsOnly() bool {
+	return true
+}
+
+func (WeightRandom) UseZeroCopySnapshot() bool {
+	return true
+}
+
+func (w WeightRandom) Handler(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
+	return w.HandlerWithSnapshot(loadbalancer.PickContext{
+		Config:           c,
+		HealthyEndpoints: c.GetEndpoint(true),
+	}, policy)
+}
+
+func (WeightRandom) HandlerWithSnapshot(c loadbalancer.PickContext, _ model.LbPolicy) *model.Endpoint {
+	endpoints := c.HealthyEndpoints
 
 	if len(endpoints) == 0 {
 		return nil

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -19,12 +19,14 @@ package proxy
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -40,9 +42,19 @@ import (
 )
 
 const (
-	Kind                = constant.LLMProxyFilter
-	APIKeyPrefix        = "Bearer"
-	LLMUnhealthyKey     = "LLMUnhealthy"
+	Kind         = constant.LLMProxyFilter
+	APIKeyPrefix = "Bearer"
+	// maxCooldownStoreEntries bounds process-wide cooldown state under registry churn.
+	maxCooldownStoreEntries = 1024
+	cooldownStoreSweepAfter = time.Second
+	cooldownStoreSweepAt    = maxCooldownStoreEntries * 9 / 10
+	// LLMUnhealthyKey is kept for downstream compatibility.
+	//
+	// Deprecated: runtime LLM health is now tracked outside endpoint metadata.
+	LLMUnhealthyKey = "LLMUnhealthy"
+	// HealthyCheckTimeKey is kept for downstream compatibility.
+	//
+	// Deprecated: runtime LLM health is now tracked outside endpoint metadata.
 	HealthyCheckTimeKey = "HealthyCheckTime"
 	// Context key to pass attempt data from proxy to downstream filters
 	LLMUpstreamAttemptsKey    = "llm_upstream_attempts"
@@ -69,8 +81,9 @@ type (
 
 	// FilterFactory creates filter instances.
 	FilterFactory struct {
-		cfg    *Config
-		client http.Client
+		cfg       *Config
+		client    http.Client
+		cooldowns *cooldownStore
 	}
 
 	// Filter is the processing entity for each request.
@@ -79,6 +92,7 @@ type (
 		scheme         string
 		strategy       *Strategy
 		clusterManager *server.ClusterManager
+		cooldowns      *cooldownStore
 	}
 
 	// Config describes the top-level configuration for the filter.
@@ -96,8 +110,31 @@ type (
 		filter         *Filter
 		clusterName    string
 		clusterManager *server.ClusterManager
+		cooldowns      *cooldownStore
+	}
+
+	cooldownKey struct {
+		clusterName     string
+		endpointID      string
+		endpointAddress string
+		credentialHash  string
+	}
+
+	cooldownStore struct {
+		mu                    sync.Mutex
+		lastFailureByEndpoint map[cooldownKey]cooldownEntry
+		lastSweep             time.Time
+	}
+
+	cooldownEntry struct {
+		lastFailure time.Time
+		ttl         time.Duration
 	}
 )
+
+// sharedCooldownStore keeps endpoint cooldowns process-wide so filter reloads
+// and multiple LLM proxy factories do not reset runtime failure state.
+var sharedCooldownStore = newCooldownStore()
 
 func getPreferredEndpointID(hc *contexthttp.HttpContext) string {
 	if hc == nil || hc.Params == nil {
@@ -156,6 +193,7 @@ func (factory *FilterFactory) PrepareFilterChain(_ *contexthttp.HttpContext, cha
 		scheme:         factory.cfg.Scheme,
 		strategy:       &Strategy{},
 		clusterManager: server.GetClusterManager(),
+		cooldowns:      factory.cooldownStore(),
 	}
 	chain.AppendDecodeFilters(f)
 	return nil
@@ -185,6 +223,7 @@ func (f *Filter) Decode(hc *contexthttp.HttpContext) filter.FilterStatus {
 		filter:         f,
 		clusterName:    rEntry.Cluster,
 		clusterManager: f.clusterManager,
+		cooldowns:      f.cooldowns,
 	}
 
 	// Delegate the complex execution logic to the strategy
@@ -282,37 +321,24 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 	// 1. Pick initial endpoint from the cluster based on load balancing.
 	endpoint := executor.clusterManager.PickEndpoint(executor.clusterName, executor.hc)
 	if preferred := getPreferredEndpointID(executor.hc); preferred != "" {
-		if target := executor.clusterManager.GetEndpointByID(executor.clusterName, preferred); target != nil {
+		if target := executor.clusterManager.GetHealthyEndpointByID(executor.clusterName, preferred); target != nil {
 			endpoint = target
 		}
 	}
 
 	// 2. The main fallback loop. It continues as long as we have a valid endpoint to try.
 	for endpoint != nil {
-		if endpoint.Metadata == nil {
-			endpoint.Metadata = make(map[string]string)
-		}
 		if executor.hc.Params == nil {
 			executor.hc.Params = make(map[string]any)
 		}
 
 		logger.Debugf("[dubbo-go-pixiu] client attempting endpoint [%s: %v]", endpoint.ID, endpoint.Address.GetAddress())
 
-		// 3. Check the health of current endpoint,
-		if unhealthy, ok := endpoint.Metadata[LLMUnhealthyKey]; ok && unhealthy == "true" {
-			// check the health cooldown time
-			if t, ok := endpoint.Metadata[HealthyCheckTimeKey]; ok {
-				lt, err := time.Parse(time.RFC3339, t)
-				if err == nil && time.Since(lt) < time.Millisecond*time.Duration(endpoint.LLMMeta.HealthCheckInterval) {
-					logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] is still in unhealthy cooldown period. Skipping to next endpoint.", endpoint.ID, endpoint.Address.GetAddress())
-					endpoint = getNextFallbackEndpoint(endpoint, executor)
-					continue
-				}
-				// The Cooldown period has passed, ready for a new attempt
-				delete(endpoint.Metadata, LLMUnhealthyKey)
-				delete(endpoint.Metadata, HealthyCheckTimeKey)
-				logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] cooldown period passed. Retrying this endpoint.", endpoint.ID, endpoint.Address.GetAddress())
-			}
+		// 3. Check the runtime health cooldown of current endpoint.
+		if executor.endpointInCooldown(endpoint) {
+			logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] is still in unhealthy cooldown period. Skipping to next endpoint.", endpoint.ID, endpoint.Address.GetAddress())
+			endpoint = getNextFallbackEndpoint(endpoint, executor)
+			continue
 		}
 
 		// 4. Dynamically load the retry policy for the current endpoint
@@ -373,8 +399,7 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 
 		// 6. If we are here, all retries for the current endpoint are exhausted.
 		// Get the next endpoint for fallback. The loop will terminate if it's nil.
-		endpoint.Metadata[LLMUnhealthyKey] = "true"
-		endpoint.Metadata[HealthyCheckTimeKey] = time.Now().Format(time.RFC3339)
+		executor.markEndpointCooldown(endpoint)
 		endpoint = getNextFallbackEndpoint(endpoint, executor)
 	}
 
@@ -388,6 +413,192 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 		problems = append(problems, errors.New("all retries and fallbacks failed without a definitive error or response"))
 	}
 	return resp, errors.Join(problems...)
+}
+
+func (executor *RequestExecutor) endpointInCooldown(endpoint *model.Endpoint) bool {
+	store := executor.cooldownStore()
+	if store == nil || endpoint == nil {
+		return false
+	}
+
+	lastFailure, ttl, ok := store.lastFailureWithCurrentTTL(executor.clusterName, endpoint)
+	if !ok {
+		return false
+	}
+
+	if time.Since(lastFailure) < ttl {
+		return true
+	}
+
+	if store.deleteLastFailureIfMatches(executor.clusterName, endpoint, lastFailure) {
+		logger.Debugf("[dubbo-go-pixiu] endpoint [%s: %v] cooldown period passed. Retrying this endpoint.", endpoint.ID, endpoint.Address.GetAddress())
+	}
+	return false
+}
+
+func (executor *RequestExecutor) markEndpointCooldown(endpoint *model.Endpoint) {
+	store := executor.cooldownStore()
+	if store == nil || endpoint == nil {
+		return
+	}
+	store.markFailure(executor.clusterName, endpoint, time.Now())
+}
+
+func (executor *RequestExecutor) cooldownStore() *cooldownStore {
+	if executor == nil {
+		return nil
+	}
+	if executor.cooldowns != nil {
+		return executor.cooldowns
+	}
+	if executor.filter != nil && executor.filter.cooldowns != nil {
+		return executor.filter.cooldowns
+	}
+	return sharedCooldownStore
+}
+
+func (factory *FilterFactory) cooldownStore() *cooldownStore {
+	if factory == nil || factory.cooldowns == nil {
+		return sharedCooldownStore
+	}
+	return factory.cooldowns
+}
+
+func newCooldownStore() *cooldownStore {
+	return &cooldownStore{
+		lastFailureByEndpoint: map[cooldownKey]cooldownEntry{},
+	}
+}
+
+func (s *cooldownStore) lastFailure(clusterName string, endpoint *model.Endpoint) (time.Time, bool) {
+	lastFailure, _, ok := s.lastFailureWithCurrentTTL(clusterName, endpoint)
+	return lastFailure, ok
+}
+
+func (s *cooldownStore) lastFailureWithCurrentTTL(clusterName string, endpoint *model.Endpoint) (time.Time, time.Duration, bool) {
+	if s == nil || endpoint == nil {
+		return time.Time{}, 0, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := newCooldownKey(clusterName, endpoint)
+	now := time.Now()
+	s.sweepExpiredIfNeededLocked(now, key)
+	entry, ok := s.lastFailureByEndpoint[key]
+	if !ok {
+		return time.Time{}, 0, false
+	}
+	currentTTL := endpointCooldownInterval(endpoint)
+	if entry.ttl != currentTTL {
+		entry.ttl = currentTTL
+		s.lastFailureByEndpoint[key] = entry
+	}
+	return entry.lastFailure, entry.ttl, true
+}
+
+func (s *cooldownStore) markFailure(clusterName string, endpoint *model.Endpoint, lastFailure time.Time) {
+	if s == nil || endpoint == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := newCooldownKey(clusterName, endpoint)
+	s.sweepExpiredIfNeededLocked(time.Now(), key)
+	if _, ok := s.lastFailureByEndpoint[key]; !ok {
+		s.evictOldestIfFullLocked(key)
+	}
+	s.lastFailureByEndpoint[key] = cooldownEntry{
+		lastFailure: lastFailure,
+		ttl:         endpointCooldownInterval(endpoint),
+	}
+}
+
+func (s *cooldownStore) deleteLastFailureIfMatches(clusterName string, endpoint *model.Endpoint, expected time.Time) bool {
+	if s == nil || endpoint == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := newCooldownKey(clusterName, endpoint)
+	current, ok := s.lastFailureByEndpoint[key]
+	if !ok || current.lastFailure != expected {
+		return false
+	}
+	delete(s.lastFailureByEndpoint, key)
+	return true
+}
+
+func (s *cooldownStore) sweepExpiredIfNeededLocked(now time.Time, current cooldownKey) {
+	if len(s.lastFailureByEndpoint) < cooldownStoreSweepAt &&
+		!s.lastSweep.IsZero() &&
+		now.Sub(s.lastSweep) < cooldownStoreSweepAfter {
+		return
+	}
+	s.lastSweep = now
+	s.sweepExpiredExceptLocked(now, current)
+}
+
+func (s *cooldownStore) sweepExpiredExceptLocked(now time.Time, current cooldownKey) {
+	for key, entry := range s.lastFailureByEndpoint {
+		if key == current {
+			continue
+		}
+		if now.Sub(entry.lastFailure) >= entry.ttl {
+			delete(s.lastFailureByEndpoint, key)
+		}
+	}
+}
+
+func (s *cooldownStore) evictOldestIfFullLocked(current cooldownKey) {
+	if len(s.lastFailureByEndpoint) < maxCooldownStoreEntries {
+		return
+	}
+
+	var (
+		oldestKey   cooldownKey
+		oldestEntry cooldownEntry
+		found       bool
+	)
+	for key, entry := range s.lastFailureByEndpoint {
+		if key == current {
+			continue
+		}
+		if !found || entry.lastFailure.Before(oldestEntry.lastFailure) {
+			oldestKey = key
+			oldestEntry = entry
+			found = true
+		}
+	}
+	if found {
+		delete(s.lastFailureByEndpoint, oldestKey)
+	}
+}
+
+func newCooldownKey(clusterName string, endpoint *model.Endpoint) cooldownKey {
+	if endpoint == nil {
+		return cooldownKey{clusterName: clusterName}
+	}
+	return cooldownKey{
+		clusterName:     clusterName,
+		endpointID:      endpoint.ID,
+		endpointAddress: endpoint.Address.GetAddress(),
+		credentialHash:  endpointCredentialHash(endpoint),
+	}
+}
+
+func endpointCredentialHash(endpoint *model.Endpoint) string {
+	if endpoint == nil || endpoint.LLMMeta == nil || endpoint.LLMMeta.APIKey == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(endpoint.LLMMeta.APIKey))
+	return fmt.Sprintf("%x", sum)
+}
+
+func endpointCooldownInterval(endpoint *model.Endpoint) time.Duration {
+	if endpoint == nil || endpoint.LLMMeta == nil {
+		return 0
+	}
+	return time.Millisecond * time.Duration(endpoint.LLMMeta.HealthCheckInterval)
 }
 
 // getNextFallbackEndpoint checks if fallback is enabled and returns the next endpoint.

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -45,9 +45,10 @@ const (
 	Kind         = constant.LLMProxyFilter
 	APIKeyPrefix = "Bearer"
 	// maxCooldownStoreEntries bounds process-wide cooldown state under registry churn.
-	maxCooldownStoreEntries = 1024
-	cooldownStoreSweepAfter = time.Second
-	cooldownStoreSweepAt    = maxCooldownStoreEntries * 9 / 10
+	maxCooldownStoreEntries             = 1024
+	cooldownStoreSweepLoadFactorPercent = 90
+	cooldownStoreSweepAfter             = time.Second
+	cooldownStoreSweepAt                = maxCooldownStoreEntries * cooldownStoreSweepLoadFactorPercent / 100
 	// LLMUnhealthyKey is kept for downstream compatibility.
 	//
 	// Deprecated: runtime LLM health is now tracked outside endpoint metadata.

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -471,11 +471,6 @@ func newCooldownStore() *cooldownStore {
 	}
 }
 
-func (s *cooldownStore) lastFailure(clusterName string, endpoint *model.Endpoint) (time.Time, bool) {
-	lastFailure, _, ok := s.lastFailureWithCurrentTTL(clusterName, endpoint)
-	return lastFailure, ok
-}
-
 func (s *cooldownStore) lastFailureWithCurrentTTL(clusterName string, endpoint *model.Endpoint) (time.Time, time.Duration, bool) {
 	if s == nil || endpoint == nil {
 		return time.Time{}, 0, false
@@ -595,6 +590,15 @@ func endpointCredentialHash(endpoint *model.Endpoint) string {
 	return fmt.Sprintf("%x", sum)
 }
 
+// endpointCooldownInterval returns the per-endpoint cooldown TTL derived from
+// LLMMeta.HealthCheckInterval in milliseconds.
+//
+// Returning 0 is meaningful: an endpoint whose HealthCheckInterval is unset or
+// explicitly 0 is recorded on failure, but endpointInCooldown always reports
+// false because time.Since(lastFailure) < 0 is always false. The sweep loop
+// then evicts the entry on its next pass. This is "cooldown disabled"
+// semantics, not a bug; set HealthCheckInterval to a positive value to enable
+// cooldown.
 func endpointCooldownInterval(endpoint *model.Endpoint) time.Duration {
 	if endpoint == nil || endpoint.LLMMeta == nil {
 		return 0

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -137,7 +137,7 @@ func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(
 
 	for _, endpoint := range endpoints {
 		assert.Equal(t, map[string]string{"static": "value"}, endpoint.Metadata)
-		lastFailure, ok := filter.cooldowns.lastFailure(clusterName, endpoint)
+		lastFailure, _, ok := filter.cooldowns.lastFailureWithCurrentTTL(clusterName, endpoint)
 		assert.True(t, ok)
 		assert.False(t, lastFailure.IsZero())
 	}
@@ -155,7 +155,7 @@ func TestRequestExecutorEndpointInCooldownClearsExpiredCooldownFromProxyStore(t 
 
 	assert.False(t, executor.endpointInCooldown(endpoint))
 
-	_, ok := store.lastFailure(clusterName, endpoint)
+	_, _, ok := store.lastFailureWithCurrentTTL(clusterName, endpoint)
 	assert.False(t, ok)
 }
 
@@ -170,7 +170,7 @@ func TestRequestExecutorMarkEndpointCooldownStoresCooldownInProxyStore(t *testin
 
 	executor.markEndpointCooldown(endpoint)
 
-	lastFailure, ok := store.lastFailure(clusterName, endpoint)
+	lastFailure, _, ok := store.lastFailureWithCurrentTTL(clusterName, endpoint)
 	assert.True(t, ok)
 	assert.False(t, lastFailure.IsZero())
 }
@@ -189,7 +189,7 @@ func TestRequestExecutorCooldownIsIsolatedByEndpointAddress(t *testing.T) {
 
 	assert.True(t, executor.endpointInCooldown(oldEndpoint))
 	assert.False(t, executor.endpointInCooldown(movedEndpoint))
-	_, ok := store.lastFailure(clusterName, movedEndpoint)
+	_, _, ok := store.lastFailureWithCurrentTTL(clusterName, movedEndpoint)
 	assert.False(t, ok)
 }
 
@@ -207,7 +207,7 @@ func TestRequestExecutorCooldownIsIsolatedByEndpointCredential(t *testing.T) {
 
 	assert.True(t, executor.endpointInCooldown(oldEndpoint))
 	assert.False(t, executor.endpointInCooldown(replacement))
-	_, ok := store.lastFailure(clusterName, replacement)
+	_, _, ok := store.lastFailureWithCurrentTTL(clusterName, replacement)
 	assert.False(t, ok)
 }
 
@@ -254,7 +254,7 @@ func TestCooldownStoreLazySweepKeepsEntryAfterEndpointIntervalExtends(t *testing
 	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-50*time.Millisecond))
 
 	assert.True(t, executor.endpointInCooldown(replacement))
-	_, _ = store.lastFailure(clusterName, activeEndpoint)
+	_, _, _ = store.lastFailureWithCurrentTTL(clusterName, activeEndpoint)
 	store.mu.Lock()
 	_, ok := store.lastFailureByEndpoint[newCooldownKey(clusterName, replacement)]
 	store.mu.Unlock()
@@ -286,7 +286,7 @@ func TestCooldownStoreLazySweepRemovesExpiredChurnedEndpointEntry(t *testing.T) 
 	store.mu.Lock()
 	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
 	store.mu.Unlock()
-	store.lastFailure(clusterName, activeEndpoint)
+	store.lastFailureWithCurrentTTL(clusterName, activeEndpoint)
 
 	store.mu.Lock()
 	_, oldExistsAfterUnrelatedSweep := store.lastFailureByEndpoint[newCooldownKey(clusterName, oldEndpoint)]
@@ -303,7 +303,7 @@ func TestCooldownStoreLazySweepRemovesExpiredEndpointFromDifferentCluster(t *tes
 	store.mu.Lock()
 	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
 	store.mu.Unlock()
-	store.lastFailure("active-cluster", activeEndpoint)
+	store.lastFailureWithCurrentTTL("active-cluster", activeEndpoint)
 
 	store.mu.Lock()
 	_, expiredExists := store.lastFailureByEndpoint[newCooldownKey("old-cluster", expiredEndpoint)]

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin" // Register RoundRobin for LLM proxy cluster tests.
+	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/retry/noretry"           // Register NoRetry for LLM proxy retry tests.
+	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+	"github.com/apache/dubbo-go-pixiu/pkg/server"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestFilterFactoriesShareRuntimeCooldownStore(t *testing.T) {
+	plugin := &Plugin{}
+	firstFactory, err := plugin.CreateFilterFactory()
+	if !assert.NoError(t, err) {
+		return
+	}
+	secondFactory, err := plugin.CreateFilterFactory()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	firstStore := firstFactory.(*FilterFactory).cooldownStore()
+	secondStore := secondFactory.(*FilterFactory).cooldownStore()
+
+	assert.NotNil(t, firstStore)
+	assert.Same(t, firstStore, secondStore)
+
+	clusterName := "llm-shared-runtime-cooldown"
+	endpoint := testLLMEndpoint("ep-1", 18089)
+	firstExecutor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   firstStore,
+	}
+	secondExecutor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   secondStore,
+	}
+
+	firstExecutor.markEndpointCooldown(endpoint)
+
+	assert.True(t, secondExecutor.endpointInCooldown(endpoint))
+}
+
+func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(t *testing.T) {
+	clusterName := "llm-runtime-cooldown"
+	endpoints := []*model.Endpoint{
+		testLLMEndpoint("ep-1", 18080),
+		testLLMEndpoint("ep-2", 18081),
+	}
+	clusterConfig := &model.ClusterConfig{
+		Name:      clusterName,
+		LbStr:     model.LoadBalancerRoundRobin,
+		Endpoints: endpoints,
+	}
+	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: []*model.ClusterConfig{clusterConfig},
+		},
+	})
+	filter := &Filter{
+		client: http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("upstream unavailable")
+			}),
+		},
+		scheme:    "http",
+		cooldowns: newCooldownStore(),
+	}
+	strategy := &Strategy{}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 50; j++ {
+				req, err := http.NewRequest(http.MethodPost, "http://example.com/v1/chat/completions", http.NoBody)
+				if err != nil {
+					t.Errorf("new request: %v", err)
+					return
+				}
+				hc := &contexthttp.HttpContext{
+					Request: req,
+					Params:  map[string]any{},
+				}
+				_, _ = strategy.Execute(&RequestExecutor{
+					hc:             hc,
+					filter:         filter,
+					clusterName:    clusterName,
+					clusterManager: clusterManager,
+					cooldowns:      filter.cooldowns,
+				})
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	for _, endpoint := range endpoints {
+		assert.Equal(t, map[string]string{"static": "value"}, endpoint.Metadata)
+		lastFailure, ok := filter.cooldowns.lastFailure(clusterName, endpoint)
+		assert.True(t, ok)
+		assert.False(t, lastFailure.IsZero())
+	}
+}
+
+func TestRequestExecutorEndpointInCooldownClearsExpiredCooldownFromProxyStore(t *testing.T) {
+	clusterName := "llm-expired-cooldown"
+	endpoint := testLLMEndpoint("ep-1", 18082)
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	store.markFailure(clusterName, endpoint, time.Now().Add(-time.Hour))
+
+	assert.False(t, executor.endpointInCooldown(endpoint))
+
+	_, ok := store.lastFailure(clusterName, endpoint)
+	assert.False(t, ok)
+}
+
+func TestRequestExecutorMarkEndpointCooldownStoresCooldownInProxyStore(t *testing.T) {
+	clusterName := "llm-mark-cooldown"
+	endpoint := testLLMEndpoint("ep-1", 18083)
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+
+	executor.markEndpointCooldown(endpoint)
+
+	lastFailure, ok := store.lastFailure(clusterName, endpoint)
+	assert.True(t, ok)
+	assert.False(t, lastFailure.IsZero())
+}
+
+func TestRequestExecutorCooldownIsIsolatedByEndpointAddress(t *testing.T) {
+	clusterName := "llm-address-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18084)
+	movedEndpoint := testLLMEndpoint("ep-1", 18085)
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+
+	executor.markEndpointCooldown(oldEndpoint)
+
+	assert.True(t, executor.endpointInCooldown(oldEndpoint))
+	assert.False(t, executor.endpointInCooldown(movedEndpoint))
+	_, ok := store.lastFailure(clusterName, movedEndpoint)
+	assert.False(t, ok)
+}
+
+func TestRequestExecutorCooldownIsIsolatedByEndpointCredential(t *testing.T) {
+	clusterName := "llm-credential-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18088)
+	replacement := testLLMEndpoint("ep-1", 18088)
+	replacement.LLMMeta.APIKey = "fixed-key"
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	executor.markEndpointCooldown(oldEndpoint)
+
+	assert.True(t, executor.endpointInCooldown(oldEndpoint))
+	assert.False(t, executor.endpointInCooldown(replacement))
+	_, ok := store.lastFailure(clusterName, replacement)
+	assert.False(t, ok)
+}
+
+func TestRequestExecutorCooldownSurvivesNonIdentityLLMConfigChanges(t *testing.T) {
+	clusterName := "llm-policy-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18089)
+	oldEndpoint.LLMMeta.APIKey = "same-key"
+	oldEndpoint.LLMMeta.HealthCheckInterval = 10
+	replacement := testLLMEndpoint("ep-1", 18089)
+	replacement.Name = "renamed-endpoint"
+	replacement.Metadata["dynamic"] = "value"
+	replacement.LLMMeta.APIKey = "same-key"
+	replacement.LLMMeta.HealthCheckInterval = 60000
+	replacement.LLMMeta.RetryPolicy = model.RetryPolicy{
+		Name: model.RetryerCountBased,
+		Config: map[string]any{
+			"attempts": 2,
+		},
+	}
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-50*time.Millisecond))
+
+	assert.True(t, executor.endpointInCooldown(replacement))
+}
+
+func TestCooldownStoreLazySweepKeepsEntryAfterEndpointIntervalExtends(t *testing.T) {
+	clusterName := "llm-extended-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18090)
+	oldEndpoint.LLMMeta.APIKey = "same-key"
+	oldEndpoint.LLMMeta.HealthCheckInterval = 10
+	replacement := testLLMEndpoint("ep-1", 18090)
+	replacement.LLMMeta.APIKey = "same-key"
+	replacement.LLMMeta.HealthCheckInterval = 60000
+	activeEndpoint := testLLMEndpoint("ep-2", 18091)
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-50*time.Millisecond))
+
+	assert.True(t, executor.endpointInCooldown(replacement))
+	_, _ = store.lastFailure(clusterName, activeEndpoint)
+	store.mu.Lock()
+	_, ok := store.lastFailureByEndpoint[newCooldownKey(clusterName, replacement)]
+	store.mu.Unlock()
+	assert.True(t, ok)
+}
+
+func TestLegacyEndpointHealthMetadataKeysRemainExported(t *testing.T) {
+	assert.Equal(t, "LLMUnhealthy", LLMUnhealthyKey)
+	assert.Equal(t, "HealthyCheckTime", HealthyCheckTimeKey)
+}
+
+func TestCooldownStoreLazySweepRemovesExpiredChurnedEndpointEntry(t *testing.T) {
+	clusterName := "llm-churn-cooldown"
+	oldEndpoint := testLLMEndpoint("ep-1", 18084)
+	movedEndpoint := testLLMEndpoint("ep-1", 18085)
+	activeEndpoint := testLLMEndpoint("ep-2", 18086)
+	store := newCooldownStore()
+
+	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-time.Hour))
+	store.markFailure(clusterName, movedEndpoint, time.Now())
+
+	store.mu.Lock()
+	_, oldExistsAfterMove := store.lastFailureByEndpoint[newCooldownKey(clusterName, oldEndpoint)]
+	_, movedExists := store.lastFailureByEndpoint[newCooldownKey(clusterName, movedEndpoint)]
+	store.mu.Unlock()
+	assert.True(t, oldExistsAfterMove)
+	assert.True(t, movedExists)
+
+	store.mu.Lock()
+	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
+	store.mu.Unlock()
+	store.lastFailure(clusterName, activeEndpoint)
+
+	store.mu.Lock()
+	_, oldExistsAfterUnrelatedSweep := store.lastFailureByEndpoint[newCooldownKey(clusterName, oldEndpoint)]
+	store.mu.Unlock()
+	assert.False(t, oldExistsAfterUnrelatedSweep)
+}
+
+func TestCooldownStoreLazySweepRemovesExpiredEndpointFromDifferentCluster(t *testing.T) {
+	expiredEndpoint := testLLMEndpoint("ep-1", 18092)
+	activeEndpoint := testLLMEndpoint("ep-2", 18093)
+	store := newCooldownStore()
+
+	store.markFailure("old-cluster", expiredEndpoint, time.Now().Add(-time.Hour))
+	store.mu.Lock()
+	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
+	store.mu.Unlock()
+	store.lastFailure("active-cluster", activeEndpoint)
+
+	store.mu.Lock()
+	_, expiredExists := store.lastFailureByEndpoint[newCooldownKey("old-cluster", expiredEndpoint)]
+	store.mu.Unlock()
+	assert.False(t, expiredExists)
+}
+
+func TestCooldownStoreEvictsOldestEntryWhenCapacityExceeded(t *testing.T) {
+	store := newCooldownStore()
+	now := time.Now()
+	oldestEndpoint := testLLMEndpoint("ep-0", 19000)
+
+	for i := 0; i < maxCooldownStoreEntries; i++ {
+		endpoint := testLLMEndpoint(fmt.Sprintf("ep-%d", i), 19000+i)
+		if i == 0 {
+			oldestEndpoint = endpoint
+		}
+		store.markFailure("capacity-cluster", endpoint, now.Add(time.Duration(i)*time.Millisecond))
+	}
+
+	newestEndpoint := testLLMEndpoint("ep-new", 21000)
+	store.markFailure("capacity-cluster", newestEndpoint, now.Add(time.Hour))
+
+	store.mu.Lock()
+	_, oldestExists := store.lastFailureByEndpoint[newCooldownKey("capacity-cluster", oldestEndpoint)]
+	_, newestExists := store.lastFailureByEndpoint[newCooldownKey("capacity-cluster", newestEndpoint)]
+	entryCount := len(store.lastFailureByEndpoint)
+	store.mu.Unlock()
+
+	assert.False(t, oldestExists)
+	assert.True(t, newestExists)
+	assert.Equal(t, maxCooldownStoreEntries, entryCount)
+}
+
+func TestStrategyExecuteIgnoresUnhealthyPreferredEndpoint(t *testing.T) {
+	clusterName := "llm-preferred-health"
+	healthyEndpoint := testLLMEndpoint("ep-1", 18086)
+	preferredEndpoint := testLLMEndpoint("ep-2", 18087)
+	preferredEndpoint.UnHealthy = true
+	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: []*model.ClusterConfig{{
+				Name:      clusterName,
+				LbStr:     model.LoadBalancerRoundRobin,
+				Endpoints: []*model.Endpoint{healthyEndpoint, preferredEndpoint},
+			}},
+		},
+	})
+
+	var attemptedHost string
+	filter := &Filter{
+		client: http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				attemptedHost = req.URL.Host
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Body:       http.NoBody,
+				}, nil
+			}),
+		},
+		scheme:    "http",
+		cooldowns: newCooldownStore(),
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/v1/chat/completions", http.NoBody)
+	if !assert.NoError(t, err) {
+		return
+	}
+	hc := &contexthttp.HttpContext{
+		Request: req,
+		Params: map[string]any{
+			llmPreferredEndpointIDKey: preferredEndpoint.ID,
+		},
+	}
+
+	resp, err := (&Strategy{}).Execute(&RequestExecutor{
+		hc:             hc,
+		filter:         filter,
+		clusterName:    clusterName,
+		clusterManager: clusterManager,
+		cooldowns:      filter.cooldowns,
+	})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, resp) {
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	assert.Equal(t, healthyEndpoint.Address.GetAddress(), attemptedHost)
+}
+
+func testLLMEndpoint(id string, port int) *model.Endpoint {
+	return &model.Endpoint{
+		ID:       id,
+		Name:     "endpoint-" + id,
+		Metadata: map[string]string{"static": "value"},
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    port,
+		},
+		LLMMeta: &model.LLMMeta{
+			RetryPolicy: model.RetryPolicy{
+				Name: model.RetryerNoRetry,
+			},
+			Fallback:            true,
+			HealthCheckInterval: 60000,
+		},
+	}
+}

--- a/pkg/model/base.go
+++ b/pkg/model/base.go
@@ -174,6 +174,21 @@ type (
 	}
 )
 
+// GetAddress returns the string form used as a map key by health-check
+// state, the cluster snapshot's addressByID, and external observability
+// surfaces. Domain-mode addresses (Domains is non-empty) format as
+// Domains[0]; bare-IP addresses format as "ip:port".
+//
+// Note: GetAddress() is NOT the string projection of Equal(). It is
+// possible for two SocketAddresses with different identity (one
+// domain-mode, one IP-mode) to format to the same string and still be
+// !Equal — for example, SocketAddress{Domains: ["1.2.3.4:5"]} and
+// SocketAddress{Address: "1.2.3.4", Port: 5} both produce "1.2.3.4:5"
+// but compare unequal. Callers that need identity comparison must use
+// Equal; callers that need a key for address-keyed runtime state (e.g.
+// healthcheck deduplication by network endpoint) must use GetAddress
+// consistently. Mixing the two within a single subsystem will produce
+// the equivalence-class skew described in the cluster snapshot docs.
 func (a SocketAddress) GetAddress() string {
 	if len(a.Domains) > 0 {
 		return a.Domains[0]
@@ -181,11 +196,16 @@ func (a SocketAddress) GetAddress() string {
 	return fmt.Sprintf("%s:%v", a.Address, a.Port)
 }
 
-// Equal reports whether two SocketAddresses refer to the same upstream identity
-// without allocating the formatted "address:port" string. Domain-mode addresses
-// compare on Domains[0]; bare-IP addresses compare on Address+Port. Mixed-mode
-// pairs (one domain, one IP+port) are reported unequal because they describe
+// Equal reports whether two SocketAddresses refer to the same upstream
+// identity without allocating the formatted "address:port" string.
+// Domain-mode addresses (Domains non-empty) compare on Domains[0];
+// bare-IP addresses compare on Address+Port. Mixed-mode pairs (one
+// domain, one IP+port) are reported unequal because they describe
 // different upstreams even when their formatted forms collide.
+//
+// Equal is NOT a == over GetAddress(). See GetAddress godoc for the
+// rationale and known divergence cases. Subsystems should pick one of
+// {Equal, GetAddress} as their identity oracle and stick with it.
 func (a SocketAddress) Equal(b SocketAddress) bool {
 	aHasDomain := len(a.Domains) > 0
 	bHasDomain := len(b.Domains) > 0

--- a/pkg/model/base.go
+++ b/pkg/model/base.go
@@ -180,3 +180,20 @@ func (a SocketAddress) GetAddress() string {
 	}
 	return fmt.Sprintf("%s:%v", a.Address, a.Port)
 }
+
+// Equal reports whether two SocketAddresses refer to the same upstream identity
+// without allocating the formatted "address:port" string. Domain-mode addresses
+// compare on Domains[0]; bare-IP addresses compare on Address+Port. Mixed-mode
+// pairs (one domain, one IP+port) are reported unequal because they describe
+// different upstreams even when their formatted forms collide.
+func (a SocketAddress) Equal(b SocketAddress) bool {
+	aHasDomain := len(a.Domains) > 0
+	bHasDomain := len(b.Domains) > 0
+	if aHasDomain != bHasDomain {
+		return false
+	}
+	if aHasDomain {
+		return a.Domains[0] == b.Domains[0]
+	}
+	return a.Address == b.Address && a.Port == b.Port
+}

--- a/pkg/model/base_test.go
+++ b/pkg/model/base_test.go
@@ -89,6 +89,32 @@ func TestSocketAddressEqual(t *testing.T) {
 			want:              false,
 			matchesGetAddress: true,
 		},
+		// Counterexamples: Equal != (GetAddress == GetAddress). The
+		// matchesGetAddress=false flag tells the assertion below to
+		// not enforce string-projection agreement and instead encode
+		// the divergence into the contract.
+		{
+			name: "domain literal collides with ip+port string but Equal is false",
+			// "1.2.3.4:5" as a domain entry literally formats to the
+			// same string as the IP+port form. They describe different
+			// upstreams (domain mode vs IP+port mode) so Equal returns
+			// false even though GetAddress strings match.
+			a:                 SocketAddress{Domains: []string{"1.2.3.4:5"}},
+			b:                 SocketAddress{Address: "1.2.3.4", Port: 5},
+			want:              false,
+			matchesGetAddress: false,
+		},
+		{
+			name: "domain entry shaped like ip alone collides with zero-port ip form",
+			// "1.2.3.4" as a domain entry formats to "1.2.3.4"; IP-only
+			// SocketAddress{Address: "1.2.3.4", Port: 0} formats to
+			// "1.2.3.4:0". Both string forms differ — picked another
+			// pair where the strings actually collide.
+			a:                 SocketAddress{Domains: []string{":0"}},
+			b:                 SocketAddress{}, // Address="", Port=0 -> ":0"
+			want:              false,
+			matchesGetAddress: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -101,6 +127,12 @@ func TestSocketAddressEqual(t *testing.T) {
 			if tc.matchesGetAddress {
 				assert.Equal(t, tc.a.GetAddress() == tc.b.GetAddress(), got,
 					"Equal must agree with GetAddress() comparison for case %q", tc.name)
+			} else {
+				// Counterexample cases: GetAddress strings match yet
+				// Equal is false. Encoded as part of the contract — see
+				// godoc on Equal / GetAddress.
+				assert.NotEqual(t, tc.a.GetAddress() == tc.b.GetAddress(), got,
+					"counterexample %q: Equal must diverge from GetAddress here", tc.name)
 			}
 		})
 	}

--- a/pkg/model/base_test.go
+++ b/pkg/model/base_test.go
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSocketAddressEqual(t *testing.T) {
+	tests := []struct {
+		name              string
+		a                 SocketAddress
+		b                 SocketAddress
+		want              bool
+		matchesGetAddress bool
+	}{
+		{
+			name:              "both zero",
+			a:                 SocketAddress{},
+			b:                 SocketAddress{},
+			want:              true,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "ip and port equal",
+			a:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			b:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			want:              true,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "same ip different port",
+			a:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			b:                 SocketAddress{Address: "127.0.0.1", Port: 8081},
+			want:              false,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "same single domain",
+			a:                 SocketAddress{Domains: []string{"svc.example.com"}},
+			b:                 SocketAddress{Domains: []string{"svc.example.com"}},
+			want:              true,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "different domains",
+			a:                 SocketAddress{Domains: []string{"svc.a.example.com"}},
+			b:                 SocketAddress{Domains: []string{"svc.b.example.com"}},
+			want:              false,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "one has domain other has ip port",
+			a:                 SocketAddress{Domains: []string{"svc.example.com"}},
+			b:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			want:              false,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "both have single empty domain",
+			a:                 SocketAddress{Domains: []string{""}},
+			b:                 SocketAddress{Domains: []string{""}},
+			want:              true,
+			matchesGetAddress: true,
+		},
+		{
+			name:              "ipv4 vs ipv6 formatting",
+			a:                 SocketAddress{Address: "127.0.0.1", Port: 8080},
+			b:                 SocketAddress{Address: "::1", Port: 8080},
+			want:              false,
+			matchesGetAddress: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.a.Equal(tc.b)
+			assert.Equal(t, tc.want, got)
+
+			assert.Equal(t, got, tc.b.Equal(tc.a))
+
+			if tc.matchesGetAddress {
+				assert.Equal(t, tc.a.GetAddress() == tc.b.GetAddress(), got,
+					"Equal must agree with GetAddress() comparison for case %q", tc.name)
+			}
+		})
+	}
+}

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -187,3 +187,96 @@ func endpointIDMaterial(clusterName string, endpoint *Endpoint) string {
 func endpointIDMaterialField(name, value string) string {
 	return fmt.Sprintf("%s:%d:%s\n", name, len(value), value)
 }
+
+// CloneEndpoints returns a deep copy of endpoints. Nil input is preserved.
+func CloneEndpoints(endpoints []*Endpoint) []*Endpoint {
+	if endpoints == nil {
+		return nil
+	}
+	cloned := make([]*Endpoint, len(endpoints))
+	for i, endpoint := range endpoints {
+		cloned[i] = CloneEndpoint(endpoint)
+	}
+	return cloned
+}
+
+// CloneEndpoint returns a deep copy of endpoint with independent Address,
+// Metadata, and LLMMeta. Returns nil for nil input. Snapshot consumers clone
+// before handing endpoints to callers so downstream mutation does not leak
+// back into the runtime snapshot.
+func CloneEndpoint(endpoint *Endpoint) *Endpoint {
+	if endpoint == nil {
+		return nil
+	}
+	cloned := *endpoint
+	cloned.Address = cloneSocketAddress(endpoint.Address)
+	cloned.Metadata = cloneMetadata(endpoint.Metadata)
+	cloned.LLMMeta = cloneLLMMeta(endpoint.LLMMeta)
+	return &cloned
+}
+
+func cloneSocketAddress(address SocketAddress) SocketAddress {
+	cloned := address
+	if address.Domains != nil {
+		cloned.Domains = append([]string(nil), address.Domains...)
+	}
+	return cloned
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	if metadata == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneLLMMeta(meta *LLMMeta) *LLMMeta {
+	if meta == nil {
+		return nil
+	}
+	cloned := *meta
+	cloned.RetryPolicy.Config = cloneAnyMap(meta.RetryPolicy.Config)
+	return &cloned
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(input))
+	for key, value := range input {
+		cloned[key] = cloneAnyValue(value)
+	}
+	return cloned
+}
+
+func cloneAnyValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneAnyValue(item)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), typed...)
+	case []int:
+		return append([]int(nil), typed...)
+	case []int64:
+		return append([]int64(nil), typed...)
+	case []float64:
+		return append([]float64(nil), typed...)
+	case []bool:
+		return append([]bool(nil), typed...)
+	case map[string]string:
+		return cloneMetadata(typed)
+	default:
+		return value
+	}
+}

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -204,6 +204,13 @@ func CloneEndpoints(endpoints []*Endpoint) []*Endpoint {
 // Metadata, and LLMMeta. Returns nil for nil input. Snapshot consumers clone
 // before handing endpoints to callers so downstream mutation does not leak
 // back into the runtime snapshot.
+//
+// Cost: O(depth) — LLMMeta.RetryPolicy.Config is recursively cloned via
+// cloneAnyMap, which allocates per nested map/slice. The request path
+// should clone at most once per pick (typically when returning the chosen
+// endpoint to the caller); avoid CloneEndpoint inside per-iteration loops
+// over a snapshot's endpoint slice. Use HealthyEndpointsForPick to scan
+// without cloning, then clone the single chosen endpoint.
 func CloneEndpoint(endpoint *Endpoint) *Endpoint {
 	if endpoint == nil {
 		return nil

--- a/pkg/model/lb.go
+++ b/pkg/model/lb.go
@@ -40,13 +40,43 @@ type LbPolicy interface {
 	GenerateHash() string
 }
 
-// LbConsistentHash supports consistent hash load balancing
-type LbConsistentHash interface {
+// LbConsistentHashView supports read-only consistent hash lookups.
+type LbConsistentHashView interface {
 	Hash(key string) uint32
-	Add(host string)
 	Get(key string) (string, error)
 	GetHash(key uint32) (string, error)
+}
+
+// LbConsistentHash supports mutable consistent hash load balancing.
+type LbConsistentHash interface {
+	LbConsistentHashView
+	Add(host string)
 	Remove(host string) bool
+}
+
+type readOnlyConsistentHash struct {
+	hash LbConsistentHash
+}
+
+func (h readOnlyConsistentHash) Hash(key string) uint32 {
+	return h.hash.Hash(key)
+}
+
+func (h readOnlyConsistentHash) Get(key string) (string, error) {
+	return h.hash.Get(key)
+}
+
+func (h readOnlyConsistentHash) GetHash(key uint32) (string, error) {
+	return h.hash.GetHash(key)
+}
+
+// ReadOnlyConsistentHash wraps an LbConsistentHash so callers on the request
+// path cannot mutate it. Returns nil if hash is nil.
+func ReadOnlyConsistentHash(hash LbConsistentHash) LbConsistentHashView {
+	if hash == nil {
+		return nil
+	}
+	return readOnlyConsistentHash{hash: hash}
 }
 
 type ConsistentHashInitFunc = func(ConsistentHash, []*Endpoint) LbConsistentHash

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -717,17 +717,17 @@ type setEndpointOutcome struct {
 //
 // Decision tree:
 //
-//  1. incoming.ID != "":
-//     a. ID matches an existing slot:
-//        - content equal → idempotent
-//        - content differs → replace slot in place (WARN logged by the
-//          caller when the replace actually changes the address)
-//     b. ID does not match → append with incoming.ID
-//  2. incoming.ID == "":
-//     a. Generated hash matches an existing slot:
-//        - content equal → idempotent (reuse matched slot's ID)
-//        - content differs → append with a -2/-3 suffix (WARN logged)
-//     b. No hash match → append with the generated hash as ID
+//	incoming.ID != "":
+//	   a. ID matches an existing slot:
+//	      content equal → idempotent
+//	      content differs → replace slot in place (WARN logged by the
+//	        caller when the replace actually changes the address)
+//	   b. ID does not match → append with incoming.ID
+//	incoming.ID == "":
+//	   a. Generated hash matches an existing slot:
+//	      content equal → idempotent (reuse matched slot's ID)
+//	      content differs → append with a -2/-3 suffix (WARN logged)
+//	   b. No hash match → append with the generated hash as ID
 //
 // The empty-ID branch keeps the suffix-append behavior because callers
 // without an explicit ID have not claimed instance identity — two

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -102,21 +102,28 @@ func (cm *ClusterManager) UpdateCluster(new *model.ClusterConfig) {
 // SetEndpoint registers or refreshes a single endpoint in the named
 // cluster, creating the cluster on first use.
 //
-// Dedup contract — follows the same collision rules as
-// assembleClusterEndpoints (ID match → hash match → suffix on content
-// mismatch) so static and dynamic registrations agree on outcomes, with
-// one deliberate divergence around Name documented below:
+// Dedup contract — explicit-ID and empty-ID paths diverge on purpose,
+// because the two callers have different intent:
 //
-//   - When the incoming endpoint matches an existing slot's routing
-//     identity AND its content (Address, Metadata, LLMMeta — see
-//     endpointContentEqualForSet), the call is idempotent. The existing
-//     slot stays in place; this is the safety net for replayed Nacos
-//     instance events.
-//   - When the incoming endpoint collides on explicit ID or generated hash
-//     with an existing slot but differs in content, the new endpoint is
-//     appended with a -2/-3/... suffix (a WARN is emitted, mirroring
-//     assembleClusterEndpoints).
-//   - Otherwise the endpoint is appended with its explicit or generated ID.
+//   - Explicit ID is the registry-update path (Nacos / SpringCloud /
+//     Dubbo / LLM adapters typically pass an instance ID; an adapter
+//     that omits ID falls through to the empty-ID branch below). The
+//     ID identifies the same instance across calls, so a second call
+//     with the same ID is "this instance changed". Action: replace the
+//     existing slot in place. Address-equal updates inherit the runtime
+//     health verdict from the prior snapshot — the incoming
+//     Endpoint.UnHealthy field is ignored on this path, so a
+//     known-unhealthy verdict survives a metadata flip until the
+//     healthcheck probes again. Address-changing updates stop the old
+//     address's healthcheck and start a fresh one against the new
+//     address; the new endpoint enters the snapshot at its declared
+//     health (default: healthy) until the first probe lands.
+//   - Empty ID is the ad-hoc-add path (no instance identity claimed).
+//     The deterministic hash is used as the slot key, and a hash
+//     collision with differing content is treated as a static-style
+//     duplicate (suffix -2/-3, both endpoints survive).
+//   - Same ID + same content is always idempotent — the safety net for
+//     replayed Nacos heartbeats.
 //
 // Name is intentionally NOT part of the content equality check (see
 // endpointContentEqualForSet's godoc). As a consequence, Name-only updates
@@ -620,63 +627,137 @@ func (s *ClusterStore) SetEndpoint(clusterName string, endpoint *model.Endpoint)
 		runtimeCluster = s.clustersMap[clusterName]
 	}
 
-	targetID, idempotent := resolveSetEndpointSlot(clusterName, endpoint, clusterConfig.Endpoints)
-	endpoint.ID = targetID
-	if idempotent {
+	outcome := resolveSetEndpointSlot(clusterName, endpoint, clusterConfig.Endpoints)
+	endpoint.ID = outcome.targetID
+
+	switch outcome.action {
+	case setEndpointIdempotent:
 		// A content-equal endpoint already occupies this slot, so the cluster
 		// state, consistent hash, and runtime health-check registration are
 		// already correct. Returning here keeps re-registration idempotent —
 		// the LLM/Nacos path can replay the same instance event without
 		// growing the endpoint slice.
 		return
+	case setEndpointReplace:
+		s.replaceEndpointAt(clusterConfig, runtimeCluster, outcome.replaceIdx, endpoint)
+	case setEndpointAppend:
+		clusterConfig.Endpoints = append(clusterConfig.Endpoints, endpoint)
+		s.prepareClusterConfig(clusterConfig)
+		runtimeCluster.RefreshEndpoints()
+		runtimeCluster.AddEndpoint(endpoint)
 	}
-
-	clusterConfig.Endpoints = append(clusterConfig.Endpoints, endpoint)
-	s.prepareClusterConfig(clusterConfig)
-	runtimeCluster.RefreshEndpoints()
-	runtimeCluster.AddEndpoint(endpoint)
 }
 
-// resolveSetEndpointSlot enforces the same dedup invariant as
-// assembleClusterEndpoints on the dynamic SetEndpoint path: an endpoint ID
-// identifies exactly one runtime endpoint at a time, and two registrations
-// that differ in routing-relevant content must both survive (suffixed -2,
-// -3, ...) instead of one silently overwriting the other.
+// replaceEndpointAt overwrites the cluster slot at idx with the incoming
+// endpoint and reconciles runtime state. Address-equal replacements
+// (metadata-only updates) skip the healthcheck restart so the existing
+// health verdict survives; address-changing replacements stop the old
+// address's checker and start a fresh one against the new address. The
+// snapshot CAS republish happens in RefreshEndpoints, and
+// endpointSnapshotHealth carries health forward by ID when the address
+// is unchanged (see pkg/cluster/cluster.go).
 //
-// It returns the ID the incoming endpoint should be stored under and whether
-// the call is an idempotent re-registration (an existing slot already has
-// matching content). When idempotent is false the caller should append a
-// fresh endpoint with the returned ID.
+// Removal order mirrors DeleteEndpoint (RemoveEndpoint before slice
+// mutation): healthcheck.hasOtherEndpointWithAddress iterates
+// clusterConfig.Endpoints during StopOne, so the slot must still hold
+// the old endpoint at that point. The operator-visibility WARN fires
+// only on address-changing replaces — metadata-only updates are a
+// routine registry path, not something worth tailing for.
+func (s *ClusterStore) replaceEndpointAt(
+	clusterConfig *model.ClusterConfig,
+	runtimeCluster *cluster.Cluster,
+	idx int,
+	endpoint *model.Endpoint,
+) {
+	old := clusterConfig.Endpoints[idx]
+	addressChanged := old.Address.GetAddress() != endpoint.Address.GetAddress()
+
+	if addressChanged {
+		runtimeCluster.RemoveEndpoint(old)
+		logSetEndpointOverwrite(clusterConfig.Name, endpoint.ID, old, endpoint)
+	}
+	clusterConfig.Endpoints[idx] = endpoint
+	s.prepareClusterConfig(clusterConfig)
+	runtimeCluster.RefreshEndpoints()
+	if addressChanged {
+		runtimeCluster.AddEndpoint(endpoint)
+	}
+}
+
+// setEndpointAction discriminates the three outcomes the SetEndpoint
+// dispatcher can take. See resolveSetEndpointSlot for the decision tree.
+type setEndpointAction int
+
+const (
+	// setEndpointIdempotent: an existing slot already holds content-equal
+	// state. SetEndpoint returns without touching config or runtime.
+	setEndpointIdempotent setEndpointAction = iota
+	// setEndpointReplace: an existing slot holds an endpoint with the same
+	// explicit ID but different content. SetEndpoint overwrites the slot
+	// at replaceIdx and reconciles healthcheck/snapshot accordingly.
+	setEndpointReplace
+	// setEndpointAppend: no existing slot collides, or an empty-ID hash
+	// collision occurred with differing content. SetEndpoint appends a
+	// new endpoint at targetID (suffixed when needed).
+	setEndpointAppend
+)
+
+// setEndpointOutcome captures the routing decision for one SetEndpoint call.
+// replaceIdx is only meaningful when action == setEndpointReplace.
+type setEndpointOutcome struct {
+	targetID   string
+	action     setEndpointAction
+	replaceIdx int
+}
+
+// resolveSetEndpointSlot decides how the dynamic SetEndpoint path should
+// reconcile an incoming endpoint against the cluster's existing slice.
+// The explicit-ID and empty-ID branches use different rules on purpose;
+// see the SetEndpoint godoc for the rationale.
 //
 // Decision tree:
 //
-//  1. Explicit ID matches an existing slot → idempotent iff content equal,
-//     otherwise return a -2/-3/... suffix off the explicit ID.
-//  2. Empty ID, hash matches an existing slot → idempotent iff content
-//     equal, otherwise return a suffix off the generated hash.
-//  3. No collision → use the explicit ID, or the generated hash for empty
-//     IDs.
+//  1. incoming.ID != "":
+//     a. ID matches an existing slot:
+//        - content equal → idempotent
+//        - content differs → replace slot in place (WARN logged by the
+//          caller when the replace actually changes the address)
+//     b. ID does not match → append with incoming.ID
+//  2. incoming.ID == "":
+//     a. Generated hash matches an existing slot:
+//        - content equal → idempotent (reuse matched slot's ID)
+//        - content differs → append with a -2/-3 suffix (WARN logged)
+//     b. No hash match → append with the generated hash as ID
 //
-// Share this helper across new entry points (admin API, xDS, gRPC
-// reflection, ...) to keep the dedup contract uniform; reimplementing the
-// branches in each caller is how the static and dynamic paths drifted
-// apart in the first place.
-func resolveSetEndpointSlot(clusterName string, incoming *model.Endpoint, existing []*model.Endpoint) (string, bool) {
-	if incoming == nil {
-		return "", false
-	}
+// The empty-ID branch keeps the suffix-append behavior because callers
+// without an explicit ID have not claimed instance identity — two
+// hash-colliding empty-ID payloads with differing content are treated
+// as two distinct entries (same rule as static assemble).
+//
+// Caller invariant: ClusterStore.SetEndpoint guards nil before calling
+// here, so incoming is never nil. The function is a pure decision; any
+// operator-visibility logging happens in the caller (explicit-ID
+// overwrite) or in the hash-collision branch itself (suffix append).
+func resolveSetEndpointSlot(clusterName string, incoming *model.Endpoint, existing []*model.Endpoint) setEndpointOutcome {
 	if incoming.ID != "" {
-		return resolveSetEndpointSlotByID(clusterName, incoming, existing)
+		return resolveSetEndpointSlotByID(incoming, existing)
 	}
 	return resolveSetEndpointSlotByHash(clusterName, incoming, existing)
 }
 
-// resolveSetEndpointSlotByID handles the explicit-ID branch of the decision
-// tree documented on resolveSetEndpointSlot. Probing the existing slice by
-// ID equality keeps the operator's pinned ID readable in the suffix on a
-// content mismatch (foo → foo-2, not foo → generated-...-2).
-func resolveSetEndpointSlotByID(clusterName string, incoming *model.Endpoint, existing []*model.Endpoint) (string, bool) {
-	for _, e := range existing {
+// resolveSetEndpointSlotByID handles the explicit-ID branch. An ID match
+// is treated as "this is the same instance" — content-equal calls are
+// idempotent, content-differing calls overwrite the existing slot. This
+// is what every registry adapter (Nacos, SpringCloud, Dubbo, LLM) needs
+// for OnUpdate events; the previous "append -2" behavior caused
+// endpoint accumulation on every address change.
+//
+// clusterName is unused on this branch because no suffix needs to be
+// generated; the caller logs the address-changing overwrite once the
+// runtime side has decided whether the replace actually changes the
+// healthcheck registration.
+func resolveSetEndpointSlotByID(incoming *model.Endpoint, existing []*model.Endpoint) setEndpointOutcome {
+	for i, e := range existing {
 		if e == nil {
 			continue
 		}
@@ -684,20 +765,19 @@ func resolveSetEndpointSlotByID(clusterName string, incoming *model.Endpoint, ex
 			continue
 		}
 		if endpointContentEqualForSet(e, incoming) {
-			return incoming.ID, true
+			return setEndpointOutcome{targetID: incoming.ID, action: setEndpointIdempotent, replaceIdx: -1}
 		}
-		suffixedID := nextStableEndpointID(clusterName, incoming, existingEndpointIDs(existing))
-		logSetEndpointSuffix(clusterName, incoming.ID, suffixedID)
-		return suffixedID, false
+		return setEndpointOutcome{targetID: incoming.ID, action: setEndpointReplace, replaceIdx: i}
 	}
-	return incoming.ID, false
+	return setEndpointOutcome{targetID: incoming.ID, action: setEndpointAppend, replaceIdx: -1}
 }
 
-// resolveSetEndpointSlotByHash handles the empty-ID branch of the decision
-// tree documented on resolveSetEndpointSlot. Probing by generated hash —
-// not by ID — is what lets an empty-ID call reuse an operator-pinned slot
-// (truth-table row 3) instead of inventing a parallel generated-* entry.
-func resolveSetEndpointSlotByHash(clusterName string, incoming *model.Endpoint, existing []*model.Endpoint) (string, bool) {
+// resolveSetEndpointSlotByHash handles the empty-ID branch. Probing by
+// generated hash — not by ID — lets an empty-ID call reuse an
+// operator-pinned slot when their hash material matches. A hash
+// collision with differing content keeps the static-style suffix-append
+// rule so neither entry is silently lost.
+func resolveSetEndpointSlotByHash(clusterName string, incoming *model.Endpoint, existing []*model.Endpoint) setEndpointOutcome {
 	incomingHash := model.GenerateEndpointID(clusterName, incoming)
 	for _, e := range existing {
 		if e == nil {
@@ -707,39 +787,56 @@ func resolveSetEndpointSlotByHash(clusterName string, incoming *model.Endpoint, 
 			continue
 		}
 		if endpointContentEqualForSet(e, incoming) {
-			return e.ID, true
+			return setEndpointOutcome{targetID: e.ID, action: setEndpointIdempotent, replaceIdx: -1}
 		}
 		suffixedID := nextStableEndpointID(clusterName, incoming, existingEndpointIDs(existing))
 		logSetEndpointSuffix(clusterName, incomingHash, suffixedID)
-		return suffixedID, false
+		return setEndpointOutcome{targetID: suffixedID, action: setEndpointAppend, replaceIdx: -1}
 	}
-	return incomingHash, false
+	return setEndpointOutcome{targetID: incomingHash, action: setEndpointAppend, replaceIdx: -1}
 }
 
 // logSetEndpointSuffix uses the same WARN format as
 // assembleClusterEndpoints (pkg/server/cluster_manager.go) so operators
 // tail one log line whether a duplicate came from static YAML or from a
-// runtime SetEndpoint call. Note: the dynamic path additionally logs
-// empty-ID hash collisions (when two SetEndpoint calls hash-collide but
-// differ in content), which assemble currently leaves silent — operator
-// visibility was the explicit motivation for adding this log on the
-// dynamic path.
+// runtime SetEndpoint call. The empty-ID hash collision path is the only
+// dynamic-side caller of this format after the explicit-ID semantics
+// switched to in-place replace (see logSetEndpointOverwrite for that path).
 //
 // This log is intentionally NOT pinned by a test. The contractual floor
-// is that suffix decisions actually happen (locked by the
-// *AppendsSuffix tests); the WARN is operator-visibility supplement.
-// Pinning the exact log line via stderr capture would couple the tests
-// to log formatting and offer little benefit. If a refactor accidentally
-// drops the call site, the suffix tests still pass — the regression
-// shows up as operators not seeing collision warnings they were
-// previously relying on, which is a separate signal worth treating as
-// such.
+// is that the empty-ID suffix decision actually happens (locked by
+// TestClusterManager_SetEndpointEmptyIDHashCollisionDifferentContentSuffixes);
+// the WARN is operator-visibility supplement. Pinning the exact log line
+// via stderr capture would couple the test to log formatting and offer
+// little benefit. If a refactor accidentally drops the call site, the
+// suffix test still passes — the regression shows up as operators not
+// seeing collision warnings they were previously relying on, which is a
+// separate signal worth treating as such.
 func logSetEndpointSuffix(clusterName, collidingID, assignedID string) {
 	logger.Warnf(
 		"[dubbo-go-pixiu] duplicate endpoint ID %s in cluster %s, assigned endpoint ID %s",
 		collidingID,
 		clusterName,
 		assignedID,
+	)
+}
+
+// logSetEndpointOverwrite is the explicit-ID path's operator-visibility
+// hook. Same intent as logSetEndpointSuffix but with the different
+// outcome (slot replaced, not appended). Surfaces both addresses so an
+// operator can tell whether the call was a legitimate registry update
+// (e.g. instance migrated to a new IP) or an adapter bug clobbering
+// someone else's endpoint.
+//
+// Same testing rationale as logSetEndpointSuffix: not pinned by a test
+// to avoid coupling tests to log formatting.
+func logSetEndpointOverwrite(clusterName, endpointID string, old, incoming *model.Endpoint) {
+	logger.Warnf(
+		"[dubbo-go-pixiu] endpoint %s in cluster %s overwritten by SetEndpoint (address %s -> %s)",
+		endpointID,
+		clusterName,
+		old.Address.GetAddress(),
+		incoming.Address.GetAddress(),
 	)
 }
 

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -198,14 +198,16 @@ func (cm *ClusterManager) PickNextEndpoint(clusterName, curEndpointID string) *m
 		return nil
 	}
 
-	return pickNextHealthyEndpoint(runtimeCluster.EndpointSnapshot(), curEndpointID)
+	return runtimeCluster.EndpointSnapshot().NextHealthyEndpoint(curEndpointID)
 }
 
-func pickNextHealthyEndpoint(snapshot *cluster.EndpointSnapshot, curEndpointID string) *model.Endpoint {
-	return snapshot.NextHealthyEndpoint(curEndpointID)
-}
-
-// GetEndpointByID returns the healthy runtime endpoint by ID in the given cluster.
+// GetEndpointByID returns the healthy runtime endpoint by ID in the given
+// cluster.
+//
+// Deprecated: kept as an alias for backward compatibility with v1.x callers.
+// New code should call GetHealthyEndpointByID directly to make the
+// healthy-only semantic explicit, or GetAnyEndpointByID when the caller also
+// wants to observe runtime-unhealthy endpoints.
 func (cm *ClusterManager) GetEndpointByID(clusterName, endpointID string) *model.Endpoint {
 	return cm.GetHealthyEndpointByID(clusterName, endpointID)
 }
@@ -257,7 +259,6 @@ func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, polic
 	healthyEndpoints := snapshot.HealthyEndpointsForPick()
 
 	c := runtimeCluster.Config
-	legacyPickLock := runtimeCluster.LegacyPickLock()
 	loadBalancer, ok := loadbalancer.LoadBalancerStrategy[c.LbStr]
 	if !ok {
 		loadBalancer = loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand]
@@ -268,7 +269,7 @@ func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, polic
 		allEndpoints = snapshot.AllEndpointsForPick()
 	}
 
-	return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, loadbalancer.PickContext{
+	return loadbalancer.PickEndpoint(loadBalancer, loadbalancer.PickContext{
 		Config:                c,
 		HealthyConsistentHash: snapshot.HealthyConsistentHash(),
 		AllEndpoints:          allEndpoints,
@@ -620,7 +621,7 @@ func mergeEndpointForSet(oldEndpoint, incoming *model.Endpoint) *model.Endpoint 
 		return incoming
 	}
 
-	merged := *oldEndpoint
+	merged := model.CloneEndpoint(oldEndpoint)
 	merged.ID = incoming.ID
 	merged.Name = incoming.Name
 	merged.Address = incoming.Address
@@ -628,7 +629,7 @@ func mergeEndpointForSet(oldEndpoint, incoming *model.Endpoint) *model.Endpoint 
 	if incoming.LLMMeta != nil {
 		merged.LLMMeta = incoming.LLMMeta
 	}
-	return &merged
+	return merged
 }
 
 func stableEndpointIDForSet(clusterName string, endpoint *model.Endpoint, endpoints []*model.Endpoint) string {

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -665,23 +665,40 @@ func resolveSetEndpointSlot(clusterName string, incoming *model.Endpoint, existi
 	if incoming == nil {
 		return "", false
 	}
-	incomingHash := model.GenerateEndpointID(clusterName, incoming)
-
 	if incoming.ID != "" {
-		for _, e := range existing {
-			if e == nil || e.ID != incoming.ID {
-				continue
-			}
-			if endpointContentEqualForSet(e, incoming) {
-				return incoming.ID, true
-			}
-			suffixedID := nextStableEndpointID(clusterName, incoming, existingEndpointIDs(existing))
-			logSetEndpointSuffix(clusterName, incoming.ID, suffixedID)
-			return suffixedID, false
-		}
-		return incoming.ID, false
+		return resolveSetEndpointSlotByID(clusterName, incoming, existing)
 	}
+	return resolveSetEndpointSlotByHash(clusterName, incoming, existing)
+}
 
+// resolveSetEndpointSlotByID handles the explicit-ID branch of the decision
+// tree documented on resolveSetEndpointSlot. Probing the existing slice by
+// ID equality keeps the operator's pinned ID readable in the suffix on a
+// content mismatch (foo → foo-2, not foo → generated-...-2).
+func resolveSetEndpointSlotByID(clusterName string, incoming *model.Endpoint, existing []*model.Endpoint) (string, bool) {
+	for _, e := range existing {
+		if e == nil {
+			continue
+		}
+		if e.ID != incoming.ID {
+			continue
+		}
+		if endpointContentEqualForSet(e, incoming) {
+			return incoming.ID, true
+		}
+		suffixedID := nextStableEndpointID(clusterName, incoming, existingEndpointIDs(existing))
+		logSetEndpointSuffix(clusterName, incoming.ID, suffixedID)
+		return suffixedID, false
+	}
+	return incoming.ID, false
+}
+
+// resolveSetEndpointSlotByHash handles the empty-ID branch of the decision
+// tree documented on resolveSetEndpointSlot. Probing by generated hash —
+// not by ID — is what lets an empty-ID call reuse an operator-pinned slot
+// (truth-table row 3) instead of inventing a parallel generated-* entry.
+func resolveSetEndpointSlotByHash(clusterName string, incoming *model.Endpoint, existing []*model.Endpoint) (string, bool) {
+	incomingHash := model.GenerateEndpointID(clusterName, incoming)
 	for _, e := range existing {
 		if e == nil {
 			continue

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -331,24 +331,14 @@ func (s *ClusterStore) prepareClusterConfig(c *model.ClusterConfig) {
 // assembleClusterEndpoints assembles the cluster endpoints by formatting the
 // ID, name and domains for each endpoint. If endpoint.LLMMeta is not nil, the
 // assimilation of name and domain is based on the LLM provider denoted in the
-// endpoint LLMMeta.
-//
-// CAVEAT (issue #905 follow-up): this function MUTATES the operator's
-// *model.Endpoint values in place — it writes endpoint.ID and endpoint.Name
-// when they are empty, and rewrites endpoint.ID when it collides with a
-// sibling. Callers that retain pointers into c.Endpoints (e.g. registry
-// callbacks, dynamic config) will observe these writes. The runtime
-// snapshot path is unaffected (snapshots deep-clone via model.CloneEndpoint
-// before publication); only the desired-state config is touched.
-//
-// Refactor to clone-then-mutate is tracked as a follow-up; until then,
-// callers that need an untouched copy should clone before passing into
-// AddCluster / UpdateCluster / SetEndpoint.
+// endpoint LLMMeta. The store first deep-clones c.Endpoints, so ID/name
+// defaulting never mutates operator-supplied *model.Endpoint values.
 func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 	if c == nil {
 		return
 	}
 
+	c.Endpoints = model.CloneEndpoints(c.Endpoints)
 	endpointIDs := make(map[string]struct{}, len(c.Endpoints))
 	for i, endpoint := range c.Endpoints {
 		if endpoint == nil {
@@ -585,6 +575,11 @@ func (s *ClusterStore) UpdateCluster(new *model.ClusterConfig) {
 }
 
 func (s *ClusterStore) SetEndpoint(clusterName string, endpoint *model.Endpoint) {
+	endpoint = model.CloneEndpoint(endpoint)
+	if endpoint == nil {
+		return
+	}
+
 	clusterConfig := s.findClusterConfig(clusterName)
 	if clusterConfig == nil {
 		c := &model.ClusterConfig{Name: clusterName, LbStr: model.LoadBalancerRoundRobin, Endpoints: []*model.Endpoint{}}

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -328,10 +328,22 @@ func (s *ClusterStore) prepareClusterConfig(c *model.ClusterConfig) {
 	c.CreateConsistentHash()
 }
 
-// assembleClusterEndpoints assembles the cluster endpoints
-// by formatting the ID, name and domains for each endpoint
-// If endpoint.LLMMeta is not nil, the assimilation of name and domain is based on
-// the LLM provider denoted in the endpoint LLMMeta.
+// assembleClusterEndpoints assembles the cluster endpoints by formatting the
+// ID, name and domains for each endpoint. If endpoint.LLMMeta is not nil, the
+// assimilation of name and domain is based on the LLM provider denoted in the
+// endpoint LLMMeta.
+//
+// CAVEAT (issue #905 follow-up): this function MUTATES the operator's
+// *model.Endpoint values in place — it writes endpoint.ID and endpoint.Name
+// when they are empty, and rewrites endpoint.ID when it collides with a
+// sibling. Callers that retain pointers into c.Endpoints (e.g. registry
+// callbacks, dynamic config) will observe these writes. The runtime
+// snapshot path is unaffected (snapshots deep-clone via model.CloneEndpoint
+// before publication); only the desired-state config is touched.
+//
+// Refactor to clone-then-mutate is tracked as a follow-up; until then,
+// callers that need an untouched copy should clone before passing into
+// AddCluster / UpdateCluster / SetEndpoint.
 func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 	if c == nil {
 		return

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -19,6 +19,7 @@ package server
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 )
@@ -98,6 +99,31 @@ func (cm *ClusterManager) UpdateCluster(new *model.ClusterConfig) {
 	cm.store.UpdateCluster(new)
 }
 
+// SetEndpoint registers or refreshes a single endpoint in the named
+// cluster, creating the cluster on first use.
+//
+// Dedup contract — follows the same collision rules as
+// assembleClusterEndpoints (ID match → hash match → suffix on content
+// mismatch) so static and dynamic registrations agree on outcomes, with
+// one deliberate divergence around Name documented below:
+//
+//   - When the incoming endpoint matches an existing slot's routing
+//     identity AND its content (Address, Metadata, LLMMeta — see
+//     endpointContentEqualForSet), the call is idempotent. The existing
+//     slot stays in place; this is the safety net for replayed Nacos
+//     instance events.
+//   - When the incoming endpoint collides on explicit ID or generated hash
+//     with an existing slot but differs in content, the new endpoint is
+//     appended with a -2/-3/... suffix (a WARN is emitted, mirroring
+//     assembleClusterEndpoints).
+//   - Otherwise the endpoint is appended with its explicit or generated ID.
+//
+// Name is intentionally NOT part of the content equality check (see
+// endpointContentEqualForSet's godoc). As a consequence, Name-only updates
+// (same Address/LLMMeta/Metadata, different Name) are absorbed by the
+// idempotent path and the cluster keeps the original Name. Callers that
+// need to rename an endpoint must DeleteEndpoint + SetEndpoint, or replace
+// the whole cluster config via AddCluster/UpdateCluster.
 func (cm *ClusterManager) SetEndpoint(clusterName string, endpoint *model.Endpoint) {
 	cm.rw.Lock()
 	defer cm.rw.Unlock()
@@ -594,62 +620,184 @@ func (s *ClusterStore) SetEndpoint(clusterName string, endpoint *model.Endpoint)
 		runtimeCluster = s.clustersMap[clusterName]
 	}
 
-	if endpoint.ID == "" {
-		endpoint.ID = stableEndpointIDForSet(clusterName, endpoint, clusterConfig.Endpoints)
+	targetID, idempotent := resolveSetEndpointSlot(clusterName, endpoint, clusterConfig.Endpoints)
+	endpoint.ID = targetID
+	if idempotent {
+		// A content-equal endpoint already occupies this slot, so the cluster
+		// state, consistent hash, and runtime health-check registration are
+		// already correct. Returning here keeps re-registration idempotent —
+		// the LLM/Nacos path can replay the same instance event without
+		// growing the endpoint slice.
+		return
 	}
 
-	for i, e := range clusterConfig.Endpoints {
-		if e.ID == endpoint.ID {
-			// Remove before replacing the endpoint because healthcheck keys by address.
-			runtimeCluster.RemoveEndpoint(e)
-			mergedEndpoint := mergeEndpointForSet(e, endpoint)
-			clusterConfig.Endpoints[i] = mergedEndpoint
-			s.prepareClusterConfig(clusterConfig)
-			runtimeCluster.RefreshEndpoints()
-			runtimeCluster.AddEndpoint(mergedEndpoint)
-			return
-		}
-	}
 	clusterConfig.Endpoints = append(clusterConfig.Endpoints, endpoint)
 	s.prepareClusterConfig(clusterConfig)
 	runtimeCluster.RefreshEndpoints()
 	runtimeCluster.AddEndpoint(endpoint)
 }
 
-func mergeEndpointForSet(oldEndpoint, incoming *model.Endpoint) *model.Endpoint {
-	if oldEndpoint == nil || incoming == nil {
-		return incoming
+// resolveSetEndpointSlot enforces the same dedup invariant as
+// assembleClusterEndpoints on the dynamic SetEndpoint path: an endpoint ID
+// identifies exactly one runtime endpoint at a time, and two registrations
+// that differ in routing-relevant content must both survive (suffixed -2,
+// -3, ...) instead of one silently overwriting the other.
+//
+// It returns the ID the incoming endpoint should be stored under and whether
+// the call is an idempotent re-registration (an existing slot already has
+// matching content). When idempotent is false the caller should append a
+// fresh endpoint with the returned ID.
+//
+// Decision tree:
+//
+//  1. Explicit ID matches an existing slot → idempotent iff content equal,
+//     otherwise return a -2/-3/... suffix off the explicit ID.
+//  2. Empty ID, hash matches an existing slot → idempotent iff content
+//     equal, otherwise return a suffix off the generated hash.
+//  3. No collision → use the explicit ID, or the generated hash for empty
+//     IDs.
+//
+// Share this helper across new entry points (admin API, xDS, gRPC
+// reflection, ...) to keep the dedup contract uniform; reimplementing the
+// branches in each caller is how the static and dynamic paths drifted
+// apart in the first place.
+func resolveSetEndpointSlot(clusterName string, incoming *model.Endpoint, existing []*model.Endpoint) (string, bool) {
+	if incoming == nil {
+		return "", false
+	}
+	incomingHash := model.GenerateEndpointID(clusterName, incoming)
+
+	if incoming.ID != "" {
+		for _, e := range existing {
+			if e == nil || e.ID != incoming.ID {
+				continue
+			}
+			if endpointContentEqualForSet(e, incoming) {
+				return incoming.ID, true
+			}
+			suffixedID := nextStableEndpointID(clusterName, incoming, existingEndpointIDs(existing))
+			logSetEndpointSuffix(clusterName, incoming.ID, suffixedID)
+			return suffixedID, false
+		}
+		return incoming.ID, false
 	}
 
-	merged := model.CloneEndpoint(oldEndpoint)
-	merged.ID = incoming.ID
-	merged.Name = incoming.Name
-	merged.Address = incoming.Address
-	merged.Metadata = incoming.Metadata
-	if incoming.LLMMeta != nil {
-		merged.LLMMeta = incoming.LLMMeta
-	}
-	return merged
-}
-
-func stableEndpointIDForSet(clusterName string, endpoint *model.Endpoint, endpoints []*model.Endpoint) string {
-	generatedID := model.GenerateEndpointID(clusterName, endpoint)
-	if existingEndpointMatchesGeneratedID(clusterName, generatedID, endpoints) {
-		return generatedID
-	}
-	return nextStableEndpointID(clusterName, endpoint, existingEndpointIDs(endpoints))
-}
-
-func existingEndpointMatchesGeneratedID(clusterName, generatedID string, endpoints []*model.Endpoint) bool {
-	for _, existing := range endpoints {
-		if existing == nil || existing.ID != generatedID {
+	for _, e := range existing {
+		if e == nil {
 			continue
 		}
-		if model.GenerateEndpointID(clusterName, existing) == generatedID {
-			return true
+		if model.GenerateEndpointID(clusterName, e) != incomingHash {
+			continue
+		}
+		if endpointContentEqualForSet(e, incoming) {
+			return e.ID, true
+		}
+		suffixedID := nextStableEndpointID(clusterName, incoming, existingEndpointIDs(existing))
+		logSetEndpointSuffix(clusterName, incomingHash, suffixedID)
+		return suffixedID, false
+	}
+	return incomingHash, false
+}
+
+// logSetEndpointSuffix uses the same WARN format as
+// assembleClusterEndpoints (pkg/server/cluster_manager.go) so operators
+// tail one log line whether a duplicate came from static YAML or from a
+// runtime SetEndpoint call. Note: the dynamic path additionally logs
+// empty-ID hash collisions (when two SetEndpoint calls hash-collide but
+// differ in content), which assemble currently leaves silent — operator
+// visibility was the explicit motivation for adding this log on the
+// dynamic path.
+//
+// This log is intentionally NOT pinned by a test. The contractual floor
+// is that suffix decisions actually happen (locked by the
+// *AppendsSuffix tests); the WARN is operator-visibility supplement.
+// Pinning the exact log line via stderr capture would couple the tests
+// to log formatting and offer little benefit. If a refactor accidentally
+// drops the call site, the suffix tests still pass — the regression
+// shows up as operators not seeing collision warnings they were
+// previously relying on, which is a separate signal worth treating as
+// such.
+func logSetEndpointSuffix(clusterName, collidingID, assignedID string) {
+	logger.Warnf(
+		"[dubbo-go-pixiu] duplicate endpoint ID %s in cluster %s, assigned endpoint ID %s",
+		collidingID,
+		clusterName,
+		assignedID,
+	)
+}
+
+// endpointContentEqualForSet reports whether the incoming SetEndpoint
+// payload represents the same endpoint as an existing slot for the purposes
+// of dedup. It compares the routing-relevant content — Address (full
+// SocketAddress including Domains), Metadata, and LLMMeta — but
+// deliberately excludes ID (the dedup contract uses the ID as the collision
+// key, not as a content field), Name (assembleClusterEndpoints defaults
+// missing names to "endpoint-<index>" between calls, so comparing Name
+// would treat re-registration with no name as a duplicate-content case),
+// and runtime-only state.
+//
+// nil and zero-length maps/slices are treated as equal: callers building
+// endpoints from different code paths (static YAML vs. Nacos metadata) often
+// produce one or the other for the same logical "no metadata" state.
+func endpointContentEqualForSet(a, b *model.Endpoint) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if !socketAddressContentEqual(a.Address, b.Address) {
+		return false
+	}
+	if !stringMapEqualForSet(a.Metadata, b.Metadata) {
+		return false
+	}
+	return llmMetaEqualForSet(a.LLMMeta, b.LLMMeta)
+}
+
+// socketAddressContentEqual is a deliberately stricter equality oracle than
+// model.SocketAddress.Equal. SocketAddress.Equal (see its godoc) is the
+// identity oracle used by load-balancer routing, which only compares
+// Address+Port (or Domains[0]) and ignores ResolverName, CertsDir, and
+// Domains beyond the first element. That is the right semantic for "pick
+// an endpoint by address" but too lax for SetEndpoint dedup: two endpoints
+// that differ only in CertsDir or Domains list ordering are distinct
+// configurations and must not be silently treated as one. So we compare
+// every field here, with the nil/empty-Domains normalization callers
+// expect.
+func socketAddressContentEqual(a, b model.SocketAddress) bool {
+	if a.Address != b.Address || a.Port != b.Port {
+		return false
+	}
+	if a.ResolverName != b.ResolverName || a.CertsDir != b.CertsDir {
+		return false
+	}
+	if len(a.Domains) != len(b.Domains) {
+		return false
+	}
+	for i := range a.Domains {
+		if a.Domains[i] != b.Domains[i] {
+			return false
 		}
 	}
-	return false
+	return true
+}
+
+func stringMapEqualForSet(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		bv, ok := b[k]
+		if !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func llmMetaEqualForSet(a, b *model.LLMMeta) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return reflect.DeepEqual(*a, *b)
 }
 
 func existingEndpointIDs(endpoints []*model.Endpoint) map[string]struct{} {

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -161,7 +161,12 @@ func (cm *ClusterManager) compareAndSetStore(store *ClusterStore) (bool, []*clus
 	}
 
 	currentStore := cm.store
-	replacedClusters := store.ensureRuntimeClusters()
+	var replacedClusters []*cluster.Cluster
+	if store == currentStore {
+		replacedClusters = store.ensureRuntimeClusters()
+	} else {
+		replacedClusters = store.ensureRuntimeClustersFrom(currentStore)
+	}
 	store.carryOverRuntimeStateFrom(currentStore)
 	cm.store = store
 	if store != currentStore {
@@ -174,81 +179,101 @@ func (cm *ClusterManager) compareAndSetStore(store *ClusterStore) (bool, []*clus
 func (cm *ClusterManager) PickEndpoint(clusterName string, policy model.LbPolicy) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
-	c := cm.getCluster(clusterName)
-	if c == nil {
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
 		logger.Warnf("[dubbo-go-pixiu] cluster %s not found", clusterName)
 		return nil
 	}
-	return cm.pickOneEndpoint(c, policy)
+	return cm.pickOneEndpoint(runtimeCluster, policy)
 }
 
 // PickNextEndpoint picks the next endpoint in the cluster after the current endpoint ID.
-func (cm *ClusterManager) PickNextEndpoint(clusterName string, curEndpointID string) *model.Endpoint {
+func (cm *ClusterManager) PickNextEndpoint(clusterName, curEndpointID string) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
 
-	c := cm.getCluster(clusterName)
-	if c == nil {
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
 		logger.Warnf("[dubbo-go-pixiu] cluster %s not found", clusterName)
 		return nil
 	}
 
-	for i, endpoint := range c.Endpoints {
-		if endpoint.ID == curEndpointID {
-			// pick next endpoint
-			if i < len(c.Endpoints)-1 {
-				return c.Endpoints[i+1]
-			}
-			return nil // have tried all endpoints
-		}
-	}
-
-	return nil
+	return pickNextHealthyEndpoint(runtimeCluster.EndpointSnapshot(), curEndpointID)
 }
 
-// GetEndpointByID returns the endpoint by ID in the given cluster.
-func (cm *ClusterManager) GetEndpointByID(clusterName string, endpointID string) *model.Endpoint {
+func pickNextHealthyEndpoint(snapshot *cluster.EndpointSnapshot, curEndpointID string) *model.Endpoint {
+	return snapshot.NextHealthyEndpoint(curEndpointID)
+}
+
+// GetEndpointByID returns the healthy runtime endpoint by ID in the given cluster.
+func (cm *ClusterManager) GetEndpointByID(clusterName, endpointID string) *model.Endpoint {
+	return cm.GetHealthyEndpointByID(clusterName, endpointID)
+}
+
+// GetAnyEndpointByID returns the runtime endpoint by ID regardless of its
+// current health in the runtime snapshot.
+func (cm *ClusterManager) GetAnyEndpointByID(clusterName, endpointID string) *model.Endpoint {
 	cm.rw.RLock()
 	defer cm.rw.RUnlock()
 
-	c := cm.getCluster(clusterName)
-	if c == nil {
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
 		return nil
 	}
-	for _, endpoint := range c.Endpoints {
-		if endpoint.ID == endpointID && !endpoint.UnHealthy {
-			return endpoint
-		}
+	return runtimeCluster.EndpointSnapshot().EndpointByID(endpointID)
+}
+
+// GetHealthyEndpointByID returns the runtime endpoint by ID only when it is
+// healthy in the current runtime snapshot.
+func (cm *ClusterManager) GetHealthyEndpointByID(clusterName, endpointID string) *model.Endpoint {
+	cm.rw.RLock()
+	defer cm.rw.RUnlock()
+
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
+	if runtimeCluster == nil {
+		return nil
 	}
-	return nil
+	return runtimeCluster.EndpointSnapshot().HealthyEndpointByID(endpointID)
 }
 
 // getCluster returns the cluster configuration by its name.
 func (cm *ClusterManager) getCluster(clusterName string) *model.ClusterConfig {
-	runtimeCluster := cm.store.clustersMap[clusterName]
+	runtimeCluster := cm.getRuntimeCluster(clusterName)
 	if runtimeCluster == nil {
 		return nil
 	}
 	return runtimeCluster.Config
 }
 
-func (cm *ClusterManager) pickOneEndpoint(c *model.ClusterConfig, policy model.LbPolicy) *model.Endpoint {
-	if len(c.Endpoints) == 0 {
+func (cm *ClusterManager) getRuntimeCluster(clusterName string) *cluster.Cluster {
+	return cm.store.clustersMap[clusterName]
+}
+
+func (cm *ClusterManager) pickOneEndpoint(runtimeCluster *cluster.Cluster, policy model.LbPolicy) *model.Endpoint {
+	snapshot := runtimeCluster.EndpointSnapshot()
+	if snapshot.HealthyEndpointCount() == 0 {
 		return nil
 	}
+	healthyEndpoints := snapshot.HealthyEndpointsForPick()
 
-	if len(c.Endpoints) == 1 {
-		if !c.Endpoints[0].UnHealthy {
-			return c.Endpoints[0]
-		}
-		return nil
-	}
-
+	c := runtimeCluster.Config
+	legacyPickLock := runtimeCluster.LegacyPickLock()
 	loadBalancer, ok := loadbalancer.LoadBalancerStrategy[c.LbStr]
-	if ok {
-		return loadBalancer.Handler(c, policy)
+	if !ok {
+		loadBalancer = loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand]
 	}
-	return loadbalancer.LoadBalancerStrategy[model.LoadBalancerRand].Handler(c, policy)
+
+	var allEndpoints []*model.Endpoint
+	if loadbalancer.NeedsAllEndpoints(loadBalancer) {
+		allEndpoints = snapshot.AllEndpointsForPick()
+	}
+
+	return loadbalancer.PickEndpointWithLegacyLock(loadBalancer, legacyPickLock, loadbalancer.PickContext{
+		Config:                c,
+		HealthyConsistentHash: snapshot.HealthyConsistentHash(),
+		AllEndpoints:          allEndpoints,
+		HealthyEndpoints:      healthyEndpoints,
+	}, policy)
 }
 
 func (cm *ClusterManager) RemoveCluster(namesToDel []string) {
@@ -312,28 +337,25 @@ func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 		return
 	}
 
-	// generatedIDIndex tracks the slice position where each generated ID was
-	// first observed within this cluster. A duplicate means two endpoints
-	// share (cluster_name, address, provider, api_key) and collapse onto a
-	// single identifier, which is silent in the runtime path; warn loudly so
-	// the operator can disambiguate by setting an explicit `id:`.
-	generatedIDIndex := make(map[string]int, len(c.Endpoints))
-
+	endpointIDs := make(map[string]struct{}, len(c.Endpoints))
 	for i, endpoint := range c.Endpoints {
-		// If the endpoint ID is not set, derive a deterministic one so the same
-		// endpoint hashes to the same ID across process restarts. Identifiers
-		// must be stable for metrics/log correlation and runtime lookups
-		// (PickNextEndpoint, GetEndpointByID, DeleteEndpoint).
-		if endpoint.ID == "" {
-			endpoint.ID = model.GenerateEndpointID(c.Name, endpoint)
-			if prev, dup := generatedIDIndex[endpoint.ID]; dup {
-				logger.Warnf("[cluster=%s] endpoints[%d] and endpoints[%d] share generated ID %s; "+
-					"set an explicit `id:` on one of them to keep them distinct",
-					c.Name, prev, i, endpoint.ID)
-			} else {
-				generatedIDIndex[endpoint.ID] = i
-			}
+		if endpoint == nil {
+			continue
 		}
+		// Endpoint IDs are runtime health keys, so keep them unique per cluster.
+		if endpoint.ID == "" {
+			endpoint.ID = nextStableEndpointID(c.Name, endpoint, endpointIDs)
+		} else if _, exists := endpointIDs[endpoint.ID]; exists {
+			duplicateID := endpoint.ID
+			endpoint.ID = nextStableEndpointID(c.Name, endpoint, endpointIDs)
+			logger.Warnf(
+				"[dubbo-go-pixiu] duplicate endpoint ID %s in cluster %s, assigned endpoint ID %s",
+				duplicateID,
+				c.Name,
+				endpoint.ID,
+			)
+		}
+		endpointIDs[endpoint.ID] = struct{}{}
 
 		// If the endpoint has no name, set a default name
 		if endpoint.Name == "" && endpoint.LLMMeta != nil {
@@ -344,15 +366,57 @@ func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 	}
 }
 
+// nextStableEndpointID returns a unique endpoint ID for the cluster's dedup
+// set. If endpoint.ID is set (operator-supplied) and only collides with a
+// sibling, it appends -2, -3, ... to preserve the operator's choice. If
+// endpoint.ID is empty, it derives a deterministic generated-* base via
+// model.GenerateEndpointID and suffixes that on collision. This matches
+// uniqueSnapshotEndpointID in pkg/cluster and keeps the same dashboard/log
+// identity post-rebuild.
+func nextStableEndpointID(clusterName string, endpoint *model.Endpoint, endpointIDs map[string]struct{}) string {
+	baseID := ""
+	if endpoint != nil {
+		baseID = endpoint.ID
+	}
+	if baseID == "" {
+		baseID = model.GenerateEndpointID(clusterName, endpoint)
+	}
+	if _, exists := endpointIDs[baseID]; !exists {
+		return baseID
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s-%d", baseID, suffix)
+		if _, exists := endpointIDs[candidate]; !exists {
+			return candidate
+		}
+	}
+}
+
 // replaceClusterRuntime returns the old runtime so callers decide when to stop it.
 func (s *ClusterStore) replaceClusterRuntime(name string, config *model.ClusterConfig) *cluster.Cluster {
+	var previous *cluster.EndpointSnapshot
+	if oldRuntime := s.clustersMap[name]; oldRuntime != nil {
+		previous = oldRuntime.SnapshotForRuntimeReplacement()
+	}
+	return s.replaceClusterRuntimeWithSnapshot(name, config, previous)
+}
+
+func (s *ClusterStore) replaceClusterRuntimeWithSnapshot(
+	name string,
+	config *model.ClusterConfig,
+	previous *cluster.EndpointSnapshot,
+) *cluster.Cluster {
+	s.ensureRuntimeClusterMap()
+
+	oldRuntime := s.clustersMap[name]
+	s.clustersMap[name] = cluster.NewClusterWithEndpointSnapshot(config, previous)
+	return oldRuntime
+}
+
+func (s *ClusterStore) ensureRuntimeClusterMap() {
 	if s.clustersMap == nil {
 		s.clustersMap = map[string]*cluster.Cluster{}
 	}
-
-	oldRuntime := s.clustersMap[name]
-	s.clustersMap[name] = cluster.NewCluster(config)
-	return oldRuntime
 }
 
 // ensureRuntimeClusters repairs clustersMap to match Config by name and pointer.
@@ -360,9 +424,7 @@ func (s *ClusterStore) ensureRuntimeClusters() []*cluster.Cluster {
 	if s == nil {
 		return nil
 	}
-	if s.clustersMap == nil {
-		s.clustersMap = map[string]*cluster.Cluster{}
-	}
+	s.ensureRuntimeClusterMap()
 
 	replacedClusters := make([]*cluster.Cluster, 0)
 	configsByName := make(map[string]*model.ClusterConfig, len(s.Config))
@@ -381,6 +443,64 @@ func (s *ClusterStore) ensureRuntimeClusters() []*cluster.Cluster {
 		}
 	}
 
+	return append(replacedClusters, s.removeRuntimeClustersNotIn(configsByName)...)
+}
+
+// ensureRuntimeClustersFrom repairs a candidate store using the currently
+// published runtime snapshots before the candidate runtime starts health checks.
+func (s *ClusterStore) ensureRuntimeClustersFrom(old *ClusterStore) []*cluster.Cluster {
+	if s == nil {
+		return nil
+	}
+	if old == nil || s == old {
+		return s.ensureRuntimeClusters()
+	}
+	s.ensureRuntimeClusterMap()
+
+	replacedClusters := make([]*cluster.Cluster, 0)
+	configsByName := make(map[string]*model.ClusterConfig, len(s.Config))
+	for _, clusterConfig := range s.Config {
+		clusterName, oldRuntime := s.repairRuntimeClusterFromPrevious(clusterConfig, old)
+		if clusterName == "" {
+			continue
+		}
+		configsByName[clusterName] = clusterConfig
+		if oldRuntime != nil {
+			replacedClusters = append(replacedClusters, oldRuntime)
+		}
+	}
+
+	return append(replacedClusters, s.removeRuntimeClustersNotIn(configsByName)...)
+}
+
+func (s *ClusterStore) repairRuntimeClusterFromPrevious(
+	clusterConfig *model.ClusterConfig,
+	old *ClusterStore,
+) (string, *cluster.Cluster) {
+	if clusterConfig == nil {
+		return "", nil
+	}
+	s.prepareClusterConfig(clusterConfig)
+	previous := snapshotForRuntimeReplacement(old, clusterConfig.Name)
+	runtimeCluster := s.clustersMap[clusterConfig.Name]
+	if runtimeCluster != nil && runtimeCluster.Config == clusterConfig && previous == nil {
+		return clusterConfig.Name, nil
+	}
+	return clusterConfig.Name, s.replaceClusterRuntimeWithSnapshot(clusterConfig.Name, clusterConfig, previous)
+}
+
+func snapshotForRuntimeReplacement(old *ClusterStore, clusterName string) *cluster.EndpointSnapshot {
+	if old == nil {
+		return nil
+	}
+	if oldRuntime := old.clustersMap[clusterName]; oldRuntime != nil {
+		return oldRuntime.SnapshotForRuntimeReplacement()
+	}
+	return nil
+}
+
+func (s *ClusterStore) removeRuntimeClustersNotIn(configsByName map[string]*model.ClusterConfig) []*cluster.Cluster {
+	replacedClusters := make([]*cluster.Cluster, 0)
 	for name, runtimeCluster := range s.clustersMap {
 		if _, ok := configsByName[name]; !ok {
 			replacedClusters = append(replacedClusters, runtimeCluster)
@@ -466,21 +586,73 @@ func (s *ClusterStore) SetEndpoint(clusterName string, endpoint *model.Endpoint)
 		runtimeCluster = s.clustersMap[clusterName]
 	}
 
-	for _, e := range clusterConfig.Endpoints {
+	if endpoint.ID == "" {
+		endpoint.ID = stableEndpointIDForSet(clusterName, endpoint, clusterConfig.Endpoints)
+	}
+
+	for i, e := range clusterConfig.Endpoints {
 		if e.ID == endpoint.ID {
-			// Remove before mutating address because healthcheck keys by address.
+			// Remove before replacing the endpoint because healthcheck keys by address.
 			runtimeCluster.RemoveEndpoint(e)
-			e.Name = endpoint.Name
-			e.Metadata = endpoint.Metadata
-			e.Address = endpoint.Address
+			mergedEndpoint := mergeEndpointForSet(e, endpoint)
+			clusterConfig.Endpoints[i] = mergedEndpoint
 			s.prepareClusterConfig(clusterConfig)
-			runtimeCluster.AddEndpoint(e)
+			runtimeCluster.RefreshEndpoints()
+			runtimeCluster.AddEndpoint(mergedEndpoint)
 			return
 		}
 	}
 	clusterConfig.Endpoints = append(clusterConfig.Endpoints, endpoint)
 	s.prepareClusterConfig(clusterConfig)
+	runtimeCluster.RefreshEndpoints()
 	runtimeCluster.AddEndpoint(endpoint)
+}
+
+func mergeEndpointForSet(oldEndpoint, incoming *model.Endpoint) *model.Endpoint {
+	if oldEndpoint == nil || incoming == nil {
+		return incoming
+	}
+
+	merged := *oldEndpoint
+	merged.ID = incoming.ID
+	merged.Name = incoming.Name
+	merged.Address = incoming.Address
+	merged.Metadata = incoming.Metadata
+	if incoming.LLMMeta != nil {
+		merged.LLMMeta = incoming.LLMMeta
+	}
+	return &merged
+}
+
+func stableEndpointIDForSet(clusterName string, endpoint *model.Endpoint, endpoints []*model.Endpoint) string {
+	generatedID := model.GenerateEndpointID(clusterName, endpoint)
+	if existingEndpointMatchesGeneratedID(clusterName, generatedID, endpoints) {
+		return generatedID
+	}
+	return nextStableEndpointID(clusterName, endpoint, existingEndpointIDs(endpoints))
+}
+
+func existingEndpointMatchesGeneratedID(clusterName, generatedID string, endpoints []*model.Endpoint) bool {
+	for _, existing := range endpoints {
+		if existing == nil || existing.ID != generatedID {
+			continue
+		}
+		if model.GenerateEndpointID(clusterName, existing) == generatedID {
+			return true
+		}
+	}
+	return false
+}
+
+func existingEndpointIDs(endpoints []*model.Endpoint) map[string]struct{} {
+	ids := make(map[string]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint == nil || endpoint.ID == "" {
+			continue
+		}
+		ids[endpoint.ID] = struct{}{}
+	}
+	return ids
 }
 
 func (s *ClusterStore) DeleteEndpoint(clusterName string, endpointID string) {
@@ -501,6 +673,7 @@ func (s *ClusterStore) DeleteEndpoint(clusterName string, endpointID string) {
 			runtimeCluster.RemoveEndpoint(e)
 			clusterConfig.Endpoints = append(clusterConfig.Endpoints[:i], clusterConfig.Endpoints[i+1:]...)
 			s.prepareClusterConfig(clusterConfig)
+			runtimeCluster.RefreshEndpoints()
 			return
 		}
 	}

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -129,35 +129,25 @@ func BenchmarkClusterLoadBalancerHotPathSerial(b *testing.B) {
 // external code that needs an isolated slice should use, and it shows
 // the cost of the defensive copy (allocation = endpointCount + maps).
 func BenchmarkClusterHealthySnapshotLoad(b *testing.B) {
-	for _, endpointCount := range []int{8, 64, 512} {
-		for _, healthyRatio := range []int{100, 50, 0} {
-			b.Run(fmt.Sprintf("endpoints=%d/healthy=%d", endpointCount, healthyRatio), func(b *testing.B) {
-				clusterConfig := benchmarkClusterConfig("healthy-snapshot", model.LoadBalancerRoundRobin, endpointCount, 0)
-				healthyCount := endpointCount * healthyRatio / 100
-				for i := healthyCount; i < len(clusterConfig.Endpoints); i++ {
-					clusterConfig.Endpoints[i].UnHealthy = true
-				}
-				runtimeCluster := cluster.NewCluster(clusterConfig)
-				snapshot := runtimeCluster.EndpointSnapshot()
-
-				b.ReportAllocs()
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
-					benchmarkEndpointsSink = snapshot.HealthyEndpointsForPick()
-				}
-			})
-		}
-	}
+	benchmarkHealthySnapshotAccessor(b, "healthy-snapshot", (*cluster.EndpointSnapshot).HealthyEndpointsForPick)
 }
 
 // BenchmarkClusterHealthySnapshotDefensiveCopy measures the cost of the
 // defensive HealthyEndpoints accessor. Reported separately so external
 // callers that need an isolated slice see the price.
 func BenchmarkClusterHealthySnapshotDefensiveCopy(b *testing.B) {
+	benchmarkHealthySnapshotAccessor(b, "healthy-snapshot-copy", (*cluster.EndpointSnapshot).HealthyEndpoints)
+}
+
+func benchmarkHealthySnapshotAccessor(
+	b *testing.B,
+	clusterName string,
+	accessor func(*cluster.EndpointSnapshot) []*model.Endpoint,
+) {
 	for _, endpointCount := range []int{8, 64, 512} {
 		for _, healthyRatio := range []int{100, 50, 0} {
 			b.Run(fmt.Sprintf("endpoints=%d/healthy=%d", endpointCount, healthyRatio), func(b *testing.B) {
-				clusterConfig := benchmarkClusterConfig("healthy-snapshot-copy", model.LoadBalancerRoundRobin, endpointCount, 0)
+				clusterConfig := benchmarkClusterConfig(clusterName, model.LoadBalancerRoundRobin, endpointCount, 0)
 				healthyCount := endpointCount * healthyRatio / 100
 				for i := healthyCount; i < len(clusterConfig.Endpoints); i++ {
 					clusterConfig.Endpoints[i].UnHealthy = true
@@ -168,7 +158,7 @@ func BenchmarkClusterHealthySnapshotDefensiveCopy(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					benchmarkEndpointsSink = snapshot.HealthyEndpoints()
+					benchmarkEndpointsSink = accessor(snapshot)
 				}
 			})
 		}

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -119,6 +119,15 @@ func BenchmarkClusterLoadBalancerHotPathSerial(b *testing.B) {
 	}
 }
 
+// BenchmarkClusterHealthySnapshotLoad measures the per-request endpoint
+// retrieval cost on the snapshot pick path. The request path uses
+// HealthyEndpointsForPick (zero-copy: returns the snapshot-owned slice),
+// not HealthyEndpoints (defensive deep copy). This is the bench that
+// backs the CHANGELOG claim "O(1) on the healthy view".
+//
+// HealthyEndpoints is also benchmarked below for comparison — it is what
+// external code that needs an isolated slice should use, and it shows
+// the cost of the defensive copy (allocation = endpointCount + maps).
 func BenchmarkClusterHealthySnapshotLoad(b *testing.B) {
 	for _, endpointCount := range []int{8, 64, 512} {
 		for _, healthyRatio := range []int{100, 50, 0} {
@@ -129,11 +138,37 @@ func BenchmarkClusterHealthySnapshotLoad(b *testing.B) {
 					clusterConfig.Endpoints[i].UnHealthy = true
 				}
 				runtimeCluster := cluster.NewCluster(clusterConfig)
+				snapshot := runtimeCluster.EndpointSnapshot()
 
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					benchmarkEndpointsSink = runtimeCluster.EndpointSnapshot().HealthyEndpoints()
+					benchmarkEndpointsSink = snapshot.HealthyEndpointsForPick()
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkClusterHealthySnapshotDefensiveCopy measures the cost of the
+// defensive HealthyEndpoints accessor. Reported separately so external
+// callers that need an isolated slice see the price.
+func BenchmarkClusterHealthySnapshotDefensiveCopy(b *testing.B) {
+	for _, endpointCount := range []int{8, 64, 512} {
+		for _, healthyRatio := range []int{100, 50, 0} {
+			b.Run(fmt.Sprintf("endpoints=%d/healthy=%d", endpointCount, healthyRatio), func(b *testing.B) {
+				clusterConfig := benchmarkClusterConfig("healthy-snapshot-copy", model.LoadBalancerRoundRobin, endpointCount, 0)
+				healthyCount := endpointCount * healthyRatio / 100
+				for i := healthyCount; i < len(clusterConfig.Endpoints); i++ {
+					clusterConfig.Endpoints[i].UnHealthy = true
+				}
+				runtimeCluster := cluster.NewCluster(clusterConfig)
+				snapshot := runtimeCluster.EndpointSnapshot()
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					benchmarkEndpointsSink = snapshot.HealthyEndpoints()
 				}
 			})
 		}

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/cluster"
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"     // Register Maglev for benchmark coverage.
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand"       // Register Rand for benchmark coverage.
 	_ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash"   // Register RingHash for benchmark coverage.
@@ -106,32 +107,33 @@ func BenchmarkClusterLoadBalancerHotPathSerial(b *testing.B) {
 		for _, endpointCount := range []int{4, 64, 512} {
 			b.Run(fmt.Sprintf("%s/endpoints=%d", lbType, endpointCount), func(b *testing.B) {
 				cm := &ClusterManager{}
-				cluster := benchmarkClusterConfig("lb-hot-path", lbType, endpointCount, 0)
+				runtimeCluster := cluster.NewCluster(benchmarkClusterConfig("lb-hot-path", lbType, endpointCount, 0))
 
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					benchmarkEndpointSink = cm.pickOneEndpoint(cluster, nil)
+					benchmarkEndpointSink = cm.pickOneEndpoint(runtimeCluster, nil)
 				}
 			})
 		}
 	}
 }
 
-func BenchmarkClusterHealthyFilterCost(b *testing.B) {
+func BenchmarkClusterHealthySnapshotLoad(b *testing.B) {
 	for _, endpointCount := range []int{8, 64, 512} {
 		for _, healthyRatio := range []int{100, 50, 0} {
 			b.Run(fmt.Sprintf("endpoints=%d/healthy=%d", endpointCount, healthyRatio), func(b *testing.B) {
-				cluster := benchmarkClusterConfig("healthy-filter", model.LoadBalancerRoundRobin, endpointCount, 0)
+				clusterConfig := benchmarkClusterConfig("healthy-snapshot", model.LoadBalancerRoundRobin, endpointCount, 0)
 				healthyCount := endpointCount * healthyRatio / 100
-				for i := healthyCount; i < len(cluster.Endpoints); i++ {
-					cluster.Endpoints[i].UnHealthy = true
+				for i := healthyCount; i < len(clusterConfig.Endpoints); i++ {
+					clusterConfig.Endpoints[i].UnHealthy = true
 				}
+				runtimeCluster := cluster.NewCluster(clusterConfig)
 
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					benchmarkEndpointsSink = cluster.GetEndpoint(true)
+					benchmarkEndpointsSink = runtimeCluster.EndpointSnapshot().HealthyEndpoints()
 				}
 			})
 		}

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -584,6 +584,27 @@ func TestClusterManager_SetEndpointDoesNotMutateInputEndpoint(t *testing.T) {
 	}
 }
 
+func TestClusterManager_SetEndpointUpdateDoesNotShareOldLLMMeta(t *testing.T) {
+	oldEndpoint := testEndpoint("ep-1", "127.0.0.1", 21077)
+	oldEndpoint.LLMMeta = &model.LLMMeta{APIKey: "old-key"}
+	config := testCluster("set-llm-meta-clone", model.LoadBalancerRoundRobin, []*model.Endpoint{oldEndpoint})
+	cm := testClusterManager(config)
+	defer stopStoreRuntimes(cm.store)
+
+	storedOld := cm.store.Config[0].Endpoints[0]
+	incoming := testEndpoint("ep-1", "127.0.0.2", 21078)
+
+	cm.SetEndpoint(config.Name, incoming)
+
+	updated := cm.store.Config[0].Endpoints[0]
+	if assert.NotNil(t, updated.LLMMeta) && assert.NotNil(t, storedOld.LLMMeta) {
+		assert.NotSame(t, storedOld.LLMMeta, updated.LLMMeta)
+		updated.LLMMeta.APIKey = "mutated-key"
+		assert.Equal(t, "old-key", storedOld.LLMMeta.APIKey)
+	}
+	assert.Nil(t, incoming.LLMMeta)
+}
+
 func TestClusterManager_AssembleEndpointsPreservesExplicitID(t *testing.T) {
 	cluster := &model.ClusterConfig{
 		Name:  "explicit-id",

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -886,7 +886,6 @@ func TestClusterManager_SetEndpointCertsDirChangeReplacesWithoutHealthcheckResta
 			"reason (TLS cert dir is irrelevant to L4 reachability)")
 }
 
-
 // runtime side of the address-changing replace case. When SetEndpoint
 // overwrites a slot with a new address, the old address's healthcheck
 // must stop (no goroutine leak) and a fresh checker must start against

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -395,14 +395,13 @@ func TestClusterStore_EnsureRuntimeClustersRepairsRuntimeMap(t *testing.T) {
 	})
 }
 
-// TestClusterManager_SetEndpointSuffixAppendRebuildsConsistentHash locks the
-// invariant that when a SetEndpoint call collides on explicit ID with an
-// existing endpoint but differs in routing identity, BOTH endpoints survive
-// (the second gets a -2 suffix) and the consistent hash reflects both hosts.
-// Previously the colliding call silently overwrote the original endpoint,
-// which made the PR-3 dedup rule effective only for static assembly and not
-// for the dynamic LLM/Nacos registration path.
-func TestClusterManager_SetEndpointSuffixAppendRebuildsConsistentHash(t *testing.T) {
+// TestClusterManager_SetEndpointExplicitSameIDDifferentAddressRebuildsConsistentHash
+// locks the consistent-hash side of the registry-update contract. When
+// SetEndpoint replaces an existing endpoint's address in place, the hash
+// ring must drop the old host and admit the new one. The previous behavior
+// (append a -2 sibling keeping both hosts in the ring) caused stale hosts
+// to keep receiving traffic after an instance moved.
+func TestClusterManager_SetEndpointExplicitSameIDDifferentAddressRebuildsConsistentHash(t *testing.T) {
 	tests := []model.LbPolicyType{
 		model.LoadBalancerRingHashing,
 		model.LoadBalancerMaglevHashing,
@@ -421,11 +420,11 @@ func TestClusterManager_SetEndpointSuffixAppendRebuildsConsistentHash(t *testing
 			cm.SetEndpoint(config.Name, newEndpoint)
 
 			endpoints := cm.store.Config[0].Endpoints
-			if !assert.Len(t, endpoints, 2, "duplicate explicit ID must produce a suffixed sibling, not overwrite") {
+			if !assert.Len(t, endpoints, 1, "address-changing replace must keep exactly one endpoint") {
 				return
 			}
 			assert.Equal(t, "ep-1", endpoints[0].ID)
-			assert.Equal(t, "ep-1-2", endpoints[1].ID)
+			assert.Equal(t, "127.0.0.2", endpoints[0].Address.Address)
 
 			hash := cm.store.Config[0].ConsistentHash.Hash
 			if !assert.NotNil(t, hash) {
@@ -433,12 +432,12 @@ func TestClusterManager_SetEndpointSuffixAppendRebuildsConsistentHash(t *testing
 			}
 			if hostList, ok := hash.(interface{ Hosts() []string }); ok {
 				hosts := hostList.Hosts()
-				assert.Contains(t, hosts, oldHost, "old host stays in the hash because the slot is preserved")
-				assert.Contains(t, hosts, newHost, "new host is rebuilt into the hash because the slot is appended")
+				assert.NotContains(t, hosts, oldHost, "old host must drop from the hash after the slot is overwritten")
+				assert.Contains(t, hosts, newHost, "new host must enter the hash after the slot is overwritten")
 				return
 			}
-			assert.True(t, hash.Remove(oldHost), "old host stays in the hash because the slot is preserved")
-			assert.True(t, hash.Remove(newHost), "new host is rebuilt into the hash because the slot is appended")
+			assert.False(t, hash.Remove(oldHost), "old host must not be in the hash after the slot is overwritten")
+			assert.True(t, hash.Remove(newHost), "new host must be in the hash after the slot is overwritten")
 		})
 	}
 }
@@ -598,48 +597,48 @@ func TestClusterManager_SetEndpointDoesNotMutateInputEndpoint(t *testing.T) {
 	}
 }
 
-// TestClusterManager_SetEndpointSuffixAppendKeepsOldLLMMeta verifies that
-// when an incoming SetEndpoint call collides on explicit ID but differs in
-// routing identity, the original endpoint's LLMMeta is left untouched
-// because the new endpoint is appended with a -2 suffix instead of merged
-// into the old slot. This is the dynamic-path counterpart to the static
-// dedup test TestAssembleEndpointsDeduplicatesExplicitID.
-func TestClusterManager_SetEndpointSuffixAppendKeepsOldLLMMeta(t *testing.T) {
+// TestClusterManager_SetEndpointExplicitSameIDDifferentAddressReplacesLLMMeta
+// locks LLMMeta semantics across an in-place address replacement. A
+// registry-update event ("this instance moved to a new IP, here's its
+// current LLMMeta") must publish the incoming LLMMeta verbatim — not
+// preserve the old slot's LLMMeta as if the new payload were a sibling.
+// The previous "append -2" behavior preserved the old LLMMeta, which is
+// wrong for the update path because the old slot's LLMMeta belonged to
+// an instance that no longer exists.
+func TestClusterManager_SetEndpointExplicitSameIDDifferentAddressReplacesLLMMeta(t *testing.T) {
 	oldEndpoint := testEndpoint("ep-1", "127.0.0.1", 21077)
 	oldEndpoint.LLMMeta = &model.LLMMeta{APIKey: "old-key"}
-	config := testCluster("set-llm-meta-clone", model.LoadBalancerRoundRobin, []*model.Endpoint{oldEndpoint})
+	config := testCluster("set-llm-meta-replace", model.LoadBalancerRoundRobin, []*model.Endpoint{oldEndpoint})
 	cm := testClusterManager(config)
 	defer stopStoreRuntimes(cm.store)
 
-	storedOld := cm.store.Config[0].Endpoints[0]
 	incoming := testEndpoint("ep-1", "127.0.0.2", 21078)
+	incoming.LLMMeta = &model.LLMMeta{APIKey: "new-key"}
 
 	cm.SetEndpoint(config.Name, incoming)
 
 	endpoints := cm.store.Config[0].Endpoints
-	if !assert.Len(t, endpoints, 2,
-		"same explicit ID + different address must append a suffixed endpoint, not overwrite") {
+	if !assert.Len(t, endpoints, 1,
+		"address-changing replace must keep exactly one endpoint, not append a sibling") {
 		return
 	}
 	assert.Equal(t, "ep-1", endpoints[0].ID)
-	assert.Equal(t, "ep-1-2", endpoints[1].ID)
-
+	assert.Equal(t, "127.0.0.2", endpoints[0].Address.Address)
 	if assert.NotNil(t, endpoints[0].LLMMeta) {
-		assert.Equal(t, "old-key", endpoints[0].LLMMeta.APIKey,
-			"the old slot's LLMMeta survives an additive SetEndpoint untouched")
+		assert.Equal(t, "new-key", endpoints[0].LLMMeta.APIKey,
+			"incoming LLMMeta replaces the prior slot's LLMMeta — the update represents the instance's current state")
 	}
-	assert.Equal(t, storedOld.Address, endpoints[0].Address,
-		"the old slot's address must not be overwritten by the colliding call")
-	assert.Nil(t, endpoints[1].LLMMeta, "the appended endpoint inherits nothing from the old slot")
-	assert.Nil(t, incoming.LLMMeta, "input endpoint is not mutated")
+	assert.Equal(t, "new-key", incoming.LLMMeta.APIKey, "input endpoint is not mutated")
 }
 
-// TestClusterManager_SetEndpointExplicitSameIDDifferentAddressAppendsSuffix
-// is the reviewer's direct repro for PR-3 dynamic-path dedup. Two
-// SetEndpoint calls that share an explicit ID but route to different
-// addresses must produce two endpoints (the second suffixed -2), not a
-// silent merge.
-func TestClusterManager_SetEndpointExplicitSameIDDifferentAddressAppendsSuffix(t *testing.T) {
+// TestClusterManager_SetEndpointExplicitSameIDDifferentAddressOverwritesInPlace
+// locks the registry-update contract: when two SetEndpoint calls share an
+// explicit ID but route to different addresses, the second call represents
+// "the same instance moved to a new address" (Nacos/SpringCloud OnUpdate),
+// not "two distinct endpoints that happen to collide". The cluster must end
+// up with exactly one endpoint at the new address, not two suffixed siblings
+// — otherwise registry update events accumulate stale endpoints over time.
+func TestClusterManager_SetEndpointExplicitSameIDDifferentAddressOverwritesInPlace(t *testing.T) {
 	cm := testClusterManager(testCluster("c", model.LoadBalancerRoundRobin, nil))
 	defer stopStoreRuntimes(cm.store)
 
@@ -647,15 +646,14 @@ func TestClusterManager_SetEndpointExplicitSameIDDifferentAddressAppendsSuffix(t
 	cm.SetEndpoint("c", testEndpoint("foo", "127.0.0.2", 21101))
 
 	endpoints := cm.store.Config[0].Endpoints
-	if !assert.Len(t, endpoints, 2,
-		"two SetEndpoint calls with the same explicit ID but different addresses "+
-			"must keep both endpoints, not silently overwrite the first") {
+	if !assert.Len(t, endpoints, 1,
+		"same explicit ID across two SetEndpoint calls represents the same instance; "+
+			"the second call must overwrite the slot, not accumulate a -2 sibling") {
 		return
 	}
 	assert.Equal(t, "foo", endpoints[0].ID)
-	assert.Equal(t, "foo-2", endpoints[1].ID)
-	assert.Equal(t, "127.0.0.1", endpoints[0].Address.Address)
-	assert.Equal(t, "127.0.0.2", endpoints[1].Address.Address)
+	assert.Equal(t, "127.0.0.2", endpoints[0].Address.Address)
+	assert.Equal(t, 21101, endpoints[0].Address.Port)
 }
 
 // TestClusterManager_SetEndpointExplicitSameIDSameContentIsIdempotent locks
@@ -788,6 +786,183 @@ func TestClusterManager_SetEndpointNameOnlyChangeIsIdempotent(t *testing.T) {
 			"if this assertion ever flips, update the SetEndpoint contract documentation too")
 }
 
+// TestClusterManager_SetEndpointMetadataOnlyChangeInheritsHealth locks the
+// runtime side of the address-equal replace case. Pure metadata updates
+// (same ID, same address, Metadata changed) must not restart the
+// address-keyed healthcheck — that would discard a known-unhealthy verdict
+// and briefly route to a node we already know is bad. The snapshot rebuild
+// in newEndpointSnapshot inherits health by ID-and-address; this test
+// pins that the wiring through SetEndpoint actually triggers that path.
+func TestClusterManager_SetEndpointMetadataOnlyChangeInheritsHealth(t *testing.T) {
+	addr := model.SocketAddress{Address: "127.0.0.1", Port: 21160}
+	original := &model.Endpoint{
+		ID:       "ep-1",
+		Address:  addr,
+		Metadata: map[string]string{"version": "v1"},
+	}
+	config := testCluster("metadata-inherits-health", model.LoadBalancerRoundRobin,
+		[]*model.Endpoint{original}, testHealthCheck())
+	cm := testClusterManager(config)
+	defer stopStoreRuntimes(cm.store)
+
+	runtime := cm.store.clustersMap[config.Name]
+	if !assert.NotNil(t, runtime) {
+		return
+	}
+
+	assert.True(t, runtime.UpdateEndpointHealth("ep-1", addr.GetAddress(), false),
+		"baseline: mark the endpoint unhealthy so we can observe whether the metadata "+
+			"update preserves the runtime verdict")
+	if !assert.Nil(t, runtime.EndpointSnapshot().HealthyEndpointByID("ep-1"),
+		"endpoint must be unhealthy in the snapshot before the metadata update") {
+		return
+	}
+
+	cm.SetEndpoint(config.Name, &model.Endpoint{
+		ID:       "ep-1",
+		Address:  addr,
+		Metadata: map[string]string{"version": "v2"},
+	})
+
+	runtime = cm.store.clustersMap[config.Name]
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 1, "address-equal metadata update must not grow the endpoint slice") {
+		return
+	}
+	assert.Equal(t, "ep-1", endpoints[0].ID)
+	assert.Equal(t, "v2", endpoints[0].Metadata["version"],
+		"the new metadata must be published after the replace")
+
+	assert.Nil(t, runtime.EndpointSnapshot().HealthyEndpointByID("ep-1"),
+		"address-equal metadata update must NOT reset the runtime health verdict; "+
+			"the endpoint was unhealthy before and must stay unhealthy after")
+	assert.Equal(t, 1, healthCheckersLen(runtime),
+		"address-equal replace must not restart the address-keyed healthcheck")
+}
+
+// TestClusterManager_SetEndpointCertsDirChangeReplacesWithoutHealthcheckRestart
+// pins the deliberate divergence between socketAddressContentEqual (used
+// for dedup) and SocketAddress.GetAddress() (used for healthcheck keying).
+// A SetEndpoint call that changes only CertsDir while keeping the same
+// host/port is content-different (so the slot is replaced and the new
+// CertsDir is published) but address-equal (so the healthcheck is NOT
+// restarted — the backend is still reachable at the same address). If a
+// future refactor accidentally collapses these two equality oracles, this
+// test fails on the "CertsDir didn't update" side or the "healthcheck got
+// restarted on a TLS-only change" side; either is a real regression worth
+// surfacing.
+func TestClusterManager_SetEndpointCertsDirChangeReplacesWithoutHealthcheckRestart(t *testing.T) {
+	addr := model.SocketAddress{Address: "127.0.0.1", Port: 21190, CertsDir: "/etc/certs/v1"}
+	original := &model.Endpoint{ID: "ep-1", Address: addr}
+	config := testCluster("certs-dir-replace", model.LoadBalancerRoundRobin,
+		[]*model.Endpoint{original}, testHealthCheck())
+	cm := testClusterManager(config)
+	defer stopStoreRuntimes(cm.store)
+
+	runtime := cm.store.clustersMap[config.Name]
+	if !assert.NotNil(t, runtime) {
+		return
+	}
+	originalCheckers := healthCheckerAddresses(runtime)
+
+	newAddr := model.SocketAddress{Address: "127.0.0.1", Port: 21190, CertsDir: "/etc/certs/v2"}
+	cm.SetEndpoint(config.Name, &model.Endpoint{ID: "ep-1", Address: newAddr})
+
+	runtime = cm.store.clustersMap[config.Name]
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 1,
+		"CertsDir-only change is content-different (Replace), so the slot must NOT accumulate "+
+			"a -2 sibling — that would be the dedup oracle agreeing with the address oracle, "+
+			"which is exactly the conflation this test guards against") {
+		return
+	}
+	assert.Equal(t, "ep-1", endpoints[0].ID)
+	assert.Equal(t, "/etc/certs/v2", endpoints[0].Address.CertsDir,
+		"the new CertsDir must be published — Replace overwrites the slot's TLS config")
+
+	assert.ElementsMatch(t, originalCheckers, healthCheckerAddresses(runtime),
+		"CertsDir change does not move the backend address, so the healthcheck registration "+
+			"must not flip; restarting it would briefly route to an unprobed address for no "+
+			"reason (TLS cert dir is irrelevant to L4 reachability)")
+}
+
+
+// runtime side of the address-changing replace case. When SetEndpoint
+// overwrites a slot with a new address, the old address's healthcheck
+// must stop (no goroutine leak) and a fresh checker must start against
+// the new address. Goroutine accounting via healthCheckersLen would catch
+// the leak only if the new checker also started; "old leaked, new never
+// started" gives the same count of 1. So we also assert the registered
+// address key flipped to the new address — the count + key together pin
+// "old stopped AND new started".
+func TestClusterManager_SetEndpointAddressChangeRestartsHealthcheck(t *testing.T) {
+	oldEndpoint := testEndpoint("ep-1", "127.0.0.1", 21170)
+	oldAddr := oldEndpoint.Address.GetAddress()
+	config := testCluster("address-restart", model.LoadBalancerRoundRobin,
+		[]*model.Endpoint{oldEndpoint}, testHealthCheck())
+	cm := testClusterManager(config)
+	defer stopStoreRuntimes(cm.store)
+
+	runtime := cm.store.clustersMap[config.Name]
+	if !assert.NotNil(t, runtime) {
+		return
+	}
+	if !assert.ElementsMatch(t, []string{oldAddr}, healthCheckerAddresses(runtime),
+		"baseline: exactly one healthcheck, keyed by the original address") {
+		return
+	}
+
+	newEndpoint := testEndpoint("ep-1", "127.0.0.2", 21171)
+	newAddr := newEndpoint.Address.GetAddress()
+	cm.SetEndpoint(config.Name, newEndpoint)
+
+	runtime = cm.store.clustersMap[config.Name]
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 1, "address-changing replace must keep exactly one endpoint") {
+		return
+	}
+	assert.Equal(t, "127.0.0.2", endpoints[0].Address.Address)
+	assert.ElementsMatch(t, []string{newAddr}, healthCheckerAddresses(runtime),
+		"address-changing replace must stop the old address's healthcheck AND start the new one; "+
+			"keys must equal exactly {newAddr} — {oldAddr} means new-never-started, "+
+			"{oldAddr,newAddr} means old leaked")
+}
+
+// TestClusterManager_SetEndpointRepeatedUpdatesDoNotGrowEndpoints simulates
+// the long-running regression the registry-update path would have hit:
+// SpringCloud/Nacos firing OnUpdateServiceInstance repeatedly for the same
+// instance as its address shifts. Under the old "append -2" semantics the
+// endpoint slice grew unboundedly on every update; under the replace
+// semantics it must stay at exactly one entry no matter how many updates
+// arrive. healthcheck count likewise stays at one.
+func TestClusterManager_SetEndpointRepeatedUpdatesDoNotGrowEndpoints(t *testing.T) {
+	config := testCluster("update-accumulation", model.LoadBalancerRoundRobin,
+		[]*model.Endpoint{testEndpoint("ep-1", "127.0.0.1", 21180)}, testHealthCheck())
+	cm := testClusterManager(config)
+	defer stopStoreRuntimes(cm.store)
+
+	const updates = 100
+	for i := 0; i < updates; i++ {
+		cm.SetEndpoint(config.Name, testEndpoint("ep-1", fmt.Sprintf("127.0.%d.%d", (i>>8)&0xff, i&0xff), 21181+i))
+	}
+
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 1,
+		"100 registry-update events for the same instance must collapse to one endpoint; "+
+			"any number > 1 means the dynamic SetEndpoint path is accumulating stale slots") {
+		return
+	}
+	assert.Equal(t, "ep-1", endpoints[0].ID)
+	lastAddr := fmt.Sprintf("127.0.%d.%d", ((updates-1)>>8)&0xff, (updates-1)&0xff)
+	assert.Equal(t, lastAddr, endpoints[0].Address.Address,
+		"the final endpoint must carry the last update's address")
+	assert.Equal(t, 21181+updates-1, endpoints[0].Address.Port)
+
+	runtime := cm.store.clustersMap[config.Name]
+	assert.Equal(t, 1, healthCheckersLen(runtime),
+		"healthcheck goroutines must not leak across repeated address-changing updates")
+}
+
 func TestClusterManager_AssembleEndpointsPreservesExplicitID(t *testing.T) {
 	cluster := &model.ClusterConfig{
 		Name:  "explicit-id",
@@ -918,4 +1093,22 @@ func healthCheckersLen(runtime *cluster.Cluster) int {
 		return 0
 	}
 	return reflect.ValueOf(runtime.HealthCheck).Elem().FieldByName("checkers").Len()
+}
+
+// healthCheckerAddresses returns the address keys currently registered
+// with the runtime's health checker. It exists so address-changing tests
+// can distinguish "old stopped + new started" (keys = {new}) from "old
+// leaked + new not started" (keys = {old}) — both states would otherwise
+// produce healthCheckersLen == 1 and look identical.
+func healthCheckerAddresses(runtime *cluster.Cluster) []string {
+	if runtime == nil || runtime.HealthCheck == nil {
+		return nil
+	}
+	checkers := reflect.ValueOf(runtime.HealthCheck).Elem().FieldByName("checkers")
+	addrs := make([]string, 0, checkers.Len())
+	iter := checkers.MapRange()
+	for iter.Next() {
+		addrs = append(addrs, iter.Key().String())
+	}
+	return addrs
 }

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -555,12 +555,12 @@ func TestClusterManager_AssembleEndpointsPreservesExplicitID(t *testing.T) {
 	}
 }
 
-// TestClusterManager_AssembleEndpointsCollapseDuplicateGenerated locks the
-// documented collapse behavior: two static endpoints sharing every input that
-// feeds GenerateEndpointID (cluster name, address, LLM credential) end up with
-// the same generated ID, and operators must set an explicit `id:` to keep
-// them distinct.
-func TestClusterManager_AssembleEndpointsCollapseDuplicateGenerated(t *testing.T) {
+// TestClusterManager_AssembleEndpointsDeduplicatesDuplicateGenerated locks
+// the PR-3 dedup behavior: when two static endpoints share every input that
+// feeds GenerateEndpointID (cluster name, address, LLM credential), the
+// second one's ID gets a -2 suffix so runtime health-key lookups stay
+// unambiguous. A warning is logged so the operator notices.
+func TestClusterManager_AssembleEndpointsDeduplicatesDuplicateGenerated(t *testing.T) {
 	cluster := &model.ClusterConfig{
 		Name:  "collapse-id",
 		LbStr: model.LoadBalancerRoundRobin,
@@ -578,11 +578,39 @@ func TestClusterManager_AssembleEndpointsCollapseDuplicateGenerated(t *testing.T
 		return
 	}
 
-	// Both endpoints survived in the slice (we do not silently dedupe) but
-	// share the same generated identifier.
-	assert.Equal(t, endpoints[0].ID, endpoints[1].ID,
-		"endpoints with identical hash material must collapse to the same ID")
+	assert.NotEqual(t, endpoints[0].ID, endpoints[1].ID,
+		"PR-3 deduplicates colliding generated IDs instead of collapsing them")
 	assert.Contains(t, endpoints[0].ID, "pixiu-generated-endpoint-")
+	assert.Equal(t, endpoints[0].ID+"-2", endpoints[1].ID,
+		"second endpoint must be suffixed -2 relative to the first")
+}
+
+// TestAssembleEndpointsDeduplicatesExplicitID locks Blocker 6: when an
+// operator writes the same `id:` on two static endpoints, the second one
+// becomes `<id>-2` rather than `generated-<hash>-2`. Most-readable
+// (least-surprising) choice for dashboards and log correlation.
+func TestAssembleEndpointsDeduplicatesExplicitID(t *testing.T) {
+	cluster := &model.ClusterConfig{
+		Name:  "explicit-id-collision",
+		LbStr: model.LoadBalancerRoundRobin,
+		Endpoints: []*model.Endpoint{
+			{ID: "foo", Address: model.SocketAddress{Address: "127.0.0.1", Port: 21090}},
+			{ID: "foo", Address: model.SocketAddress{Address: "127.0.0.1", Port: 21091}},
+		},
+	}
+
+	cm := testClusterManager(cluster)
+	defer stopStoreRuntimes(cm.store)
+
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 2) {
+		return
+	}
+
+	assert.Equal(t, "foo", endpoints[0].ID, "first explicit ID is preserved")
+	assert.Equal(t, "foo-2", endpoints[1].ID,
+		"colliding second endpoint must be suffixed off the operator's ID, "+
+			"not the generated- hash, so the operator's choice stays readable")
 }
 
 func testClusterManager(clusters ...*model.ClusterConfig) *ClusterManager {

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -457,7 +457,8 @@ func TestClusterManager_DeleteEndpointRepairsRuntimeAndConsistentHash(t *testing
 	assert.NotSame(t, staleRuntime, runtime)
 	assert.Same(t, config, runtime.Config)
 	if assert.Len(t, config.Endpoints, 1) {
-		assert.Same(t, remainingEndpoint, config.Endpoints[0])
+		assert.Equal(t, remainingEndpoint, config.Endpoints[0])
+		assert.NotSame(t, remainingEndpoint, config.Endpoints[0])
 	}
 
 	hash := config.ConsistentHash.Hash
@@ -536,6 +537,51 @@ func TestClusterManager_AssembleEndpointsAssignsDeterministicID(t *testing.T) {
 
 	// Endpoints differing only by port must not collide within the same cluster.
 	assert.NotEqual(t, firstEPs[0].ID, firstEPs[1].ID)
+}
+
+func TestClusterManager_AddClusterDoesNotMutateUserSuppliedEndpoint(t *testing.T) {
+	endpoint := &model.Endpoint{
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    21079,
+		},
+	}
+	cluster := &model.ClusterConfig{
+		Name:      "add-clone-boundary",
+		LbStr:     model.LoadBalancerRoundRobin,
+		Endpoints: []*model.Endpoint{endpoint},
+	}
+
+	cm := testClusterManager(cluster)
+	defer stopStoreRuntimes(cm.store)
+
+	assert.Empty(t, endpoint.ID)
+	assert.Empty(t, endpoint.Name)
+	assert.NotSame(t, endpoint, cm.store.Config[0].Endpoints[0])
+	assert.NotEmpty(t, cm.store.Config[0].Endpoints[0].ID)
+	assert.NotEmpty(t, cm.store.Config[0].Endpoints[0].Name)
+}
+
+func TestClusterManager_SetEndpointDoesNotMutateInputEndpoint(t *testing.T) {
+	cm := testClusterManager(testCluster("set-clone-boundary", model.LoadBalancerRoundRobin, nil))
+	defer stopStoreRuntimes(cm.store)
+
+	endpoint := &model.Endpoint{
+		Address: model.SocketAddress{
+			Address: "127.0.0.1",
+			Port:    21078,
+		},
+	}
+
+	cm.SetEndpoint("set-clone-boundary", endpoint)
+
+	assert.Empty(t, endpoint.ID)
+	assert.Empty(t, endpoint.Name)
+	if assert.Len(t, cm.store.Config[0].Endpoints, 1) {
+		assert.NotSame(t, endpoint, cm.store.Config[0].Endpoints[0])
+		assert.NotEmpty(t, cm.store.Config[0].Endpoints[0].ID)
+		assert.NotEmpty(t, cm.store.Config[0].Endpoints[0].Name)
+	}
 }
 
 func TestClusterManager_AssembleEndpointsPreservesExplicitID(t *testing.T) {

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -395,7 +395,14 @@ func TestClusterStore_EnsureRuntimeClustersRepairsRuntimeMap(t *testing.T) {
 	})
 }
 
-func TestClusterManager_SetEndpointUpdateRebuildsConsistentHash(t *testing.T) {
+// TestClusterManager_SetEndpointSuffixAppendRebuildsConsistentHash locks the
+// invariant that when a SetEndpoint call collides on explicit ID with an
+// existing endpoint but differs in routing identity, BOTH endpoints survive
+// (the second gets a -2 suffix) and the consistent hash reflects both hosts.
+// Previously the colliding call silently overwrote the original endpoint,
+// which made the PR-3 dedup rule effective only for static assembly and not
+// for the dynamic LLM/Nacos registration path.
+func TestClusterManager_SetEndpointSuffixAppendRebuildsConsistentHash(t *testing.T) {
 	tests := []model.LbPolicyType{
 		model.LoadBalancerRingHashing,
 		model.LoadBalancerMaglevHashing,
@@ -413,18 +420,25 @@ func TestClusterManager_SetEndpointUpdateRebuildsConsistentHash(t *testing.T) {
 			newHost := newEndpoint.GetHost()
 			cm.SetEndpoint(config.Name, newEndpoint)
 
+			endpoints := cm.store.Config[0].Endpoints
+			if !assert.Len(t, endpoints, 2, "duplicate explicit ID must produce a suffixed sibling, not overwrite") {
+				return
+			}
+			assert.Equal(t, "ep-1", endpoints[0].ID)
+			assert.Equal(t, "ep-1-2", endpoints[1].ID)
+
 			hash := cm.store.Config[0].ConsistentHash.Hash
 			if !assert.NotNil(t, hash) {
 				return
 			}
 			if hostList, ok := hash.(interface{ Hosts() []string }); ok {
 				hosts := hostList.Hosts()
-				assert.NotContains(t, hosts, oldHost)
-				assert.Contains(t, hosts, newHost)
+				assert.Contains(t, hosts, oldHost, "old host stays in the hash because the slot is preserved")
+				assert.Contains(t, hosts, newHost, "new host is rebuilt into the hash because the slot is appended")
 				return
 			}
-			assert.False(t, hash.Remove(oldHost))
-			assert.True(t, hash.Remove(newHost))
+			assert.True(t, hash.Remove(oldHost), "old host stays in the hash because the slot is preserved")
+			assert.True(t, hash.Remove(newHost), "new host is rebuilt into the hash because the slot is appended")
 		})
 	}
 }
@@ -584,7 +598,13 @@ func TestClusterManager_SetEndpointDoesNotMutateInputEndpoint(t *testing.T) {
 	}
 }
 
-func TestClusterManager_SetEndpointUpdateDoesNotShareOldLLMMeta(t *testing.T) {
+// TestClusterManager_SetEndpointSuffixAppendKeepsOldLLMMeta verifies that
+// when an incoming SetEndpoint call collides on explicit ID but differs in
+// routing identity, the original endpoint's LLMMeta is left untouched
+// because the new endpoint is appended with a -2 suffix instead of merged
+// into the old slot. This is the dynamic-path counterpart to the static
+// dedup test TestAssembleEndpointsDeduplicatesExplicitID.
+func TestClusterManager_SetEndpointSuffixAppendKeepsOldLLMMeta(t *testing.T) {
 	oldEndpoint := testEndpoint("ep-1", "127.0.0.1", 21077)
 	oldEndpoint.LLMMeta = &model.LLMMeta{APIKey: "old-key"}
 	config := testCluster("set-llm-meta-clone", model.LoadBalancerRoundRobin, []*model.Endpoint{oldEndpoint})
@@ -596,13 +616,176 @@ func TestClusterManager_SetEndpointUpdateDoesNotShareOldLLMMeta(t *testing.T) {
 
 	cm.SetEndpoint(config.Name, incoming)
 
-	updated := cm.store.Config[0].Endpoints[0]
-	if assert.NotNil(t, updated.LLMMeta) && assert.NotNil(t, storedOld.LLMMeta) {
-		assert.NotSame(t, storedOld.LLMMeta, updated.LLMMeta)
-		updated.LLMMeta.APIKey = "mutated-key"
-		assert.Equal(t, "old-key", storedOld.LLMMeta.APIKey)
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 2,
+		"same explicit ID + different address must append a suffixed endpoint, not overwrite") {
+		return
 	}
-	assert.Nil(t, incoming.LLMMeta)
+	assert.Equal(t, "ep-1", endpoints[0].ID)
+	assert.Equal(t, "ep-1-2", endpoints[1].ID)
+
+	if assert.NotNil(t, endpoints[0].LLMMeta) {
+		assert.Equal(t, "old-key", endpoints[0].LLMMeta.APIKey,
+			"the old slot's LLMMeta survives an additive SetEndpoint untouched")
+	}
+	assert.Equal(t, storedOld.Address, endpoints[0].Address,
+		"the old slot's address must not be overwritten by the colliding call")
+	assert.Nil(t, endpoints[1].LLMMeta, "the appended endpoint inherits nothing from the old slot")
+	assert.Nil(t, incoming.LLMMeta, "input endpoint is not mutated")
+}
+
+// TestClusterManager_SetEndpointExplicitSameIDDifferentAddressAppendsSuffix
+// is the reviewer's direct repro for PR-3 dynamic-path dedup. Two
+// SetEndpoint calls that share an explicit ID but route to different
+// addresses must produce two endpoints (the second suffixed -2), not a
+// silent merge.
+func TestClusterManager_SetEndpointExplicitSameIDDifferentAddressAppendsSuffix(t *testing.T) {
+	cm := testClusterManager(testCluster("c", model.LoadBalancerRoundRobin, nil))
+	defer stopStoreRuntimes(cm.store)
+
+	cm.SetEndpoint("c", testEndpoint("foo", "127.0.0.1", 21100))
+	cm.SetEndpoint("c", testEndpoint("foo", "127.0.0.2", 21101))
+
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 2,
+		"two SetEndpoint calls with the same explicit ID but different addresses "+
+			"must keep both endpoints, not silently overwrite the first") {
+		return
+	}
+	assert.Equal(t, "foo", endpoints[0].ID)
+	assert.Equal(t, "foo-2", endpoints[1].ID)
+	assert.Equal(t, "127.0.0.1", endpoints[0].Address.Address)
+	assert.Equal(t, "127.0.0.2", endpoints[1].Address.Address)
+}
+
+// TestClusterManager_SetEndpointExplicitSameIDSameContentIsIdempotent locks
+// the other side of the dedup contract: when two calls share the same
+// explicit ID AND the same routing-relevant content, the second call is a
+// re-registration (idempotent), not a duplicate that should accumulate.
+// This is the safety net so Nacos heartbeats don't grow the endpoint slice.
+func TestClusterManager_SetEndpointExplicitSameIDSameContentIsIdempotent(t *testing.T) {
+	cm := testClusterManager(testCluster("c", model.LoadBalancerRoundRobin, nil))
+	defer stopStoreRuntimes(cm.store)
+
+	cm.SetEndpoint("c", testEndpoint("foo", "127.0.0.1", 21110))
+	cm.SetEndpoint("c", testEndpoint("foo", "127.0.0.1", 21110))
+
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 1,
+		"same-content re-registration must be idempotent, never accumulate -N entries") {
+		return
+	}
+	assert.Equal(t, "foo", endpoints[0].ID)
+}
+
+// TestClusterManager_SetEndpointEmptyIDHashCollisionDifferentContentSuffixes
+// covers the empty-ID variant of the dedup contract. Two SetEndpoint calls
+// with empty IDs and the same hash material (so they resolve to the same
+// generated-* ID) but different non-hash content (Metadata) must produce
+// two endpoints — the second suffixed -2 — to stay consistent with how
+// assembleClusterEndpoints handles two static entries with identical hash
+// material.
+func TestClusterManager_SetEndpointEmptyIDHashCollisionDifferentContentSuffixes(t *testing.T) {
+	cm := testClusterManager(testCluster("c", model.LoadBalancerRoundRobin, nil))
+	defer stopStoreRuntimes(cm.store)
+
+	addr := model.SocketAddress{Address: "127.0.0.1", Port: 21120}
+	cm.SetEndpoint("c", &model.Endpoint{
+		Address:  addr,
+		Metadata: map[string]string{"region": "us-east"},
+	})
+	cm.SetEndpoint("c", &model.Endpoint{
+		Address:  addr,
+		Metadata: map[string]string{"region": "us-west"},
+	})
+
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 2,
+		"empty-ID calls with matching hash but differing Metadata must survive as siblings") {
+		return
+	}
+	baseID := model.GenerateEndpointID("c", &model.Endpoint{Address: addr})
+	assert.Equal(t, baseID, endpoints[0].ID)
+	assert.Equal(t, baseID+"-2", endpoints[1].ID)
+}
+
+// TestClusterManager_SetEndpointEmptyIDSameContentIsIdempotent guarantees
+// the natural idempotency of dynamic re-registration when callers leave the
+// ID empty: two byte-equal empty-ID SetEndpoint calls collapse to one
+// runtime endpoint, just like an explicit-ID idempotent call would.
+func TestClusterManager_SetEndpointEmptyIDSameContentIsIdempotent(t *testing.T) {
+	cm := testClusterManager(testCluster("c", model.LoadBalancerRoundRobin, nil))
+	defer stopStoreRuntimes(cm.store)
+
+	addr := model.SocketAddress{Address: "127.0.0.1", Port: 21130}
+	cm.SetEndpoint("c", &model.Endpoint{Address: addr})
+	cm.SetEndpoint("c", &model.Endpoint{Address: addr})
+
+	endpoints := cm.store.Config[0].Endpoints
+	assert.Len(t, endpoints, 1,
+		"empty-ID re-registration with identical content must collapse to one entry")
+}
+
+// TestClusterManager_SetEndpointEmptyIDReusesOperatorPinnedID locks truth-
+// table row 3: when an empty-ID SetEndpoint call hash-matches an existing
+// endpoint that carries an operator-pinned (non-generated) ID and is
+// content-equal, the pinned ID is reused — the dynamic path does NOT
+// override the operator's choice with a generated-* hash. Without this
+// test the empty-ID branch of resolveSetEndpointSlot could be silently
+// regressed to `return incomingHash, true` in a future refactor.
+//
+// Non-obvious dependency: assembleClusterEndpoints defaults the existing
+// pinned slot's Name to "endpoint-1" on first load while the incoming
+// arrives with Name="". The test passes because endpointContentEqualForSet
+// excludes Name from the equality check — see that helper's godoc. A
+// refactor that re-includes Name in equality would make this test fail
+// for a confusing reason (apparent content mismatch even though Address
+// and LLMMeta are identical); update endpointContentEqualForSet's
+// contract first if you change that.
+func TestClusterManager_SetEndpointEmptyIDReusesOperatorPinnedID(t *testing.T) {
+	addr := model.SocketAddress{Address: "127.0.0.1", Port: 21140}
+	pinned := &model.Endpoint{ID: "operator-pinned", Address: addr}
+	cm := testClusterManager(testCluster("c", model.LoadBalancerRoundRobin, []*model.Endpoint{pinned}))
+	defer stopStoreRuntimes(cm.store)
+
+	cm.SetEndpoint("c", &model.Endpoint{Address: addr})
+
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 1,
+		"empty-ID call with matching hash and content must reuse the pinned slot, not append") {
+		return
+	}
+	assert.Equal(t, "operator-pinned", endpoints[0].ID,
+		"the operator's pinned ID must survive empty-ID re-registration")
+}
+
+// TestClusterManager_SetEndpointNameOnlyChangeIsIdempotent locks the
+// deliberate trade-off documented on ClusterManager.SetEndpoint: Name is
+// excluded from the dedup content check, so a SetEndpoint call whose only
+// difference from an existing slot is Name is treated as an idempotent
+// re-registration. The original Name stays in place. Callers that need to
+// rename must DeleteEndpoint + SetEndpoint, or update the cluster config.
+//
+// Without this test we cannot tell whether the Name-not-applied behavior
+// is a deliberate contract or a latent bug, and the next refactor could
+// flip it silently.
+func TestClusterManager_SetEndpointNameOnlyChangeIsIdempotent(t *testing.T) {
+	addr := model.SocketAddress{Address: "127.0.0.1", Port: 21150}
+	original := &model.Endpoint{ID: "ep-1", Name: "original-name", Address: addr}
+	cm := testClusterManager(testCluster("c", model.LoadBalancerRoundRobin, []*model.Endpoint{original}))
+	defer stopStoreRuntimes(cm.store)
+
+	cm.SetEndpoint("c", &model.Endpoint{ID: "ep-1", Name: "renamed", Address: addr})
+
+	endpoints := cm.store.Config[0].Endpoints
+	if !assert.Len(t, endpoints, 1,
+		"Name-only change must NOT append a -2 sibling — that would grow the slice on harmless renames") {
+		return
+	}
+	assert.Equal(t, "ep-1", endpoints[0].ID)
+	assert.Equal(t, "original-name", endpoints[0].Name,
+		"the SetEndpoint godoc commits to not applying Name-only updates; "+
+			"if this assertion ever flips, update the SetEndpoint contract documentation too")
 }
 
 func TestClusterManager_AssembleEndpointsPreservesExplicitID(t *testing.T) {


### PR DESCRIPTION
## Summary

Migrates the cluster runtime endpoint view from mutable `Config.Endpoints` +
`Endpoint.UnHealthy` into an immutable `EndpointSnapshot` published via
`atomic.Pointer`. Request-path picks read snapshots; health updates and
membership changes go through CAS replacement instead of mutating shared
state.
## Architecture

- `Cluster.endpoints atomic.Pointer[EndpointSnapshot]` publishes the
  immutable view. Health updates produce a new snapshot via CAS.
- `EndpointSnapshot` indexes endpoints by ID, address, and health, all
  precomputed at publish time so the request path is O(1) on the healthy
  view instead of an O(N) scan over `ClusterConfig.Endpoints`.
- `PickContext` carries snapshot + config into load balancers. Bundled
  balancers (round-robin, rand, weight-random, ring-hash, maglev)
  implement `SnapshotLoadBalancer`; legacy balancers keep working via
  the compatibility adapter, which serializes them through a
  package-level lock.
- `healthcheck.HealthChecker` emits `EndpointHealthEvent` via callback;
  the legacy direct-mutation path (`CreateHealthCheck` without a
  callback) is preserved for existing callers.
- LLM proxy cooldown state moved out of `Endpoint.Metadata` into a
  process-wide bounded store (`maxCooldownStoreEntries = 1024`) with a
  throttled sweep.

## Operator-visible behavior changes

(For the maintainer writing release notes — these belong in the
next CHANGELOG entry.)

- **Endpoint state is immutable post-publish.** Direct mutation of
  `Endpoint.UnHealthy` or `Endpoint.Metadata` after cluster start is no
  longer observed by the request path. Health updates go through
  `Cluster.UpdateEndpointHealth` / health-check callbacks; membership
  changes go through `Cluster.RefreshEndpoints`.
- **`Endpoint.UnHealthy` post-init mutation is no longer observed by the
  request path.** Code that flips `endpoint.UnHealthy = true/false` after
  the cluster has started will see no effect on which endpoints get picked;
  the snapshot is built once and only updated via
  `Cluster.UpdateEndpointHealth` (or via the health-check callback).
  Upgrade impact: any external integration that flipped this field
  directly will silently stop functioning. The healthcheck legacy path
  (`CreateHealthCheck` without callback) still mutates the field for
  backward compatibility, but pickers do not read it.
- **LLM proxy cooldown** moved out of `Endpoint.Metadata` into a
  bounded process-wide store. Constants `LLMUnhealthyKey` and
  `HealthyCheckTimeKey` are no longer written by the filter and are
  marked deprecated in source; suggest removal in v1.3.
- **Endpoint ID dedup** changed from "warn but allow collision" to
  "first wins, second gets a `-2` suffix". Operator-supplied colliding
  IDs become `<id>-2` (not `generated-<hash>-2`) so dashboards stay
  readable.
- **Health-check thresholds now actually take effect.** The
  `HealthyThreshold` / `UnhealthyThreshold` config values used to be
  compared against an uninitialized counter that was always zero, so
  any deployment's first probe flipped state regardless of config; on
  the non-timeout failure path there was no counter at all. Defaults
  remain 5/5. Deployments that depended on fire-on-first-probe should
  set both thresholds to `1` explicitly. Mixed timeout + negative
  responses now share one counter, so the threshold applies to total
  consecutive failures.

- **Endpoint ID is a trust boundary in the snapshot pick path.** When a
  snapshot endpoint's address is a blank-domain placeholder
  (`Domains == [""]`, `Address == ""`, `Port == 0`),
  `sameEndpointIdentity` accepts any balancer-returned address as long as
  the endpoint ID matches. This is a narrow wildcard for legacy resolvers
  that publish placeholder endpoints to be resolved downstream. Operators
  must treat endpoint IDs as system-controlled values; do not let untrusted
  input populate `endpoint.id` on a placeholder endpoint, because the ID
  alone is sufficient to match any picked address through that placeholder.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — the only failure is
      `pkg/cluster/healthcheck/TestCheckTcpConn/failed_connection_due_to_invalid_address_format`,
      which fails on the base branch too (pre-existing, unrelated).
- [x] `go test -race ./pkg/cluster/... ./pkg/server/ ./pkg/cluster/loadbalancer/...
      ./pkg/filter/llm/proxy/ ./pkg/adapter/llmregistry/registry/nacos/
      ./pkg/model/`
- [x] `go test -race -count=20 -run TestClusterRefreshAndHealthUpdateConcurrent
      ./pkg/cluster/` — locks the snapshot CAS invariant under concurrent
      `RefreshEndpoints` + `UpdateEndpointHealth` writers.
- [x] `go test -bench=. -benchmem -count=3 ./pkg/server/` — numbers below.
- [x] `go mod tidy && git diff --quiet go.mod go.sum`
- [x] Optional pre-merge soak (PR author or release owner):
      deploy a race-detector build to staging after code review approval;
      observe `pixiu_request_elapsed` p99 drift < 20% and zero `DATA RACE` /
      `panic:` over 24h. Not required for local review; run only if staging
      capacity is available.

## Benchmark (Apple M5)

Request-path endpoint retrieval on the snapshot pick path
(`HealthyEndpointsForPick`, which the actual request handler uses):

```
endpoints=8    healthy=100%   0.46 ns/op   0 B/op   0 allocs/op
endpoints=64   healthy=100%   0.46 ns/op   0 B/op   0 allocs/op
endpoints=512  healthy=100%   0.46 ns/op   0 B/op   0 allocs/op
```

For comparison, the defensive `HealthyEndpoints()` accessor (used by
external callers that need an isolated slice — not the request path):

```
endpoints=8    healthy=100%      279 ns/op    1216 B/op    9 allocs/op
endpoints=64   healthy=100%     2157 ns/op    9728 B/op   65 allocs/op
endpoints=512  healthy=100%    17099 ns/op   78592 B/op  513 allocs/op
```

End-to-end pick (`PickEndpoint` through round-robin):

```
clusters=1     RoundRobin     130 ns/op    144 B/op   1 allocs/op
clusters=1024  RoundRobin     147 ns/op    144 B/op   1 allocs/op
```

## Known follow-ups (separate issues, all filed before merge)
- #1045 — Optimize full rebuilds of RingHash and Maglev in endpoint snapshots.
- #938 — collapse `EndpointChecker.HandleFailure(timeout bool)` in the next major release.
- #939 — drop `sharedCooldownStore` global and inject cooldownStore via `ClusterManager`.
- #940 — avoid double-cloning endpoints across the assemble/publish boundary.
- #941 — move `ZeroCopy` / `HealthyOnly` snapshot marker interfaces behind an internal boundary.
- #942 — cache consistent hash when the healthy endpoint set is unchanged.
- #943 — replace O(N) cooldown LRU eviction with `container/list`.
- #944 — add snapshot publish and endpoint count metrics.
- #945 — enable staticcheck SA1019 for deprecated symbol usage.
- #949 — RFC: treat duplicate endpoint IDs as a hard configuration error
  (raised in https://github.com/apache/dubbo-go-pixiu/pull/932#issuecomment-4566120689)
- #950 — chore: audit "unified static/dynamic" helpers in pkg/server/cluster_manager.go

## Reviewer-raised items intentionally kept

- **`EndpointSnapshot` nil-receiver guards on accessor methods** — kept for a consistent nil-safe accessor surface.
- **Public `Cluster.Config`** — making it private is intentionally out of scope; it touches many callsites and belongs in the later decoupling series.
- **`compareAndSetStore` Version equality** — pre-existing behavior, not introduced by this PR.
- **`assembleClusterEndpoints` plus snapshot double-clone** — tracked in #940 so clone-boundary semantics can be reviewed separately from the snapshot mechanism.

## Out of scope (tracked as tech debt)
- `Cluster.Config` remains public in this PR. Making it private + adding
  getters touches ~20 callsites and belongs in the decoupling series after
  PR-3 lands; target: decoupling PR-6, together with runtime ownership cleanup.
- `LLMUnhealthyKey` / `HealthyCheckTimeKey` are deprecated here for downstream
  compatibility. Target removal: v1.3 cleanup PR, after one minor-release
  migration window.