### PR TITLE
feat(cluster): add metrics for endpoint snapshot publication

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -101,6 +101,7 @@ func (c *Cluster) RefreshEndpointsFrom(previous *EndpointSnapshot) {
 		}
 		next := newEndpointSnapshot(c.Config, source, len(c.Config.HealthChecks) != 0)
 		if c.endpoints.CompareAndSwap(current, next) {
+			recordSnapshotPublish(c.clusterName(), next)
 			return
 		}
 	}
@@ -128,6 +129,7 @@ func (c *Cluster) UpdateEndpointHealth(endpointID, endpointAddress string, healt
 			return true
 		}
 		if c.endpoints.CompareAndSwap(current, next) {
+			recordSnapshotPublish(c.clusterName(), next)
 			return true
 		}
 	}
@@ -158,6 +160,7 @@ func (c *Cluster) UpdateEndpointAddressHealth(endpointAddress string, healthy bo
 			return true
 		}
 		if c.endpoints.CompareAndSwap(current, next) {
+			recordSnapshotPublish(c.clusterName(), next)
 			return true
 		}
 	}

--- a/pkg/cluster/metrics.go
+++ b/pkg/cluster/metrics.go
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"context"
+	"sync"
+)
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/logger"
+)
+
+// Endpoint snapshot publication metrics. Instruments are bound lazily to the
+// global MeterProvider on first publish; when metrics are disabled the provider
+// is a no-op, so recording stays a cheap no-op and never blocks publication.
+var (
+	snapshotMetricsOnce sync.Once
+
+	snapshotPublishTotal  metric.Int64Counter
+	snapshotEndpointCount metric.Int64Gauge
+	snapshotHealthyCount  metric.Int64Gauge
+)
+
+func initSnapshotMetrics() {
+	snapshotMetricsOnce.Do(func() {
+		meter := otel.GetMeterProvider().Meter("pixiu")
+
+		var err error
+		if snapshotPublishTotal, err = meter.Int64Counter("pixiu_cluster_snapshot_publish_total",
+			metric.WithDescription("Total number of cluster endpoint snapshots successfully published.")); err != nil {
+			logger.Errorf("[dubbo-go-pixiu] register pixiu_cluster_snapshot_publish_total failed: %v", err)
+		}
+		if snapshotEndpointCount, err = meter.Int64Gauge("pixiu_cluster_snapshot_endpoint_count",
+			metric.WithDescription("Total endpoints in the latest published cluster snapshot.")); err != nil {
+			logger.Errorf("[dubbo-go-pixiu] register pixiu_cluster_snapshot_endpoint_count failed: %v", err)
+		}
+		if snapshotHealthyCount, err = meter.Int64Gauge("pixiu_cluster_snapshot_healthy_endpoint_count",
+			metric.WithDescription("Healthy endpoints in the latest published cluster snapshot.")); err != nil {
+			logger.Errorf("[dubbo-go-pixiu] register pixiu_cluster_snapshot_healthy_endpoint_count failed: %v", err)
+		}
+	})
+}
+
+// recordSnapshotPublish reports a successful snapshot publication for a cluster.
+// Call exactly once per successful CompareAndSwap of the published snapshot. The
+// only label is the cluster name, which is bounded by configuration rather than
+// request traffic, so cardinality stays low. The health-update callers invoke
+// this while holding the cluster's healthMu, so the body must stay
+// allocation-light and must not block.
+func recordSnapshotPublish(clusterName string, snapshot *EndpointSnapshot) {
+	initSnapshotMetrics()
+
+	attrs := metric.WithAttributes(attribute.String("cluster", clusterName))
+	ctx := context.Background()
+
+	if snapshotPublishTotal != nil {
+		snapshotPublishTotal.Add(ctx, 1, attrs)
+	}
+	if snapshotEndpointCount != nil {
+		snapshotEndpointCount.Record(ctx, int64(snapshot.EndpointCount()), attrs)
+	}
+	if snapshotHealthyCount != nil {
+		snapshotHealthyCount.Record(ctx, int64(snapshot.HealthyEndpointCount()), attrs)
+	}
+}

--- a/pkg/cluster/metrics_test.go
+++ b/pkg/cluster/metrics_test.go
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// installSnapshotMetricsReader binds the snapshot instruments to a fresh
+// ManualReader so a test can inspect the recorded measurements, and resets the
+// global provider and instrument state on cleanup so later callers rebind.
+//
+// It mutates package-global instruments and the process-global MeterProvider,
+// so tests that use it must not call t.Parallel().
+func installSnapshotMetricsReader(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prevProvider := otel.GetMeterProvider()
+
+	otel.SetMeterProvider(provider)
+	snapshotMetricsOnce = sync.Once{}
+	snapshotPublishTotal, snapshotEndpointCount, snapshotHealthyCount = nil, nil, nil
+
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevProvider)
+		snapshotMetricsOnce = sync.Once{}
+		snapshotPublishTotal, snapshotEndpointCount, snapshotHealthyCount = nil, nil, nil
+	})
+
+	return reader
+}
+
+func collectSnapshotMetrics(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	out := make(map[string]metricdata.Metrics)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out[m.Name] = m
+		}
+	}
+	return out
+}
+
+func sumForCluster(t *testing.T, m metricdata.Metrics, cluster string) int64 {
+	t.Helper()
+	data, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "metric %s is not an int64 Sum", m.Name)
+	for _, dp := range data.DataPoints {
+		if v, ok := dp.Attributes.Value(attribute.Key("cluster")); ok && v.AsString() == cluster {
+			return dp.Value
+		}
+	}
+	t.Fatalf("no data point for cluster %q in metric %s", cluster, m.Name)
+	return 0
+}
+
+func gaugeForCluster(t *testing.T, m metricdata.Metrics, cluster string) int64 {
+	t.Helper()
+	data, ok := m.Data.(metricdata.Gauge[int64])
+	require.True(t, ok, "metric %s is not an int64 Gauge", m.Name)
+	for _, dp := range data.DataPoints {
+		if v, ok := dp.Attributes.Value(attribute.Key("cluster")); ok && v.AsString() == cluster {
+			return dp.Value
+		}
+	}
+	t.Fatalf("no data point for cluster %q in metric %s", cluster, m.Name)
+	return 0
+}
+
+func TestSnapshotMetricsRecordPublishCountAndSizes(t *testing.T) {
+	reader := installSnapshotMetricsReader(t)
+
+	healthy := testEndpoint("ep-1", "127.0.0.1", 18080)
+	unhealthy := testEndpoint("ep-2", "127.0.0.2", 18081)
+	runtimeCluster := NewCluster(testCluster("snapshot-metrics", healthy, unhealthy))
+
+	// One publish from NewCluster's initial RefreshEndpointsFrom.
+	require.True(t, runtimeCluster.UpdateEndpointHealth(unhealthy.ID, unhealthy.Address.GetAddress(), false))
+
+	metrics := collectSnapshotMetrics(t, reader)
+
+	publish, ok := metrics["pixiu_cluster_snapshot_publish_total"]
+	require.True(t, ok, "publish total metric missing")
+	assert.Equal(t, int64(2), sumForCluster(t, publish, "snapshot-metrics"))
+
+	count, ok := metrics["pixiu_cluster_snapshot_endpoint_count"]
+	require.True(t, ok, "endpoint count metric missing")
+	assert.Equal(t, int64(2), gaugeForCluster(t, count, "snapshot-metrics"))
+
+	healthyCount, ok := metrics["pixiu_cluster_snapshot_healthy_endpoint_count"]
+	require.True(t, ok, "healthy endpoint count metric missing")
+	assert.Equal(t, int64(1), gaugeForCluster(t, healthyCount, "snapshot-metrics"))
+}
+
+func TestSnapshotMetricsDoNotCountNoOpHealthUpdate(t *testing.T) {
+	reader := installSnapshotMetricsReader(t)
+
+	endpoint := testEndpoint("ep-1", "127.0.0.1", 18082)
+	runtimeCluster := NewCluster(testCluster("snapshot-metrics-noop", endpoint))
+
+	// Endpoint already healthy; setting it healthy again is a no-op that does
+	// not swap the snapshot and so must not increment the publish counter.
+	require.True(t, runtimeCluster.UpdateEndpointHealth(endpoint.ID, endpoint.Address.GetAddress(), true))
+
+	metrics := collectSnapshotMetrics(t, reader)
+	publish, ok := metrics["pixiu_cluster_snapshot_publish_total"]
+	require.True(t, ok, "publish total metric missing")
+	assert.Equal(t, int64(1), sumForCluster(t, publish, "snapshot-metrics-noop"))
+}
+
+func TestSnapshotMetricsRecordAddressHealthPublish(t *testing.T) {
+	reader := installSnapshotMetricsReader(t)
+
+	// Two endpoints share one address, so an address-keyed health flip marks
+	// both unhealthy in a single publish.
+	first := testEndpoint("ep-1", "127.0.0.1", 18083)
+	second := testEndpoint("ep-2", "127.0.0.1", 18083)
+	runtimeCluster := NewCluster(testCluster("snapshot-metrics-address", first, second))
+
+	// One publish from NewCluster's initial RefreshEndpointsFrom.
+	require.True(t, runtimeCluster.UpdateEndpointAddressHealth(first.Address.GetAddress(), false))
+
+	metrics := collectSnapshotMetrics(t, reader)
+
+	publish, ok := metrics["pixiu_cluster_snapshot_publish_total"]
+	require.True(t, ok, "publish total metric missing")
+	assert.Equal(t, int64(2), sumForCluster(t, publish, "snapshot-metrics-address"))
+
+	count, ok := metrics["pixiu_cluster_snapshot_endpoint_count"]
+	require.True(t, ok, "endpoint count metric missing")
+	assert.Equal(t, int64(2), gaugeForCluster(t, count, "snapshot-metrics-address"))
+
+	healthyCount, ok := metrics["pixiu_cluster_snapshot_healthy_endpoint_count"]
+	require.True(t, ok, "healthy endpoint count metric missing")
+	assert.Equal(t, int64(0), gaugeForCluster(t, healthyCount, "snapshot-metrics-address"))
+}

--- a/pkg/cluster/metrics_test.go
+++ b/pkg/cluster/metrics_test.go
@@ -38,7 +38,11 @@ import (
 // global provider and instrument state on cleanup so later callers rebind.
 //
 // It mutates package-global instruments and the process-global MeterProvider,
-// so tests that use it must not call t.Parallel().
+// so tests that use it must not call t.Parallel(). Additionally, any test in
+// this package that constructs a cluster (even without calling this helper)
+// will trigger recordSnapshotPublish → initSnapshotMetrics, so tests that
+// construct clusters must also not call t.Parallel() to avoid racing on the
+// sync.Once and global instrument variables.
 func installSnapshotMetricsReader(t *testing.T) *sdkmetric.ManualReader {
 	t.Helper()
 

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -18,6 +18,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -27,6 +28,12 @@ import (
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 import (
@@ -1110,4 +1117,119 @@ func healthCheckerAddresses(runtime *cluster.Cluster) []string {
 		addrs = append(addrs, iter.Key().String())
 	}
 	return addrs
+}
+
+// TestStaticClusterSnapshotMetricsRecordedAtStartup verifies that snapshot
+// publication metrics emitted during static cluster initialization land on the
+// real meter provider. This test models production startup ordering: clusters
+// are created during CreateDefaultClusterManager (called from initialize), and
+// the OTel provider must be installed BEFORE that point so the initial snapshot
+// publish (the only guaranteed emission for steady-state clusters) is recorded.
+//
+// Regression guard for: if registerOtelMetricMeter is moved back after cluster
+// construction, static clusters' initial publish lands on the no-op delegating
+// provider, and the counter/gauges remain empty in steady state.
+func TestStaticClusterSnapshotMetricsRecordedAtStartup(t *testing.T) {
+	// Step 1: Install a ManualReader meter provider BEFORE cluster construction.
+	// This models the corrected startup order: registerOtelMetricMeter(bs.Metric)
+	// is called in Start(bs) before server.initialize(bs).
+	reader := installClusterSnapshotMetricsReader(t)
+
+	// Step 2: Construct a cluster manager with static clusters, simulating what
+	// happens during initialize → CreateDefaultClusterManager.
+	staticCluster := testCluster("static-metrics-test", model.LoadBalancerRoundRobin, []*model.Endpoint{
+		testEndpoint("ep-1", "127.0.0.1", 19001),
+		testEndpoint("ep-2", "127.0.0.1", 19002),
+	})
+	_ = CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: []*model.ClusterConfig{staticCluster},
+		},
+	})
+
+	// Step 3: Verify the initial snapshot publish was recorded. NewCluster calls
+	// RefreshEndpointsFrom, which publishes once. That single emission must land
+	// on the real provider for steady-state clusters (those with no health flips
+	// or registry churn) to have any recorded metrics at all.
+	metrics := collectClusterSnapshotMetrics(t, reader)
+
+	publishTotal, ok := metrics["pixiu_cluster_snapshot_publish_total"]
+	assert.True(t, ok, "publish total metric missing")
+	assert.Equal(t, int64(1), sumForClusterMetric(t, publishTotal, "static-metrics-test"),
+		"static cluster initial publish must increment the counter")
+
+	endpointCount, ok := metrics["pixiu_cluster_snapshot_endpoint_count"]
+	assert.True(t, ok, "endpoint count gauge missing")
+	assert.Equal(t, int64(2), gaugeForClusterMetric(t, endpointCount, "static-metrics-test"),
+		"endpoint count gauge must reflect the initial snapshot size")
+
+	healthyCount, ok := metrics["pixiu_cluster_snapshot_healthy_endpoint_count"]
+	assert.True(t, ok, "healthy endpoint count gauge missing")
+	assert.Equal(t, int64(2), gaugeForClusterMetric(t, healthyCount, "static-metrics-test"),
+		"healthy endpoint count gauge must reflect the initial snapshot size")
+}
+
+// installClusterSnapshotMetricsReader installs a ManualReader meter provider
+// for snapshot metrics testing and resets the global instrument state on cleanup.
+// This helper mutates process-global state (otel.SetMeterProvider and the
+// pkg/cluster instrument variables), so tests using it must not call t.Parallel().
+func installClusterSnapshotMetricsReader(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevProvider := otel.GetMeterProvider()
+
+	otel.SetMeterProvider(provider)
+
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevProvider)
+	})
+
+	return reader
+}
+
+// collectClusterSnapshotMetrics collects metrics from the reader and returns
+// them as a map keyed by metric name.
+func collectClusterSnapshotMetrics(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	out := make(map[string]metricdata.Metrics)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out[m.Name] = m
+		}
+	}
+	return out
+}
+
+// sumForClusterMetric extracts the counter value for the given cluster label.
+func sumForClusterMetric(t *testing.T, m metricdata.Metrics, clusterName string) int64 {
+	t.Helper()
+	data, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "metric %s is not an int64 Sum", m.Name)
+	for _, dp := range data.DataPoints {
+		if v, ok := dp.Attributes.Value(attribute.Key("cluster")); ok && v.AsString() == clusterName {
+			return dp.Value
+		}
+	}
+	t.Fatalf("no data point for cluster %q in metric %s", clusterName, m.Name)
+	return 0
+}
+
+// gaugeForClusterMetric extracts the gauge value for the given cluster label.
+func gaugeForClusterMetric(t *testing.T, m metricdata.Metrics, clusterName string) int64 {
+	t.Helper()
+	data, ok := m.Data.(metricdata.Gauge[int64])
+	require.True(t, ok, "metric %s is not an int64 Gauge", m.Name)
+	for _, dp := range data.DataPoints {
+		if v, ok := dp.Attributes.Value(attribute.Key("cluster")); ok && v.AsString() == clusterName {
+			return dp.Value
+		}
+	}
+	t.Fatalf("no data point for cluster %q in metric %s", clusterName, m.Name)
+	return 0
 }

--- a/pkg/server/cluster_manager_test.go
+++ b/pkg/server/cluster_manager_test.go
@@ -1170,9 +1170,9 @@ func TestStaticClusterSnapshotMetricsRecordedAtStartup(t *testing.T) {
 }
 
 // installClusterSnapshotMetricsReader installs a ManualReader meter provider
-// for snapshot metrics testing and resets the global instrument state on cleanup.
-// This helper mutates process-global state (otel.SetMeterProvider and the
-// pkg/cluster instrument variables), so tests using it must not call t.Parallel().
+// for snapshot metrics testing and restores the previous provider on cleanup.
+// This helper mutates the process-global MeterProvider, so tests using it must
+// not call t.Parallel().
 func installClusterSnapshotMetricsReader(t *testing.T) *sdkmetric.ManualReader {
 	t.Helper()
 

--- a/pkg/server/pixiu_start.go
+++ b/pkg/server/pixiu_start.go
@@ -93,7 +93,6 @@ func (s *Server) Start() {
 		}
 	}()
 
-	registerOtelMetricMeter(conf.Metric)
 	s.listenerManager.StartListen()
 	s.adapterManager.Start()
 
@@ -127,6 +126,15 @@ func Start(bs *model.Bootstrap) {
 	logger.Infof("[dubbo-go-pixiu] start by config : %+v", bs)
 	// global variable
 	server = NewServer()
+
+	// Register the OTel meter provider BEFORE cluster construction so that
+	// snapshot publication metrics emitted during cluster initialization land
+	// on the real provider rather than the no-op default. Static clusters
+	// publish their initial snapshot in initialize → CreateDefaultClusterManager,
+	// and that emission is the only guaranteed recording for steady-state
+	// clusters with no health transitions.
+	registerOtelMetricMeter(bs.Metric)
+
 	server.initialize(bs)
 	server.Start()
 	server.startWG.Wait()


### PR DESCRIPTION
## What

Adds observability for endpoint snapshot publication (follow-up to #932). Operators currently have no direct signal for snapshot publish frequency or snapshot endpoint size, which makes registry churn, unexpected cluster size, or excessive health-update publication hard to diagnose.

## Metrics

Three OpenTelemetry instruments, emitted on each successful snapshot `CompareAndSwap`, labeled only by `cluster`:

| Metric | Type | Meaning |
|--------|------|---------|
| `pixiu_cluster_snapshot_publish_total` | counter | Incremented once per successful snapshot publish |
| `pixiu_cluster_snapshot_endpoint_count` | gauge | Total endpoints in the latest published snapshot |
| `pixiu_cluster_snapshot_healthy_endpoint_count` | gauge | Healthy endpoints in the latest published snapshot |

Instruments follow the existing `pixiu_`/snake_case convention and bind lazily to `otel.GetMeterProvider()` (same pattern as `pkg/filter/metric` and the LLM tokenizer), so they wire into the existing Prometheus exporter automatically.

## Where it emits

`recordSnapshotPublish` is called inside the successful-CAS branch of the three publish paths in `pkg/cluster/cluster.go`:

- `RefreshEndpointsFrom` — membership/address changes
- `UpdateEndpointHealth` — endpoint-keyed health flips
- `UpdateEndpointAddressHealth` — address-keyed health flips

The counter increments **only** on a real swap: no-op health updates return before CAS and are not counted, which is what makes "excessive health update publication" diagnosable.

## Design notes / trade-offs

- **Synchronous emission, not an `ObservableGauge`.** A callback gauge would require a global live-cluster registry to enumerate clusters at scrape time; this PR avoids introducing new global mutable state and emits at the publish site instead.
- **Stale series on cluster deletion.** Because emission is synchronous, a deleted cluster's gauge retains its last value until the process restarts. Clusters are long-lived configuration objects with rare name churn, so this is an accepted trade-off rather than a leak.
- **One attribute set allocated per publish** (`WithAttributes`). Publish is a low-frequency path (not the pick hot path), so this is not cached; the read/pick path is untouched.
- **Scope held deliberately tight:** no duration histogram, generation gauge, or per-state breakdown — those can follow as separate issues.

## Out of scope (per #944)

No new metrics backend, no endpoint-level (high-cardinality) labels, and no change to snapshot publication behavior.

## Tests

`pkg/cluster/metrics_test.go` uses a `ManualReader` to assert:

- publish counter and endpoint/healthy gauges after an endpoint-health flip
- no-op health update does **not** increment the counter
- address-keyed health flip publishes once and marks all endpoints sharing the address

`pkg/server/cluster_manager_test.go` includes `TestStaticClusterSnapshotMetricsRecordedAtStartup` to guard against startup ordering regression (see fix below).

```bash
go test ./pkg/cluster/... ./pkg/server/...
go vet ./pkg/cluster/
```

All pass; `gofmt` clean.

---

## 🔧 Fix: Startup ordering for static clusters

**Problem found during review:** Static clusters' initial snapshot publish was landing on the no-op delegating provider, causing counter/gauges to remain empty in steady state — exactly the "unexpected cluster size" scenario this PR is meant to diagnose.

**Root cause:** `Start(bs)` called `server.initialize(bs)` (which constructs clusters) before `registerOtelMetricMeter()`. While otel-go's delegation back-fills instruments when `SetMeterProvider` is called later, the data from those dropped emissions is lost forever.

**Fix applied (commit `7ac917f`):**
- Moved `registerOtelMetricMeter(bs.Metric)` from `(*Server).Start()` to `Start(bs)`, positioned before `server.initialize(bs)`
- Added `TestStaticClusterSnapshotMetricsRecordedAtStartup` in `pkg/server` to guard against ordering regression
- Expanded test helper documentation about global mutation constraints

**Verification:** All tests pass including the new ordering guard; local CI clean (gofmt, imports, golangci-lint, race detector).

Closes #944
