### PR TITLE
fix(loadbalancer/maglev): satisfy benchmark lint

### DIFF
--- a/pkg/cluster/loadbalancer/maglev/permutation.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation.go
@@ -18,6 +18,7 @@
 package maglev
 
 import (
+	"crypto/sha3"
 	"encoding/binary"
 	"math"
 	"math/big"
@@ -30,7 +31,6 @@ import (
 	"github.com/pkg/errors"
 
 	"golang.org/x/crypto/blake2b"
-	"golang.org/x/crypto/sha3"
 )
 
 // Default table size support maximum 10,000 endpoints

--- a/pkg/cluster/loadbalancer/maglev/permutation_bench_test.go
+++ b/pkg/cluster/loadbalancer/maglev/permutation_bench_test.go
@@ -18,13 +18,10 @@
 package maglev
 
 import (
+	"crypto/sha3"
 	"encoding/binary"
 	"hash/maphash"
 	"testing"
-)
-
-import (
-	"golang.org/x/crypto/sha3"
 )
 
 var benchmarkHashSink uint32


### PR DESCRIPTION
## What

Follow up on #928 after running newer golangci-lint checks. Switch the Maglev SHA3 imports from `golang.org/x/crypto/sha3` to the standard library `crypto/sha3`.

## Why

`golangci-lint` 2.12.2 enables the `govet` inline analyzer. Recent `golang.org/x/crypto/sha3` wrappers carry `//go:fix inline` directives pointing callers to the standard library SHA3 package, so the new benchmark code was reported as:

```text
inline: Call of sha3.Sum512 should be inlined
```

Using `crypto/sha3` directly is the intended migration path and avoids future full-package lint noise in `permutation.go` too.

## Tests

- [x] `gofmt -w pkg/cluster/loadbalancer/maglev/permutation.go pkg/cluster/loadbalancer/maglev/permutation_bench_test.go`
- [x] `gofmt -s -w pkg/cluster/loadbalancer/maglev/permutation.go pkg/cluster/loadbalancer/maglev/permutation_bench_test.go`
- [x] `imports-formatter`
- [x] `git diff --check`
- [x] `go test ./pkg/cluster/loadbalancer/maglev`
- [x] `golangci-lint 2.12.2 run --new-from-rev upstream/develop ./pkg/cluster/loadbalancer/maglev/...`
- [x] `golangci-lint 2.12.2 run --new-from-rev origin/develop ./pkg/cluster/loadbalancer/maglev/...`
- [x] `go test ./pkg/cluster/loadbalancer/maglev -run '^$' -bench 'BenchmarkLookUpTable(Hash|Get)$' -benchtime=100ms`
