### PR TITLE
perf(llm): drop per-request hex alloc in cooldown credential hash

### DIFF
--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -118,7 +118,7 @@ type (
 		clusterName     string
 		endpointID      string
 		endpointAddress string
-		credentialHash  string
+		credentialHash  [32]byte
 	}
 
 	cooldownStore struct {
@@ -582,12 +582,11 @@ func newCooldownKey(clusterName string, endpoint *model.Endpoint) cooldownKey {
 	}
 }
 
-func endpointCredentialHash(endpoint *model.Endpoint) string {
+func endpointCredentialHash(endpoint *model.Endpoint) [32]byte {
 	if endpoint == nil || endpoint.LLMMeta == nil || endpoint.LLMMeta.APIKey == "" {
-		return ""
+		return [32]byte{}
 	}
-	sum := sha256.Sum256([]byte(endpoint.LLMMeta.APIKey))
-	return fmt.Sprintf("%x", sum)
+	return sha256.Sum256([]byte(endpoint.LLMMeta.APIKey))
 }
 
 // endpointCooldownInterval returns the per-endpoint cooldown TTL derived from

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -412,3 +412,26 @@ func testLLMEndpoint(id string, port int) *model.Endpoint {
 		},
 	}
 }
+
+func BenchmarkCooldown_EndpointInCooldown(b *testing.B) {
+	const clusterName = "llm-cooldown-bench"
+	const endpointCount = 100
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	endpoints := make([]*model.Endpoint, endpointCount)
+	for i := range endpoints {
+		endpoint := testLLMEndpoint(fmt.Sprintf("ep-%d", i), 19000+i)
+		endpoint.LLMMeta.APIKey = fmt.Sprintf("api-key-%d", i)
+		endpoints[i] = endpoint
+		store.markFailure(clusterName, endpoint, time.Now())
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		executor.endpointInCooldown(endpoints[i%endpointCount])
+	}
+}

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -416,6 +416,10 @@ func testLLMEndpoint(id string, port int) *model.Endpoint {
 func BenchmarkCooldown_EndpointInCooldown(b *testing.B) {
 	const clusterName = "llm-cooldown-bench"
 	const endpointCount = 100
+	// Keep the cooldown TTL far longer than any -benchtime run so every
+	// iteration stays on the intended in-cooldown hot path. Otherwise entries
+	// could expire mid-benchmark and shift measurement onto the delete+log path.
+	const cooldownTTLMillis = int64(24 * time.Hour / time.Millisecond)
 	store := newCooldownStore()
 	executor := &RequestExecutor{
 		clusterName: clusterName,
@@ -425,6 +429,7 @@ func BenchmarkCooldown_EndpointInCooldown(b *testing.B) {
 	for i := range endpoints {
 		endpoint := testLLMEndpoint(fmt.Sprintf("ep-%d", i), 19000+i)
 		endpoint.LLMMeta.APIKey = fmt.Sprintf("api-key-%d", i)
+		endpoint.LLMMeta.HealthCheckInterval = cooldownTTLMillis
 		endpoints[i] = endpoint
 		store.markFailure(clusterName, endpoint, time.Now())
 	}


### PR DESCRIPTION
## Summary

Closes #956.

Every LLM request resolves a `cooldownKey` at least once (more on the retry/fallback path) through `endpointCredentialHash`. That function ran `fmt.Sprintf("%x", sum)` and allocated a fresh 64-byte hex string that escapes to the heap. The hex string is pure overhead — `credentialHash` is only ever used as a comparable component of the `cooldownKey` map key, never displayed or logged.

This PR uses the raw `[32]byte` sha256 output directly as the key component. A `[32]byte` array is comparable and valid in a struct map key, so the hex encoding and its heap allocation are removed while the cooldown identity semantics stay byte-for-byte identical.

`sha256` itself stays per-call (nanoseconds for short keys); the allocation was the dominant cost. Caching the hash on the endpoint was explicitly **not** done — it would pollute the model struct and complicate snapshot cloning for a ~200ns win, as the issue notes.

## Change

- `cooldownKey.credentialHash`: `string` → `[32]byte`
- `endpointCredentialHash(...)`: returns `[32]byte` (zero value for no-credential endpoints), dropping `fmt.Sprintf`

`cooldownKey` is unexported, so this is a purely internal change with no upstream-visible API impact.

## Benchmark

`BenchmarkCooldown_EndpointInCooldown` (added in this PR), 100 LLM endpoints each with an API key, on the hot `endpointInCooldown` path:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 300.0 | 168 | 6 |
| after | 163.2 | 40 | 3 |

3 fewer allocs/op and ~46% faster, exceeding the issue's "at least one fewer alloc/op" target.

## Test plan

- [x] `go test -race ./pkg/filter/llm/proxy/...` — existing cooldown tests pass unchanged with the `[32]byte` zero value
- [x] `go vet ./pkg/filter/llm/proxy/` clean
- [x] `go build ./...` clean
- [x] New `BenchmarkCooldown_EndpointInCooldown` documents the before/after alloc delta