### PR TITLE
Feat(cluster): reduce endpoint cloning

### DIFF
--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -359,9 +359,6 @@ func (s *ClusterStore) AddCluster(c *model.ClusterConfig) {
 // prepareClusterConfig clones operator-supplied endpoints, then rebuilds
 // endpoint defaults and hash from current endpoints.
 func (s *ClusterStore) prepareClusterConfig(c *model.ClusterConfig) {
-	if c == nil {
-		return
-	}
 	c.Endpoints = model.CloneEndpoints(c.Endpoints)
 	s.prepareOwnedClusterConfig(c)
 }
@@ -370,20 +367,17 @@ func (s *ClusterStore) prepareClusterConfig(c *model.ClusterConfig) {
 // already owned by ClusterStore. Callers must not pass operator-owned endpoint
 // pointers here; use prepareClusterConfig at external input boundaries.
 func (s *ClusterStore) prepareOwnedClusterConfig(c *model.ClusterConfig) {
-	if c == nil {
-		return
-	}
 	s.assembleClusterEndpoints(c)
 	c.CreateConsistentHash()
 }
 
-// assembleClusterEndpoints assembles the cluster endpoints by formatting the
-// ID, name and domains for each endpoint. If endpoint.LLMMeta is not nil, the
-// assimilation of name and domain is based on the LLM provider denoted in the
-// endpoint LLMMeta. Callers choose the ownership boundary before invoking this
-// helper: external input paths clone endpoints in prepareClusterConfig, while
-// store-owned mutation paths call prepareOwnedClusterConfig to avoid a second
-// full endpoint clone before snapshot publication.
+// assembleClusterEndpoints assembles the cluster endpoints by assigning stable
+// unique IDs and default names for each endpoint. If endpoint.LLMMeta is not nil,
+// the default endpoint name is based on the LLM provider denoted in the endpoint
+// LLMMeta. Callers choose the ownership boundary before invoking this helper:
+// external input paths clone endpoints in prepareClusterConfig, while store-owned
+// mutation paths call prepareOwnedClusterConfig to avoid a second full endpoint
+// clone before snapshot publication.
 func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 	if c == nil {
 		return

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -356,8 +356,23 @@ func (s *ClusterStore) AddCluster(c *model.ClusterConfig) {
 	stopClusters([]*cluster.Cluster{s.replaceClusterRuntime(c.Name, c)})
 }
 
-// prepareClusterConfig rebuilds endpoint defaults and hash from current endpoints.
+// prepareClusterConfig clones operator-supplied endpoints, then rebuilds
+// endpoint defaults and hash from current endpoints.
 func (s *ClusterStore) prepareClusterConfig(c *model.ClusterConfig) {
+	if c == nil {
+		return
+	}
+	c.Endpoints = model.CloneEndpoints(c.Endpoints)
+	s.prepareOwnedClusterConfig(c)
+}
+
+// prepareOwnedClusterConfig rebuilds endpoint defaults and hash for endpoints
+// already owned by ClusterStore. Callers must not pass operator-owned endpoint
+// pointers here; use prepareClusterConfig at external input boundaries.
+func (s *ClusterStore) prepareOwnedClusterConfig(c *model.ClusterConfig) {
+	if c == nil {
+		return
+	}
 	s.assembleClusterEndpoints(c)
 	c.CreateConsistentHash()
 }
@@ -365,14 +380,15 @@ func (s *ClusterStore) prepareClusterConfig(c *model.ClusterConfig) {
 // assembleClusterEndpoints assembles the cluster endpoints by formatting the
 // ID, name and domains for each endpoint. If endpoint.LLMMeta is not nil, the
 // assimilation of name and domain is based on the LLM provider denoted in the
-// endpoint LLMMeta. The store first deep-clones c.Endpoints, so ID/name
-// defaulting never mutates operator-supplied *model.Endpoint values.
+// endpoint LLMMeta. Callers choose the ownership boundary before invoking this
+// helper: external input paths clone endpoints in prepareClusterConfig, while
+// store-owned mutation paths call prepareOwnedClusterConfig to avoid a second
+// full endpoint clone before snapshot publication.
 func (s *ClusterStore) assembleClusterEndpoints(c *model.ClusterConfig) {
 	if c == nil {
 		return
 	}
 
-	c.Endpoints = model.CloneEndpoints(c.Endpoints)
 	endpointIDs := make(map[string]struct{}, len(c.Endpoints))
 	for i, endpoint := range c.Endpoints {
 		if endpoint == nil {
@@ -642,7 +658,7 @@ func (s *ClusterStore) SetEndpoint(clusterName string, endpoint *model.Endpoint)
 		s.replaceEndpointAt(clusterConfig, runtimeCluster, outcome.replaceIdx, endpoint)
 	case setEndpointAppend:
 		clusterConfig.Endpoints = append(clusterConfig.Endpoints, endpoint)
-		s.prepareClusterConfig(clusterConfig)
+		s.prepareOwnedClusterConfig(clusterConfig)
 		runtimeCluster.RefreshEndpoints()
 		runtimeCluster.AddEndpoint(endpoint)
 	}
@@ -677,7 +693,7 @@ func (s *ClusterStore) replaceEndpointAt(
 		logSetEndpointOverwrite(clusterConfig.Name, endpoint.ID, old, endpoint)
 	}
 	clusterConfig.Endpoints[idx] = endpoint
-	s.prepareClusterConfig(clusterConfig)
+	s.prepareOwnedClusterConfig(clusterConfig)
 	runtimeCluster.RefreshEndpoints()
 	if addressChanged {
 		runtimeCluster.AddEndpoint(endpoint)
@@ -942,7 +958,7 @@ func (s *ClusterStore) DeleteEndpoint(clusterName string, endpointID string) {
 		if e.ID == endpointID {
 			runtimeCluster.RemoveEndpoint(e)
 			clusterConfig.Endpoints = append(clusterConfig.Endpoints[:i], clusterConfig.Endpoints[i+1:]...)
-			s.prepareClusterConfig(clusterConfig)
+			s.prepareOwnedClusterConfig(clusterConfig)
 			runtimeCluster.RefreshEndpoints()
 			return
 		}

--- a/pkg/server/cluster_manager.go
+++ b/pkg/server/cluster_manager.go
@@ -20,6 +20,7 @@ package server
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
 )
@@ -951,7 +952,7 @@ func (s *ClusterStore) DeleteEndpoint(clusterName string, endpointID string) {
 	for i, e := range clusterConfig.Endpoints {
 		if e.ID == endpointID {
 			runtimeCluster.RemoveEndpoint(e)
-			clusterConfig.Endpoints = append(clusterConfig.Endpoints[:i], clusterConfig.Endpoints[i+1:]...)
+			clusterConfig.Endpoints = slices.Delete(clusterConfig.Endpoints, i, i+1)
 			s.prepareOwnedClusterConfig(clusterConfig)
 			runtimeCluster.RefreshEndpoints()
 			return

--- a/pkg/server/cluster_manager_bench_test.go
+++ b/pkg/server/cluster_manager_bench_test.go
@@ -165,6 +165,39 @@ func benchmarkHealthySnapshotAccessor(
 	}
 }
 
+func BenchmarkClusterSetEndpointMembershipChurn(b *testing.B) {
+	endpointCount := 1000
+	clusterName := "endpoint-churn"
+
+	clusterConfig := benchmarkClusterConfig(clusterName, model.LoadBalancerRoundRobin, endpointCount, 0)
+	for _, endpoint := range clusterConfig.Endpoints {
+		endpoint.Metadata = map[string]string{
+			"first":  "0",
+			"second": "0",
+			"third":  "0",
+		}
+	}
+
+	cm := testClusterManager(clusterConfig)
+	endpoints := cm.store.Config[0].Endpoints
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		endpoint := endpoints[i%len(endpoints)]
+
+		cm.SetEndpoint(clusterName, &model.Endpoint{
+			ID:      endpoint.ID,
+			Address: endpoint.Address,
+			Metadata: map[string]string{
+				"first":  fmt.Sprintf("%d", i),
+				"second": fmt.Sprintf("%d", i),
+				"third":  fmt.Sprintf("%d", i),
+			},
+		})
+	}
+}
+
 func BenchmarkClusterCompareAndSetStoreMixed(b *testing.B) {
 	cm, names := benchmarkClusterManager(128, 4, model.LoadBalancerRoundRobin)
 	readIndex := 0


### PR DESCRIPTION
**What this PR does**:

This PR reduces duplicated endpoint deep clones in the `SetEndpoint` membership churn path, while preserving the existing ownership safety boundaries.

Specifically, this PR:

- Keeps the snapshot-side clone.

- Separates endpoint ID/name defaulting from the endpoint clone boundary.
  - For endpoints already owned by `ClusterStore` in the `SetEndpoint` / `DeleteEndpoint` paths, this PR uses a store-owned prepare path to avoid another full `CloneEndpoints`.
  - It keeps the store-side clone at external input boundaries, so Pixiu still does not mutate endpoint objects provided by callers.

- Adds a membership churn benchmark that measures repeated `SetEndpoint` metadata updates with 1000 endpoints.

This PR strictly follows these constraints:

- Do not change endpoint ID generation.
- Do not mutate user-supplied endpoint objects after `AddCluster` or `SetEndpoint`.
- Do not share snapshot-owned endpoint pointers with code that may mutate them.
- Do not rewrite the snapshot mechanism.

**Which issue(s) this PR fixes**:
Fixes #940

**Special notes for your reviewer**:

This PR chooses the second approach suggested in the issue:

```text
Keep snapshot-side clone, move ID/name defaulting to a point where caller-owned objects are not mutated.
```

It does not choose the first approach:

```text
Keep store-side clone, make snapshot publication reuse safe already-owned endpoint objects if possible.
```

Why the first approach was not chosen:

Keeping the store-side clone and allowing snapshots to reuse store-owned endpoints can reduce one deep clone. However, `Cluster.Config` is still a publicly mutable field today. If a snapshot reuses endpoint pointers from `Config.Endpoints`, later direct mutations to `Cluster.Config.Endpoints`, `Metadata`, `LLMMeta`, or `UnHealthy` could pollute an already published runtime snapshot.

To implement the first approach safely, we would likely need changes such as:

- making `Cluster.Config` private and exposing it through read-only or clone-returning getters;
- introducing truly immutable/frozen endpoints;
- splitting the public config from the snapshot-owned endpoint source;
- auditing all config mutation paths and making them copy-on-write.

That scope is much larger and gets close to the “Do not rewrite the snapshot mechanism” boundary. Therefore, this PR does not choose the first approach. Instead, it keeps the snapshot-side clone and only removes the duplicated clone from store-owned mutation paths.

**Verification**:

```bash
go test ./pkg/server/... ./pkg/cluster ./pkg/model/...
go test -run '^$' -bench '^BenchmarkClusterSetEndpointMembershipChurn$' -benchmem ./pkg/server
```

Local benchmark results before and after this change:

Before:

```text
goos: darwin
goarch: arm64
pkg: github.com/apache/dubbo-go-pixiu/pkg/server
cpu: Apple M5
BenchmarkClusterSetEndpointMembershipChurn-10               2100            478004 ns/op         1435526 B/op       9060 allocs/op
PASS
ok      github.com/apache/dubbo-go-pixiu/pkg/server     2.198s
```

After:

```text
goos: darwin
goarch: arm64
pkg: github.com/apache/dubbo-go-pixiu/pkg/server
cpu: Apple M5
BenchmarkClusterSetEndpointMembershipChurn-10               2830            358501 ns/op          947546 B/op       6061 allocs/op
PASS
ok      github.com/apache/dubbo-go-pixiu/pkg/server     1.562s
```

**Does this PR introduce a user-facing change?**

```release-note
NONE
```