### PR TITLE
feat(llm): inject cooldown store via plugin and remove shared global

### DIFF
--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -73,7 +73,7 @@ type UpstreamAttempt struct {
 }
 
 func init() {
-	filter.RegisterHttpFilter(&Plugin{})
+	filter.RegisterHttpFilter(newPlugin())
 }
 
 type (
@@ -81,8 +81,7 @@ type (
 	// and lives for the whole process, so it owns the cooldown store that must
 	// outlive individual filter factory reloads.
 	Plugin struct {
-		cooldownOnce sync.Once
-		cooldowns    *cooldownStore
+		cooldowns *cooldownStore
 	}
 
 	// FilterFactory creates filter instances.
@@ -138,14 +137,11 @@ type (
 	}
 )
 
-// cooldownStore lazily builds the process-wide cooldown store on first use and
-// returns the same instance thereafter, so filter reloads and multiple LLM
-// proxy factories created by this plugin share one runtime failure state.
-func (p *Plugin) cooldownStore() *cooldownStore {
-	p.cooldownOnce.Do(func() {
-		p.cooldowns = newCooldownStore()
-	})
-	return p.cooldowns
+// newPlugin builds the plugin with its process-wide cooldown store, so every
+// filter factory the plugin creates shares one runtime failure state that
+// survives individual factory reloads.
+func newPlugin() *Plugin {
+	return &Plugin{cooldowns: newCooldownStore()}
 }
 
 func getPreferredEndpointID(hc *contexthttp.HttpContext) string {
@@ -172,7 +168,7 @@ func (p *Plugin) Kind() string {
 // plugin-owned cooldown store is injected here so every factory and the
 // request executors it builds share one explicit store with no global fallback.
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
-	return &FilterFactory{cfg: &Config{}, cooldowns: p.cooldownStore()}, nil
+	return &FilterFactory{cfg: &Config{}, cooldowns: p.cooldowns}, nil
 }
 
 // Config returns the configuration struct for the factory.

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -73,7 +73,7 @@ type UpstreamAttempt struct {
 }
 
 func init() {
-	filter.RegisterHttpFilter(newPlugin())
+	filter.RegisterHttpFilter(&Plugin{})
 }
 
 type (
@@ -81,6 +81,7 @@ type (
 	// and lives for the whole process, so it owns the cooldown store that must
 	// outlive individual filter factory reloads.
 	Plugin struct {
+		initOnce  sync.Once
 		cooldowns *cooldownStore
 	}
 
@@ -144,6 +145,13 @@ func newPlugin() *Plugin {
 	return &Plugin{cooldowns: newCooldownStore()}
 }
 
+func (p *Plugin) cooldownStore() *cooldownStore {
+	p.initOnce.Do(func() {
+		p.cooldowns = newCooldownStore()
+	})
+	return p.cooldowns
+}
+
 func getPreferredEndpointID(hc *contexthttp.HttpContext) string {
 	if hc == nil || hc.Params == nil {
 		return ""
@@ -168,7 +176,7 @@ func (p *Plugin) Kind() string {
 // plugin-owned cooldown store is injected here so every factory and the
 // request executors it builds share one explicit store with no global fallback.
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
-	return &FilterFactory{cfg: &Config{}, cooldowns: p.cooldowns}, nil
+	return &FilterFactory{cfg: &Config{}, cooldowns: p.cooldownStore()}, nil
 }
 
 // Config returns the configuration struct for the factory.

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -77,8 +77,13 @@ func init() {
 }
 
 type (
-	// Plugin is the main plugin entrypoint.
-	Plugin struct{}
+	// Plugin is the main plugin entrypoint. It is registered once at init time
+	// and lives for the whole process, so it owns the cooldown store that must
+	// outlive individual filter factory reloads.
+	Plugin struct {
+		cooldownOnce sync.Once
+		cooldowns    *cooldownStore
+	}
 
 	// FilterFactory creates filter instances.
 	FilterFactory struct {
@@ -133,9 +138,15 @@ type (
 	}
 )
 
-// sharedCooldownStore keeps endpoint cooldowns process-wide so filter reloads
-// and multiple LLM proxy factories do not reset runtime failure state.
-var sharedCooldownStore = newCooldownStore()
+// cooldownStore lazily builds the process-wide cooldown store on first use and
+// returns the same instance thereafter, so filter reloads and multiple LLM
+// proxy factories created by this plugin share one runtime failure state.
+func (p *Plugin) cooldownStore() *cooldownStore {
+	p.cooldownOnce.Do(func() {
+		p.cooldowns = newCooldownStore()
+	})
+	return p.cooldowns
+}
 
 func getPreferredEndpointID(hc *contexthttp.HttpContext) string {
 	if hc == nil || hc.Params == nil {
@@ -157,9 +168,11 @@ func (p *Plugin) Kind() string {
 	return Kind
 }
 
-// CreateFilterFactory creates a new factory instance for this filter.
+// CreateFilterFactory creates a new factory instance for this filter. The
+// plugin-owned cooldown store is injected here so every factory and the
+// request executors it builds share one explicit store with no global fallback.
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
-	return &FilterFactory{cfg: &Config{}}, nil
+	return &FilterFactory{cfg: &Config{}, cooldowns: p.cooldownStore()}, nil
 }
 
 // Config returns the configuration struct for the factory.
@@ -194,7 +207,7 @@ func (factory *FilterFactory) PrepareFilterChain(_ *contexthttp.HttpContext, cha
 		scheme:         factory.cfg.Scheme,
 		strategy:       &Strategy{},
 		clusterManager: server.GetClusterManager(),
-		cooldowns:      factory.cooldownStore(),
+		cooldowns:      factory.cooldowns,
 	}
 	chain.AppendDecodeFilters(f)
 	return nil
@@ -417,7 +430,7 @@ func (s *Strategy) Execute(executor *RequestExecutor) (*http.Response, error) {
 }
 
 func (executor *RequestExecutor) endpointInCooldown(endpoint *model.Endpoint) bool {
-	store := executor.cooldownStore()
+	store := executor.cooldowns
 	if store == nil || endpoint == nil {
 		return false
 	}
@@ -438,31 +451,11 @@ func (executor *RequestExecutor) endpointInCooldown(endpoint *model.Endpoint) bo
 }
 
 func (executor *RequestExecutor) markEndpointCooldown(endpoint *model.Endpoint) {
-	store := executor.cooldownStore()
+	store := executor.cooldowns
 	if store == nil || endpoint == nil {
 		return
 	}
 	store.markFailure(executor.clusterName, endpoint, time.Now())
-}
-
-func (executor *RequestExecutor) cooldownStore() *cooldownStore {
-	if executor == nil {
-		return nil
-	}
-	if executor.cooldowns != nil {
-		return executor.cooldowns
-	}
-	if executor.filter != nil && executor.filter.cooldowns != nil {
-		return executor.filter.cooldowns
-	}
-	return sharedCooldownStore
-}
-
-func (factory *FilterFactory) cooldownStore() *cooldownStore {
-	if factory == nil || factory.cooldowns == nil {
-		return sharedCooldownStore
-	}
-	return factory.cooldowns
 }
 
 func newCooldownStore() *cooldownStore {

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -45,7 +45,7 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 func TestFilterFactoriesShareRuntimeCooldownStore(t *testing.T) {
-	plugin := &Plugin{}
+	plugin := newPlugin()
 	firstFactory, err := plugin.CreateFilterFactory()
 	if !assert.NoError(t, err) {
 		return
@@ -78,8 +78,8 @@ func TestFilterFactoriesShareRuntimeCooldownStore(t *testing.T) {
 }
 
 func TestIndependentPluginsDoNotShareCooldownState(t *testing.T) {
-	firstPlugin := &Plugin{}
-	secondPlugin := &Plugin{}
+	firstPlugin := newPlugin()
+	secondPlugin := newPlugin()
 
 	firstFactory, err := firstPlugin.CreateFilterFactory()
 	if !assert.NoError(t, err) {

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -55,8 +55,8 @@ func TestFilterFactoriesShareRuntimeCooldownStore(t *testing.T) {
 		return
 	}
 
-	firstStore := firstFactory.(*FilterFactory).cooldownStore()
-	secondStore := secondFactory.(*FilterFactory).cooldownStore()
+	firstStore := firstFactory.(*FilterFactory).cooldowns
+	secondStore := secondFactory.(*FilterFactory).cooldowns
 
 	assert.NotNil(t, firstStore)
 	assert.Same(t, firstStore, secondStore)
@@ -75,6 +75,43 @@ func TestFilterFactoriesShareRuntimeCooldownStore(t *testing.T) {
 	firstExecutor.markEndpointCooldown(endpoint)
 
 	assert.True(t, secondExecutor.endpointInCooldown(endpoint))
+}
+
+func TestIndependentPluginsDoNotShareCooldownState(t *testing.T) {
+	firstPlugin := &Plugin{}
+	secondPlugin := &Plugin{}
+
+	firstFactory, err := firstPlugin.CreateFilterFactory()
+	if !assert.NoError(t, err) {
+		return
+	}
+	secondFactory, err := secondPlugin.CreateFilterFactory()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	firstStore := firstFactory.(*FilterFactory).cooldowns
+	secondStore := secondFactory.(*FilterFactory).cooldowns
+
+	assert.NotNil(t, firstStore)
+	assert.NotNil(t, secondStore)
+	assert.NotSame(t, firstStore, secondStore)
+
+	clusterName := "llm-isolated-runtime-cooldown"
+	endpoint := testLLMEndpoint("ep-1", 18189)
+	firstExecutor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   firstStore,
+	}
+	secondExecutor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   secondStore,
+	}
+
+	firstExecutor.markEndpointCooldown(endpoint)
+
+	assert.True(t, firstExecutor.endpointInCooldown(endpoint))
+	assert.False(t, secondExecutor.endpointInCooldown(endpoint))
 }
 
 func TestStrategyExecuteUsesRuntimeCooldownStateWithoutMutatingEndpointMetadata(t *testing.T) {

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -45,7 +45,7 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 func TestFilterFactoriesShareRuntimeCooldownStore(t *testing.T) {
-	plugin := newPlugin()
+	plugin := &Plugin{}
 	firstFactory, err := plugin.CreateFilterFactory()
 	if !assert.NoError(t, err) {
 		return
@@ -78,8 +78,8 @@ func TestFilterFactoriesShareRuntimeCooldownStore(t *testing.T) {
 }
 
 func TestIndependentPluginsDoNotShareCooldownState(t *testing.T) {
-	firstPlugin := newPlugin()
-	secondPlugin := newPlugin()
+	firstPlugin := &Plugin{}
+	secondPlugin := &Plugin{}
 
 	firstFactory, err := firstPlugin.CreateFilterFactory()
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
Closes #939 
## What

Make LLM proxy cooldown store ownership explicit, resolving #939.

Previously the cooldown store was a package-level `sharedCooldownStore` reached through a multi-level fallback in both `FilterFactory.cooldownStore()` and `RequestExecutor.cooldownStore()`. Ownership was fuzzy and it made test isolation / future multi-manager behavior harder.

Now the proxy `Plugin` — registered once at init and living for the whole process in the filter registry — lazily owns a single cooldown store (`sync.Once`) and injects it into every `FilterFactory` it creates. The factory passes it to each `Filter`, and the `RequestExecutor` always receives a non-nil store from construction, so the production request path has no fallback resolver.

## Why the Plugin, not ClusterManager

The issue's preferred direction was for `ClusterManager` to own the store. That isn't viable without restructuring: `pkg/server` does not import `pkg/filter/llm/proxy` (the dependency runs the other way), so `ClusterManager` cannot hold the proxy-private `cooldownStore` type without an import cycle or moving the type out and burdening the generic cluster manager with LLM-specific state. The `Plugin` is the "another clearly owned process-level runtime object" the issue allows, and it keeps cooldown — an LLM concern — inside the LLM package while preserving the survives-reload property the old global provided.

## Changes

- `Plugin` gains `sync.Once` + `*cooldownStore` and a lazy `cooldownStore()` accessor.
- `CreateFilterFactory` injects the store; `PrepareFilterChain` and the executor read the explicit field.
- Removed `sharedCooldownStore`, `FilterFactory.cooldownStore()`, and `RequestExecutor.cooldownStore()` fallback chain.
- nil guards kept only at the `endpointInCooldown` / `markEndpointCooldown` boundaries, not in construction.
- Tests: existing factory-sharing test now reads the field; added `TestIndependentPluginsDoNotShareCooldownState` proving two independently constructed plugins do not share state.

Out-of-scope items from the issue (key semantics, TTL, eviction policy #943, persistence, background sweeper) are untouched.

## Acceptance criteria

- [x] `sharedCooldownStore` removed
- [x] Production request execution needs no multi-level fallback to locate cooldown state
- [x] Existing cooldown tests pass with explicit store ownership
- [x] New test covers isolation between independently constructed plugins
- [x] `go test ./pkg/filter/llm/proxy/... ./pkg/server/... ./pkg/filter/...` pass; `gofmt`/`go vet` clean; `go build ./...` OK