### PR TITLE
style: fix import ordering in filter_sse_test.go to pass gofmt

### DIFF
--- a/pkg/filter/mcp/mcpserver/filter_sse_test.go
+++ b/pkg/filter/mcp/mcpserver/filter_sse_test.go
@@ -28,10 +28,10 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-pixiu/pkg/client"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
 	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
-	"github.com/apache/dubbo-go-pixiu/pkg/client"
 	"github.com/apache/dubbo-go-pixiu/pkg/filter/mcp/mcpserver/transport"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )


### PR DESCRIPTION
What this PR does:
Fix import ordering in pkg/filter/mcp/mcpserver/filter_sse_test.go to comply with gofmt -s requirements, resolving the CI formatting failure encountered in the previous PR.

Which issue(s) this PR fixes:
N/A (no linked issue)

Special notes for your reviewer:
This PR makes no logic changes — only code formatting. The CI command gofmt -s -w previously reported a diff because the import block was not sorted alphabetically. After running gofmt -s -w on the single file, the ordering is now correct.

Does this PR introduce a user-facing change?:
NONE

release-note
NONE