### PR TITLE
Feat/reuse snapshot consistent hash

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -616,48 +616,16 @@ func sameHealthyEndpointsForConsistentHash(previous, next *EndpointSnapshot) boo
 		return false
 	}
 	for i := range previous.healthy {
-		if !sameEndpointForConsistentHash(previous.healthy[i], next.healthy[i]) {
+		if !sameEndpointHostForConsistentHash(previous.healthy[i], next.healthy[i]) {
 			return false
 		}
 	}
 	return true
 }
 
-func sameEndpointForConsistentHash(a, b *model.Endpoint) bool {
+func sameEndpointHostForConsistentHash(a, b *model.Endpoint) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	if a.ID != b.ID {
-		return false
-	}
-	if !sameEndpointAddressForConsistentHash(a.Address, b.Address) {
-		return false
-	}
-	return sameHashRelevantMetadata(a.Metadata, b.Metadata)
-}
-
-func sameEndpointAddressForConsistentHash(a, b model.SocketAddress) bool {
-	aHasDomain := len(a.Domains) > 0
-	bHasDomain := len(b.Domains) > 0
-	if aHasDomain != bHasDomain {
-		return false
-	}
-
-	if aHasDomain && a.Domains[0] != b.Domains[0] {
-		return false
-	}
-
-	return a.Address == b.Address && a.Port == b.Port
-}
-
-func sameHashRelevantMetadata(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for key, aValue := range a {
-		if b[key] != aValue {
-			return false
-		}
-	}
-	return true
+	return a.Address.Address == b.Address.Address && a.Address.Port == b.Address.Port
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -197,6 +197,7 @@ type EndpointSnapshot struct {
 	healthyByAddress     map[string]bool
 	lbPolicy             model.LbPolicyType
 	consistentHashOnce   sync.Once
+	consistentHashMu     sync.RWMutex
 	consistentHash       model.LbConsistentHashView
 	consistentHashConfig model.ConsistentHash
 }
@@ -248,6 +249,7 @@ func newEndpointSnapshot(config *model.ClusterConfig, previous *EndpointSnapshot
 		healthy := endpointSnapshotHealth(snapshotEndpoint, address, previous, inheritRuntimeHealth)
 		snapshot.addEndpoint(snapshotEndpoint, address, healthy)
 	}
+	snapshot.reuseHealthyConsistentHashFrom(previous)
 	return snapshot
 }
 
@@ -395,7 +397,34 @@ func (s *EndpointSnapshot) HealthyConsistentHash() model.LbConsistentHashView {
 		return nil
 	}
 	s.consistentHashOnce.Do(s.rebuildConsistentHash)
+	return s.cachedHealthyConsistentHash()
+}
+
+func (s *EndpointSnapshot) cachedHealthyConsistentHash() model.LbConsistentHashView {
+	if s == nil {
+		return nil
+	}
+	s.consistentHashMu.RLock()
+	defer s.consistentHashMu.RUnlock()
 	return s.consistentHash
+}
+
+func (s *EndpointSnapshot) seedHealthyConsistentHash(hash model.LbConsistentHashView) {
+	if s == nil || hash == nil {
+		return
+	}
+	s.consistentHashOnce.Do(func() {
+		s.storeHealthyConsistentHash(hash)
+	})
+}
+
+func (s *EndpointSnapshot) storeHealthyConsistentHash(hash model.LbConsistentHashView) {
+	if s == nil || hash == nil {
+		return
+	}
+	s.consistentHashMu.Lock()
+	defer s.consistentHashMu.Unlock()
+	s.consistentHash = hash
 }
 
 // PickHealthyEndpoint gives request-path selectors a read-only view of healthy
@@ -534,6 +563,7 @@ func (s *EndpointSnapshot) withEndpointHealthForIDs(
 		}
 	}
 
+	next.reuseHealthyConsistentHashFrom(s)
 	return next, true
 }
 
@@ -545,5 +575,78 @@ func (s *EndpointSnapshot) rebuildConsistentHash() {
 	if !ok {
 		return
 	}
-	s.consistentHash = model.ReadOnlyConsistentHash(newConsistentHash(s.consistentHashConfig, s.healthy))
+	hash := model.ReadOnlyConsistentHash(newConsistentHash(s.consistentHashConfig, s.healthy))
+	s.storeHealthyConsistentHash(hash)
+}
+
+func (s *EndpointSnapshot) reuseHealthyConsistentHashFrom(previous *EndpointSnapshot) {
+	if !canReuseHealthyConsistentHash(previous, s) {
+		return
+	}
+	s.seedHealthyConsistentHash(previous.cachedHealthyConsistentHash())
+}
+
+func canReuseHealthyConsistentHash(previous, next *EndpointSnapshot) bool {
+	if previous == nil || next == nil {
+		return false
+	}
+	if previous.lbPolicy != next.lbPolicy {
+		return false
+	}
+	if _, ok := model.ConsistentHashInitMap[next.lbPolicy]; !ok {
+		return false
+	}
+	if !sameConsistentHashConfig(previous.consistentHashConfig, next.consistentHashConfig) {
+		return false
+	}
+	return sameHealthyEndpointsForConsistentHash(previous, next)
+}
+
+func sameConsistentHashConfig(a, b model.ConsistentHash) bool {
+	return a.ReplicaNum == b.ReplicaNum &&
+		a.MaxVnodeNum == b.MaxVnodeNum &&
+		a.MaglevTableSize == b.MaglevTableSize
+}
+
+func sameHealthyEndpointsForConsistentHash(previous, next *EndpointSnapshot) bool {
+	if previous == nil || next == nil {
+		return false
+	}
+	if len(previous.healthy) != len(next.healthy) {
+		return false
+	}
+	for i := range previous.healthy {
+		if !sameEndpointForConsistentHash(previous.healthy[i], next.healthy[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameEndpointForConsistentHash(a, b *model.Endpoint) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.ID != b.ID {
+		return false
+	}
+	if a.Address.GetAddress() != b.Address.GetAddress() {
+		return false
+	}
+	if a.GetHost() != b.GetHost() {
+		return false
+	}
+	return sameHashRelevantMetadata(a.Metadata, b.Metadata)
+}
+
+func sameHashRelevantMetadata(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, aValue := range a {
+		if b[key] != aValue {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -630,13 +630,24 @@ func sameEndpointForConsistentHash(a, b *model.Endpoint) bool {
 	if a.ID != b.ID {
 		return false
 	}
-	if a.Address.GetAddress() != b.Address.GetAddress() {
-		return false
-	}
-	if a.GetHost() != b.GetHost() {
+	if !sameEndpointAddressForConsistentHash(a.Address, b.Address) {
 		return false
 	}
 	return sameHashRelevantMetadata(a.Metadata, b.Metadata)
+}
+
+func sameEndpointAddressForConsistentHash(a, b model.SocketAddress) bool {
+	aHasDomain := len(a.Domains) > 0
+	bHasDomain := len(b.Domains) > 0
+	if aHasDomain != bHasDomain {
+		return false
+	}
+
+	if aHasDomain && a.Domains[0] != b.Domains[0] {
+		return false
+	}
+
+	return a.Address == b.Address && a.Port == b.Port
 }
 
 func sameHashRelevantMetadata(a, b map[string]string) bool {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -563,7 +563,6 @@ func (s *EndpointSnapshot) withEndpointHealthForIDs(
 		}
 	}
 
-	next.reuseHealthyConsistentHashFrom(s)
 	return next, true
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -189,6 +189,8 @@ func TestClusterEndpointSnapshotExposesReadOnlyConsistentHash(t *testing.T) {
 func TestClusterEndpointSnapshotBuildsConsistentHashLazily(t *testing.T) {
 	var builds int32
 	lbPolicy := model.LbPolicyType("test-lazy-hash")
+	// Mutates the global ConsistentHashInitMap; keep usage serial
+	// and do not add t.Parallel.
 	previousInit, hadPreviousInit := model.ConsistentHashInitMap[lbPolicy]
 	model.ConsistentHashInitMap[lbPolicy] = func(_ model.ConsistentHash, endpoints []*model.Endpoint) model.LbConsistentHash {
 		atomic.AddInt32(&builds, 1)
@@ -371,7 +373,7 @@ func TestClusterEndpointSnapshotDoesNotReuseConsistentHashWhenHashConfigChanges(
 		"hash config change must force a fresh consistent hash")
 }
 
-func TestClusterEndpointSnapshotDoesNotReuseConsistentHashWhenMetadataChanges(t *testing.T) {
+func TestClusterEndpointSnapshotReusesConsistentHashWhenMetadataChanges(t *testing.T) {
 	var builds int32
 	lbPolicy := registerCountingConsistentHash(t, "test-reuse-hash-metadata-change", &builds)
 
@@ -389,8 +391,8 @@ func TestClusterEndpointSnapshotDoesNotReuseConsistentHashWhenMetadataChanges(t 
 	config.Endpoints[0] = movedWeight
 	next := newEndpointSnapshot(config, previous, false)
 	assert.NotNil(t, next.HealthyConsistentHash())
-	assert.Equal(t, int32(2), atomic.LoadInt32(&builds),
-		"metadata change must force a fresh consistent hash")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds),
+		"metadata-only change with unchanged hosts must reuse the previous consistent hash instead of rebuilding")
 }
 
 func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
@@ -705,6 +707,8 @@ func testSnapshotEndpointWithLLMMeta() *model.Endpoint {
 	return endpoint
 }
 
+// Mutates the global ConsistentHashInitMap; keep usage serial
+// and do not add t.Parallel.
 func registerCountingConsistentHash(t *testing.T, name string, builds *int32) model.LbPolicyType {
 	t.Helper()
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -247,6 +247,152 @@ func TestClusterEndpointSnapshotBuildsConsistentHashLazily(t *testing.T) {
 		"build count is monotonic, but per-flap rebuild count is not locked here")
 }
 
+func TestClusterEndpointSnapshotReusesConsistentHashForUnchangedHealthySet(t *testing.T) {
+	var builds int32
+	lbPolicy := registerCountingConsistentHash(t, "test-reuse-hash-unchanged", &builds)
+
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+	config := testCluster("snapshot-reuse-hash-unchanged", first, second)
+	config.LbStr = lbPolicy
+	config.ConsistentHash = model.ConsistentHash{ReplicaNum: 10, MaxVnodeNum: 1023, MaglevTableSize: 521}
+
+	previous := NewCluster(config).EndpointSnapshot()
+	previousHash := previous.HealthyConsistentHash()
+	assert.NotNil(t, previousHash)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+	next := newEndpointSnapshot(config, previous, false)
+	assert.Equal(t, previousHash, next.HealthyConsistentHash(),
+		"equivalent snapshot should reuse the previous hash view")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds),
+		"reused snapshot must not rebuild on first access")
+}
+
+func TestClusterEndpointSnapshotDoesNotReuseConsistentHashWhenHealthChangesHealthySet(t *testing.T) {
+	var builds int32
+	lbPolicy := registerCountingConsistentHash(t, "test-reuse-hash-health-change", &builds)
+
+	first := testEndpoint("ep-1", "127.0.0.1", 18080)
+	second := testEndpoint("ep-2", "127.0.0.1", 18081)
+	config := testCluster("snapshot-reuse-hash-health-change", first, second)
+	config.LbStr = lbPolicy
+
+	previous := NewCluster(config).EndpointSnapshot()
+	assert.NotNil(t, previous.HealthyConsistentHash())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+	next, ok := previous.withEndpointHealthForIDs(map[string]struct{}{second.ID: {}}, false)
+	assert.True(t, ok)
+	assert.NotNil(t, next.HealthyConsistentHash())
+	assert.Equal(t, int32(2), atomic.LoadInt32(&builds),
+		"health change that changes the healthy set must force a fresh consistent hash")
+}
+
+func TestClusterEndpointSnapshotDoesNotReuseConsistentHashWhenEndpointAddressChanges(t *testing.T) {
+	var builds int32
+	lbPolicy := registerCountingConsistentHash(t, "test-reuse-hash-address-change", &builds)
+
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
+	config := testCluster("snapshot-reuse-hash-address-change", endpoint)
+	config.LbStr = lbPolicy
+
+	previous := NewCluster(config).EndpointSnapshot()
+	assert.NotNil(t, previous.HealthyConsistentHash())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+	config.Endpoints[0] = testEndpoint("ep-1", "127.0.0.2", 18080)
+	next := newEndpointSnapshot(config, previous, false)
+	assert.NotNil(t, next.HealthyConsistentHash())
+	assert.Equal(t, int32(2), atomic.LoadInt32(&builds),
+		"address change must force a fresh consistent hash")
+}
+
+func TestClusterEndpointSnapshotDoesNotReuseConsistentHashWhenEndpointCountChanges(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints func(first, second, third *model.Endpoint) []*model.Endpoint
+	}{
+		{
+			name: "add",
+			endpoints: func(first, second, third *model.Endpoint) []*model.Endpoint {
+				return []*model.Endpoint{first, second, third}
+			},
+		},
+		{
+			name: "delete",
+			endpoints: func(first, second, third *model.Endpoint) []*model.Endpoint {
+				return []*model.Endpoint{first}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var builds int32
+			lbPolicy := registerCountingConsistentHash(t, "test-reuse-hash-count-change"+tt.name, &builds)
+
+			first := testEndpoint("ep-1", "127.0.0.1", 18080)
+			second := testEndpoint("ep-2", "127.0.0.1", 18081)
+			third := testEndpoint("ep-3", "127.0.0.1", 18082)
+			config := testCluster("snapshot-reuse-hash-count-change-"+tt.name, first, second)
+			config.LbStr = lbPolicy
+
+			previous := NewCluster(config).EndpointSnapshot()
+			assert.NotNil(t, previous.HealthyConsistentHash())
+			assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+			config.Endpoints = tt.endpoints(first, second, third)
+			next := newEndpointSnapshot(config, previous, false)
+			assert.NotNil(t, next.HealthyConsistentHash())
+			assert.Equal(t, int32(2), atomic.LoadInt32(&builds),
+				"count change must force a fresh consistent hash")
+		})
+	}
+}
+
+func TestClusterEndpointSnapshotDoesNotReuseConsistentHashWhenHashConfigChanges(t *testing.T) {
+	var builds int32
+	lbPolicy := registerCountingConsistentHash(t, "test-reuse-hash-config-change", &builds)
+
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
+	config := testCluster("snapshot-reuse-hash-config-change", endpoint)
+	config.LbStr = lbPolicy
+	config.ConsistentHash = model.ConsistentHash{ReplicaNum: 10, MaxVnodeNum: 1023, MaglevTableSize: 521}
+
+	previous := NewCluster(config).EndpointSnapshot()
+	assert.NotNil(t, previous.HealthyConsistentHash())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+	config.ConsistentHash.ReplicaNum = 20
+	next := newEndpointSnapshot(config, previous, false)
+	assert.NotNil(t, next.HealthyConsistentHash())
+	assert.Equal(t, int32(2), atomic.LoadInt32(&builds),
+		"hash config change must force a fresh consistent hash")
+}
+
+func TestClusterEndpointSnapshotDoesNotReuseConsistentHashWhenMetadataChanges(t *testing.T) {
+	var builds int32
+	lbPolicy := registerCountingConsistentHash(t, "test-reuse-hash-metadata-change", &builds)
+
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18080)
+	endpoint.Metadata = map[string]string{"weight": "10"}
+	config := testCluster("snapshot-reuse-hash-metadata-change", endpoint)
+	config.LbStr = lbPolicy
+
+	previous := NewCluster(config).EndpointSnapshot()
+	assert.NotNil(t, previous.HealthyConsistentHash())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+	movedWeight := testEndpoint("ep-1", "127.0.0.1", 18080)
+	movedWeight.Metadata = map[string]string{"weight": "20"}
+	config.Endpoints[0] = movedWeight
+	next := newEndpointSnapshot(config, previous, false)
+	assert.NotNil(t, next.HealthyConsistentHash())
+	assert.Equal(t, int32(2), atomic.LoadInt32(&builds),
+		"metadata change must force a fresh consistent hash")
+}
+
 func TestClusterEndpointSnapshotClonesConfigEndpointObjects(t *testing.T) {
 	endpoint := testSnapshotEndpointWithLLMMeta()
 	runtimeCluster := NewCluster(testCluster("snapshot-clone", endpoint))
@@ -557,6 +703,28 @@ func testSnapshotEndpointWithLLMMeta() *model.Endpoint {
 		},
 	}
 	return endpoint
+}
+
+func registerCountingConsistentHash(t *testing.T, name string, builds *int32) model.LbPolicyType {
+	t.Helper()
+
+	lbPolicy := model.LbPolicyType(name)
+	previousInit, hadPreviousInit := model.ConsistentHashInitMap[lbPolicy]
+	model.ConsistentHashInitMap[lbPolicy] = func(_ model.ConsistentHash, endpoints []*model.Endpoint) model.LbConsistentHash {
+		atomic.AddInt32(builds, 1)
+		if len(endpoints) == 0 {
+			return countingConsistentHash{}
+		}
+		return countingConsistentHash{host: endpoints[0].GetHost()}
+	}
+	t.Cleanup(func() {
+		if hadPreviousInit {
+			model.ConsistentHashInitMap[lbPolicy] = previousInit
+			return
+		}
+		delete(model.ConsistentHashInitMap, lbPolicy)
+	})
+	return lbPolicy
 }
 
 type countingConsistentHash struct {

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -34,9 +34,10 @@ import (
 
 var (
 	// Keep benchmark results live so the compiler cannot optimize the hot path away.
-	benchmarkEndpointSink  *model.Endpoint
-	benchmarkEndpointsSink []*model.Endpoint
-	benchmarkClusterSink   *model.ClusterConfig
+	benchmarkEndpointSink       *model.Endpoint
+	benchmarkEndpointsSink      []*model.Endpoint
+	benchmarkClusterSink        *model.ClusterConfig
+	benchmarkConsistentHashSink model.LbConsistentHashView
 )
 
 type benchmarkHashPolicy string
@@ -205,6 +206,50 @@ func BenchmarkClusterConsistentHashResolve(b *testing.B) {
 				benchmarkEndpointSink = cm.PickEndpoint(clusterName, keys[i%len(keys)])
 			}
 		})
+	}
+}
+
+func BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet(b *testing.B) {
+	for _, lbType := range []model.LbPolicyType{model.LoadBalancerRingHashing, model.LoadBalancerMaglevHashing} {
+		for _, endpointCount := range []int{1, 32, 256, 1024} {
+			name := fmt.Sprintf("%s/endpoints=%d", lbType, endpointCount)
+			b.Run(name, func(b *testing.B) {
+				b.Run("reuse-cached-previous", func(b *testing.B) {
+					benchmarkConsistentHashSnapshotRefresh(b, lbType, endpointCount, true)
+				})
+				b.Run("rebuild-uncached-previous", func(b *testing.B) {
+					benchmarkConsistentHashSnapshotRefresh(b, lbType, endpointCount, false)
+				})
+			})
+		}
+	}
+}
+
+func benchmarkConsistentHashSnapshotRefresh(
+	b *testing.B,
+	lbType model.LbPolicyType,
+	endpointCount int,
+	previousHashBuilt bool,
+) {
+	config := benchmarkClusterConfig("consistent-hash-refresh", lbType, endpointCount, 0)
+	previous := cluster.NewCluster(config).EndpointSnapshot()
+	if previousHashBuilt {
+		benchmarkConsistentHashSink = previous.HealthyConsistentHash()
+		if benchmarkConsistentHashSink == nil {
+			b.Fatal("expected previous consistent hash")
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtimeCluster := cluster.NewClusterWithEndpointSnapshot(config, previous)
+		next := runtimeCluster.EndpointSnapshot()
+		benchmarkConsistentHashSink = next.HealthyConsistentHash()
+	}
+	b.StopTimer()
+	if benchmarkConsistentHashSink == nil {
+		b.Fatal("expected consistent hash")
 	}
 }
 

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -34,9 +34,10 @@ import (
 
 var (
 	// Keep benchmark results live so the compiler cannot optimize the hot path away.
-	benchmarkEndpointSink  *model.Endpoint
-	benchmarkEndpointsSink []*model.Endpoint
-	benchmarkClusterSink   *model.ClusterConfig
+	benchmarkEndpointSink       *model.Endpoint
+	benchmarkEndpointsSink      []*model.Endpoint
+	benchmarkClusterSink        *model.ClusterConfig
+	benchmarkConsistentHashSink model.LbConsistentHashView
 )
 
 type benchmarkHashPolicy string
@@ -205,6 +206,44 @@ func BenchmarkClusterConsistentHashResolve(b *testing.B) {
 				benchmarkEndpointSink = cm.PickEndpoint(clusterName, keys[i%len(keys)])
 			}
 		})
+	}
+}
+
+func BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet(b *testing.B) {
+	for _, lbType := range []model.LbPolicyType{model.LoadBalancerRingHashing, model.LoadBalancerMaglevHashing} {
+		for _, endpointCount := range []int{1, 32, 256, 1024} {
+			b.Run(fmt.Sprintf("%s/endpoints=%d", lbType, endpointCount), func(b *testing.B) {
+				for _, cachedPrevious := range []bool{true, false} {
+					name := "rebuild-uncached-previous"
+					if cachedPrevious {
+						name = "reuse-cached-previous"
+					}
+
+					b.Run(name, func(b *testing.B) {
+						config := benchmarkClusterConfig("consistent-hash-refresh", lbType, endpointCount, 0)
+						previous := cluster.NewCluster(config).EndpointSnapshot()
+						if cachedPrevious {
+							benchmarkConsistentHashSink = previous.HealthyConsistentHash()
+							if benchmarkConsistentHashSink == nil {
+								b.Fatal("expected previous consistent hash")
+							}
+						}
+
+						b.ReportAllocs()
+						b.ResetTimer()
+						for i := 0; i < b.N; i++ {
+							runtimeCluster := cluster.NewClusterWithEndpointSnapshot(config, previous)
+							next := runtimeCluster.EndpointSnapshot()
+							benchmarkConsistentHashSink = next.HealthyConsistentHash()
+						}
+						b.StopTimer()
+						if benchmarkConsistentHashSink == nil {
+							b.Fatal("expected consistent hash")
+						}
+					})
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

This PR optimizes consistent hash reuse in `EndpointSnapshot`.

For consistent-hash load balancers such as RingHashing and MaglevHashing, when a new endpoint snapshot is published, if the new snapshot has the same routing-relevant healthy endpoint set as the previous snapshot and the consistent hash configuration is unchanged, the new snapshot reuses the previously built `consistentHash`. This avoids unnecessary CPU work and memory allocations caused by rebuilding the hash structure.

Main changes:

- Add safe cached consistent hash reuse logic to `EndpointSnapshot`.
  - Reuse the previous hash only when the following fields are equivalent:
    - load balancer policy
    - consistent hash config
    - healthy endpoint ID
    - healthy endpoint address / host
    - endpoint metadata
  - Forbid reuse when endpoints are added or removed, endpoint addresses change, the healthy endpoint set changes, the hash config changes, or metadata changes.
- Add unit tests for reusable and non-reusable cases:
  - Reuse is allowed when a health update does not change the healthy endpoint set.
  - Reuse is forbidden when a health update changes the healthy endpoint set.
  - Reuse is forbidden when an endpoint address changes.
  - Reuse is forbidden when an endpoint is added or deleted.
  - Reuse is forbidden when the consistent hash config changes.
  - Reuse is forbidden when endpoint metadata changes.
- Add benchmark coverage for snapshot refresh cost with unchanged healthy sets for RingHashing and MaglevHashing.

**Which issue(s) this PR fixes**:
Fixes #942

**Special notes for your reviewer**:

This PR does not make any out-of-scope changes and keeps the following constraints:

- Do not change consistent hash algorithms.
- Do not change endpoint identity generation.
- Do not reuse hashes based on slice pointer equality alone.
- Do not weaken health filtering.
- Keep lazy initialization behavior intact.

Verified with:

```bash
go test ./pkg/cluster/... ./pkg/server/... ./pkg/cluster/loadbalancer/...
go test -run '^$' -bench '^BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet$' -benchmem ./pkg/server
```

Output:

Unit tests:

```text
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster    (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/healthcheck        (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer       (cached)
?       github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/internal/lbtest       [no test files]
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev        (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/rand  (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/ringhash      (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/roundrobin    (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/weightrandom  (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/retry      (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/retry/countbased   (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/retry/exponentialbackoff   (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/cluster/retry/noretry      (cached)
ok      github.com/apache/dubbo-go-pixiu/pkg/server     (cached)
?       github.com/apache/dubbo-go-pixiu/pkg/server/controls    [no test files]
?       github.com/apache/dubbo-go-pixiu/pkg/server/controls/mocks      [no test files]
```

Benchmark:

```text
goos: darwin
goarch: arm64
pkg: github.com/apache/dubbo-go-pixiu/pkg/server
cpu: Apple M5
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/RingHashing/endpoints=1/reuse-cached-previous-10                1607060               746.3 ns/op          1976 B/op         30 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/RingHashing/endpoints=1/rebuild-uncached-previous-10              45808             26038 ns/op           20115 B/op        218 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/RingHashing/endpoints=32/reuse-cached-previous-10                 86304             13888 ns/op           23530 B/op        539 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/RingHashing/endpoints=32/rebuild-uncached-previous-10               387           3078728 ns/op          380584 B/op       5749 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/RingHashing/endpoints=256/reuse-cached-previous-10                10000            105583 ns/op          179754 B/op       4123 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/RingHashing/endpoints=256/rebuild-uncached-previous-10               20          54802988 ns/op         1528823 B/op      45423 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/RingHashing/endpoints=1024/reuse-cached-previous-10                2889            420657 ns/op          726992 B/op      16423 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/RingHashing/endpoints=1024/rebuild-uncached-previous-10               5         242039292 ns/op         4597780 B/op     181381 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/MaglevHashing/endpoints=1/reuse-cached-previous-10              1605380               749.8 ns/op          1976 B/op         30 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/MaglevHashing/endpoints=1/rebuild-uncached-previous-10           377761              3165 ns/op            9100 B/op         41 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/MaglevHashing/endpoints=32/reuse-cached-previous-10               86888             13777 ns/op           23529 B/op        539 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/MaglevHashing/endpoints=32/rebuild-uncached-previous-10            4636            253168 ns/op          766625 B/op        708 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/MaglevHashing/endpoints=256/reuse-cached-previous-10              13172             88850 ns/op          179687 B/op       4123 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/MaglevHashing/endpoints=256/rebuild-uncached-previous-10            164           7211631 ns/op        42814169 B/op       5413 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/MaglevHashing/endpoints=1024/reuse-cached-previous-10              2998            420360 ns/op          726738 B/op      16423 allocs/op
BenchmarkClusterConsistentHashSnapshotRefreshUnchangedHealthySet/MaglevHashing/endpoints=1024/rebuild-uncached-previous-10                     7         161302827 ns/op        514595870 B/op     21554 allocs/op
PASS
ok      github.com/apache/dubbo-go-pixiu/pkg/server     26.679s
```
**Does this PR introduce a user-facing change?**
```release-note
NONE
```