### PR TITLE
perf(llm): make cooldown store eviction O(1) with container/list LRU

### DIFF
--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -515,7 +515,7 @@ func (s *cooldownStore) markFailure(clusterName string, endpoint *model.Endpoint
 		s.recencyOrder.MoveToBack(element)
 		return
 	}
-	s.evictOldestIfFullLocked(key)
+	s.evictOldestIfFullLocked()
 	s.lastFailureByEndpoint[key] = s.recencyOrder.PushBack(&cooldownEntry{
 		key:         key,
 		lastFailure: lastFailure,
@@ -568,11 +568,8 @@ func (s *cooldownStore) sweepExpiredExceptLocked(now time.Time, current cooldown
 }
 
 // evictOldestIfFullLocked removes the least-recently-failed entry when the
-// store is at capacity, in O(1) via the front of the recency list. current is
-// the key about to be inserted; it is never in the list yet on this path, but
-// the guard keeps the invariant explicit so a future caller cannot evict the
-// entry it is in the middle of writing.
-func (s *cooldownStore) evictOldestIfFullLocked(current cooldownKey) {
+// store is at capacity, in O(1) via the front of the recency list.
+func (s *cooldownStore) evictOldestIfFullLocked() {
 	if len(s.lastFailureByEndpoint) < maxCooldownStoreEntries {
 		return
 	}
@@ -580,11 +577,7 @@ func (s *cooldownStore) evictOldestIfFullLocked(current cooldownKey) {
 	if oldest == nil {
 		return
 	}
-	oldestKey := oldest.Value.(*cooldownEntry).key
-	if oldestKey == current {
-		return
-	}
-	s.removeLocked(oldestKey, oldest)
+	s.removeLocked(oldest.Value.(*cooldownEntry).key, oldest)
 }
 
 func newCooldownKey(clusterName string, endpoint *model.Endpoint) cooldownKey {

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -19,6 +19,7 @@ package proxy
 
 import (
 	"bytes"
+	"container/list"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -127,12 +128,20 @@ type (
 	}
 
 	cooldownStore struct {
-		mu                    sync.Mutex
-		lastFailureByEndpoint map[cooldownKey]cooldownEntry
-		lastSweep             time.Time
+		mu sync.Mutex
+		// lastFailureByEndpoint indexes each tracked endpoint to its node in
+		// recencyOrder, so lookups stay O(1) and the node can be repositioned
+		// or removed without scanning.
+		lastFailureByEndpoint map[cooldownKey]*list.Element
+		// recencyOrder holds *cooldownEntry values ordered oldest-at-front,
+		// newest-at-back. Eviction pops the front in O(1); refreshing an entry
+		// moves its node to the back.
+		recencyOrder *list.List
+		lastSweep    time.Time
 	}
 
 	cooldownEntry struct {
+		key         cooldownKey
 		lastFailure time.Time
 		ttl         time.Duration
 	}
@@ -464,7 +473,8 @@ func (executor *RequestExecutor) markEndpointCooldown(endpoint *model.Endpoint) 
 
 func newCooldownStore() *cooldownStore {
 	return &cooldownStore{
-		lastFailureByEndpoint: map[cooldownKey]cooldownEntry{},
+		lastFailureByEndpoint: map[cooldownKey]*list.Element{},
+		recencyOrder:          list.New(),
 	}
 }
 
@@ -477,14 +487,14 @@ func (s *cooldownStore) lastFailureWithCurrentTTL(clusterName string, endpoint *
 	key := newCooldownKey(clusterName, endpoint)
 	now := time.Now()
 	s.sweepExpiredIfNeededLocked(now, key)
-	entry, ok := s.lastFailureByEndpoint[key]
+	element, ok := s.lastFailureByEndpoint[key]
 	if !ok {
 		return time.Time{}, 0, false
 	}
+	entry := element.Value.(*cooldownEntry)
 	currentTTL := endpointCooldownInterval(endpoint)
 	if entry.ttl != currentTTL {
 		entry.ttl = currentTTL
-		s.lastFailureByEndpoint[key] = entry
 	}
 	return entry.lastFailure, entry.ttl, true
 }
@@ -497,13 +507,20 @@ func (s *cooldownStore) markFailure(clusterName string, endpoint *model.Endpoint
 	defer s.mu.Unlock()
 	key := newCooldownKey(clusterName, endpoint)
 	s.sweepExpiredIfNeededLocked(time.Now(), key)
-	if _, ok := s.lastFailureByEndpoint[key]; !ok {
-		s.evictOldestIfFullLocked(key)
+	ttl := endpointCooldownInterval(endpoint)
+	if element, ok := s.lastFailureByEndpoint[key]; ok {
+		entry := element.Value.(*cooldownEntry)
+		entry.lastFailure = lastFailure
+		entry.ttl = ttl
+		s.recencyOrder.MoveToBack(element)
+		return
 	}
-	s.lastFailureByEndpoint[key] = cooldownEntry{
+	s.evictOldestIfFullLocked(key)
+	s.lastFailureByEndpoint[key] = s.recencyOrder.PushBack(&cooldownEntry{
+		key:         key,
 		lastFailure: lastFailure,
-		ttl:         endpointCooldownInterval(endpoint),
-	}
+		ttl:         ttl,
+	})
 }
 
 func (s *cooldownStore) deleteLastFailureIfMatches(clusterName string, endpoint *model.Endpoint, expected time.Time) bool {
@@ -513,12 +530,19 @@ func (s *cooldownStore) deleteLastFailureIfMatches(clusterName string, endpoint 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	key := newCooldownKey(clusterName, endpoint)
-	current, ok := s.lastFailureByEndpoint[key]
-	if !ok || current.lastFailure != expected {
+	element, ok := s.lastFailureByEndpoint[key]
+	if !ok || element.Value.(*cooldownEntry).lastFailure != expected {
 		return false
 	}
-	delete(s.lastFailureByEndpoint, key)
+	s.removeLocked(key, element)
 	return true
+}
+
+// removeLocked drops one entry from both the map and the recency list,
+// keeping the two structures in sync. Callers must hold s.mu.
+func (s *cooldownStore) removeLocked(key cooldownKey, element *list.Element) {
+	delete(s.lastFailureByEndpoint, key)
+	s.recencyOrder.Remove(element)
 }
 
 func (s *cooldownStore) sweepExpiredIfNeededLocked(now time.Time, current cooldownKey) {
@@ -532,39 +556,35 @@ func (s *cooldownStore) sweepExpiredIfNeededLocked(now time.Time, current cooldo
 }
 
 func (s *cooldownStore) sweepExpiredExceptLocked(now time.Time, current cooldownKey) {
-	for key, entry := range s.lastFailureByEndpoint {
+	for key, element := range s.lastFailureByEndpoint {
 		if key == current {
 			continue
 		}
+		entry := element.Value.(*cooldownEntry)
 		if now.Sub(entry.lastFailure) >= entry.ttl {
-			delete(s.lastFailureByEndpoint, key)
+			s.removeLocked(key, element)
 		}
 	}
 }
 
+// evictOldestIfFullLocked removes the least-recently-failed entry when the
+// store is at capacity, in O(1) via the front of the recency list. current is
+// the key about to be inserted; it is never in the list yet on this path, but
+// the guard keeps the invariant explicit so a future caller cannot evict the
+// entry it is in the middle of writing.
 func (s *cooldownStore) evictOldestIfFullLocked(current cooldownKey) {
 	if len(s.lastFailureByEndpoint) < maxCooldownStoreEntries {
 		return
 	}
-
-	var (
-		oldestKey   cooldownKey
-		oldestEntry cooldownEntry
-		found       bool
-	)
-	for key, entry := range s.lastFailureByEndpoint {
-		if key == current {
-			continue
-		}
-		if !found || entry.lastFailure.Before(oldestEntry.lastFailure) {
-			oldestKey = key
-			oldestEntry = entry
-			found = true
-		}
+	oldest := s.recencyOrder.Front()
+	if oldest == nil {
+		return
 	}
-	if found {
-		delete(s.lastFailureByEndpoint, oldestKey)
+	oldestKey := oldest.Value.(*cooldownEntry).key
+	if oldestKey == current {
+		return
 	}
+	s.removeLocked(oldestKey, oldest)
 }
 
 func newCooldownKey(clusterName string, endpoint *model.Endpoint) cooldownKey {

--- a/pkg/filter/llm/proxy/filter.go
+++ b/pkg/filter/llm/proxy/filter.go
@@ -138,6 +138,10 @@ type (
 		// moves its node to the back.
 		recencyOrder *list.List
 		lastSweep    time.Time
+		// nowFn is called inside the mutex so the recorded timestamp and the
+		// recency-list insertion order are always consistent, even under
+		// concurrent writes. Overridable in tests.
+		nowFn func() time.Time
 	}
 
 	cooldownEntry struct {
@@ -468,13 +472,14 @@ func (executor *RequestExecutor) markEndpointCooldown(endpoint *model.Endpoint) 
 	if store == nil || endpoint == nil {
 		return
 	}
-	store.markFailure(executor.clusterName, endpoint, time.Now())
+	store.markFailure(executor.clusterName, endpoint)
 }
 
 func newCooldownStore() *cooldownStore {
 	return &cooldownStore{
 		lastFailureByEndpoint: map[cooldownKey]*list.Element{},
 		recencyOrder:          list.New(),
+		nowFn:                 time.Now,
 	}
 }
 
@@ -499,12 +504,13 @@ func (s *cooldownStore) lastFailureWithCurrentTTL(clusterName string, endpoint *
 	return entry.lastFailure, entry.ttl, true
 }
 
-func (s *cooldownStore) markFailure(clusterName string, endpoint *model.Endpoint, lastFailure time.Time) {
+func (s *cooldownStore) markFailure(clusterName string, endpoint *model.Endpoint) {
 	if s == nil || endpoint == nil {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	lastFailure := s.nowFn()
 	key := newCooldownKey(clusterName, endpoint)
 	s.sweepExpiredIfNeededLocked(time.Now(), key)
 	ttl := endpointCooldownInterval(endpoint)

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -188,7 +188,9 @@ func TestRequestExecutorEndpointInCooldownClearsExpiredCooldownFromProxyStore(t 
 		clusterName: clusterName,
 		cooldowns:   store,
 	}
-	store.markFailure(clusterName, endpoint, time.Now().Add(-time.Hour))
+	store.nowFn = func() time.Time { return time.Now().Add(-time.Hour) }
+	store.markFailure(clusterName, endpoint)
+	store.nowFn = time.Now
 
 	assert.False(t, executor.endpointInCooldown(endpoint))
 
@@ -269,7 +271,9 @@ func TestRequestExecutorCooldownSurvivesNonIdentityLLMConfigChanges(t *testing.T
 		clusterName: clusterName,
 		cooldowns:   store,
 	}
-	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-50*time.Millisecond))
+	store.nowFn = func() time.Time { return time.Now().Add(-50 * time.Millisecond) }
+	store.markFailure(clusterName, oldEndpoint)
+	store.nowFn = time.Now
 
 	assert.True(t, executor.endpointInCooldown(replacement))
 }
@@ -288,7 +292,9 @@ func TestCooldownStoreLazySweepKeepsEntryAfterEndpointIntervalExtends(t *testing
 		clusterName: clusterName,
 		cooldowns:   store,
 	}
-	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-50*time.Millisecond))
+	store.nowFn = func() time.Time { return time.Now().Add(-50 * time.Millisecond) }
+	store.markFailure(clusterName, oldEndpoint)
+	store.nowFn = time.Now
 
 	assert.True(t, executor.endpointInCooldown(replacement))
 	_, _, _ = store.lastFailureWithCurrentTTL(clusterName, activeEndpoint)
@@ -310,8 +316,10 @@ func TestCooldownStoreLazySweepRemovesExpiredChurnedEndpointEntry(t *testing.T) 
 	activeEndpoint := testLLMEndpoint("ep-2", 18086)
 	store := newCooldownStore()
 
-	store.markFailure(clusterName, oldEndpoint, time.Now().Add(-time.Hour))
-	store.markFailure(clusterName, movedEndpoint, time.Now())
+	store.nowFn = func() time.Time { return time.Now().Add(-time.Hour) }
+	store.markFailure(clusterName, oldEndpoint)
+	store.nowFn = time.Now
+	store.markFailure(clusterName, movedEndpoint)
 
 	store.mu.Lock()
 	_, oldExistsAfterMove := store.lastFailureByEndpoint[newCooldownKey(clusterName, oldEndpoint)]
@@ -336,7 +344,9 @@ func TestCooldownStoreLazySweepRemovesExpiredEndpointFromDifferentCluster(t *tes
 	activeEndpoint := testLLMEndpoint("ep-2", 18093)
 	store := newCooldownStore()
 
-	store.markFailure("old-cluster", expiredEndpoint, time.Now().Add(-time.Hour))
+	store.nowFn = func() time.Time { return time.Now().Add(-time.Hour) }
+	store.markFailure("old-cluster", expiredEndpoint)
+	store.nowFn = time.Now
 	store.mu.Lock()
 	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
 	store.mu.Unlock()
@@ -351,6 +361,8 @@ func TestCooldownStoreLazySweepRemovesExpiredEndpointFromDifferentCluster(t *tes
 func TestCooldownStoreEvictsOldestEntryWhenCapacityExceeded(t *testing.T) {
 	store := newCooldownStore()
 	now := time.Now()
+	current := now
+	store.nowFn = func() time.Time { return current }
 	oldestEndpoint := testLLMEndpoint("ep-0", 19000)
 
 	for i := 0; i < maxCooldownStoreEntries; i++ {
@@ -358,11 +370,13 @@ func TestCooldownStoreEvictsOldestEntryWhenCapacityExceeded(t *testing.T) {
 		if i == 0 {
 			oldestEndpoint = endpoint
 		}
-		store.markFailure("capacity-cluster", endpoint, now.Add(time.Duration(i)*time.Millisecond))
+		current = now.Add(time.Duration(i) * time.Millisecond)
+		store.markFailure("capacity-cluster", endpoint)
 	}
 
 	newestEndpoint := testLLMEndpoint("ep-new", 21000)
-	store.markFailure("capacity-cluster", newestEndpoint, now.Add(time.Hour))
+	current = now.Add(time.Hour)
+	store.markFailure("capacity-cluster", newestEndpoint)
 
 	store.mu.Lock()
 	_, oldestExists := store.lastFailureByEndpoint[newCooldownKey("capacity-cluster", oldestEndpoint)]
@@ -381,14 +395,18 @@ func TestCooldownStoreEvictsOldestEntryWhenCapacityExceeded(t *testing.T) {
 func TestCooldownStoreRefreshUpdatesRecency(t *testing.T) {
 	store := newCooldownStore()
 	now := time.Now()
+	current := now
+	store.nowFn = func() time.Time { return current }
 
 	first := testLLMEndpoint("ep-first", 19000)
 	second := testLLMEndpoint("ep-second", 19001)
-	store.markFailure("recency-cluster", first, now)
-	store.markFailure("recency-cluster", second, now.Add(time.Millisecond))
+	store.markFailure("recency-cluster", first)
+	current = now.Add(time.Millisecond)
+	store.markFailure("recency-cluster", second)
 
 	// Refresh the first endpoint so it becomes the most recently failed.
-	store.markFailure("recency-cluster", first, now.Add(2*time.Millisecond))
+	current = now.Add(2 * time.Millisecond)
+	store.markFailure("recency-cluster", first)
 
 	store.mu.Lock()
 	front := store.recencyOrder.Front().Value.(*cooldownEntry)
@@ -412,7 +430,9 @@ func TestCooldownStoreSweepRemovesMapAndListState(t *testing.T) {
 	activeEndpoint := testLLMEndpoint("ep-active", 19001)
 	store := newCooldownStore()
 
-	store.markFailure(clusterName, expiredEndpoint, time.Now().Add(-time.Hour))
+	store.nowFn = func() time.Time { return time.Now().Add(-time.Hour) }
+	store.markFailure(clusterName, expiredEndpoint)
+	store.nowFn = time.Now
 	store.mu.Lock()
 	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
 	store.mu.Unlock()
@@ -442,7 +462,9 @@ func TestCooldownStoreDeleteExpiredLeavesNoStaleListElement(t *testing.T) {
 		clusterName: clusterName,
 		cooldowns:   store,
 	}
-	store.markFailure(clusterName, endpoint, time.Now().Add(-time.Hour))
+	store.nowFn = func() time.Time { return time.Now().Add(-time.Hour) }
+	store.markFailure(clusterName, endpoint)
+	store.nowFn = time.Now
 
 	// endpointInCooldown observes the entry as expired and deletes it.
 	assert.False(t, executor.endpointInCooldown(endpoint))

--- a/pkg/filter/llm/proxy/filter_test.go
+++ b/pkg/filter/llm/proxy/filter_test.go
@@ -375,6 +375,87 @@ func TestCooldownStoreEvictsOldestEntryWhenCapacityExceeded(t *testing.T) {
 	assert.Equal(t, maxCooldownStoreEntries, entryCount)
 }
 
+// TestCooldownStoreRefreshUpdatesRecency verifies that re-failing an existing
+// endpoint moves it to the newest side of the LRU, so a later eviction drops a
+// genuinely older entry instead of the just-refreshed one.
+func TestCooldownStoreRefreshUpdatesRecency(t *testing.T) {
+	store := newCooldownStore()
+	now := time.Now()
+
+	first := testLLMEndpoint("ep-first", 19000)
+	second := testLLMEndpoint("ep-second", 19001)
+	store.markFailure("recency-cluster", first, now)
+	store.markFailure("recency-cluster", second, now.Add(time.Millisecond))
+
+	// Refresh the first endpoint so it becomes the most recently failed.
+	store.markFailure("recency-cluster", first, now.Add(2*time.Millisecond))
+
+	store.mu.Lock()
+	front := store.recencyOrder.Front().Value.(*cooldownEntry)
+	back := store.recencyOrder.Back().Value.(*cooldownEntry)
+	listLen := store.recencyOrder.Len()
+	mapLen := len(store.lastFailureByEndpoint)
+	store.mu.Unlock()
+
+	assert.Equal(t, newCooldownKey("recency-cluster", second), front.key, "least-recent should be the un-refreshed entry")
+	assert.Equal(t, newCooldownKey("recency-cluster", first), back.key, "most-recent should be the refreshed entry")
+	assert.Equal(t, 2, listLen)
+	assert.Equal(t, mapLen, listLen, "map and recency list must stay in sync")
+}
+
+// TestCooldownStoreSweepRemovesMapAndListState verifies the lazy TTL sweep
+// drops an expired entry from both the map and the recency list, leaving no
+// stale list element behind.
+func TestCooldownStoreSweepRemovesMapAndListState(t *testing.T) {
+	clusterName := "sweep-cluster"
+	expiredEndpoint := testLLMEndpoint("ep-expired", 19000)
+	activeEndpoint := testLLMEndpoint("ep-active", 19001)
+	store := newCooldownStore()
+
+	store.markFailure(clusterName, expiredEndpoint, time.Now().Add(-time.Hour))
+	store.mu.Lock()
+	store.lastSweep = time.Now().Add(-cooldownStoreSweepAfter - time.Millisecond)
+	store.mu.Unlock()
+
+	// Touching an unrelated endpoint triggers the lazy sweep.
+	store.lastFailureWithCurrentTTL(clusterName, activeEndpoint)
+
+	store.mu.Lock()
+	_, expiredExists := store.lastFailureByEndpoint[newCooldownKey(clusterName, expiredEndpoint)]
+	listLen := store.recencyOrder.Len()
+	mapLen := len(store.lastFailureByEndpoint)
+	store.mu.Unlock()
+
+	assert.False(t, expiredExists)
+	assert.Equal(t, 0, listLen, "expired entry must be removed from the recency list, not just the map")
+	assert.Equal(t, mapLen, listLen, "map and recency list must stay in sync")
+}
+
+// TestCooldownStoreDeleteExpiredLeavesNoStaleListElement verifies that clearing
+// an expired cooldown via the request path removes both the map entry and its
+// recency list element.
+func TestCooldownStoreDeleteExpiredLeavesNoStaleListElement(t *testing.T) {
+	clusterName := "delete-expired-cluster"
+	endpoint := testLLMEndpoint("ep-1", 19000)
+	store := newCooldownStore()
+	executor := &RequestExecutor{
+		clusterName: clusterName,
+		cooldowns:   store,
+	}
+	store.markFailure(clusterName, endpoint, time.Now().Add(-time.Hour))
+
+	// endpointInCooldown observes the entry as expired and deletes it.
+	assert.False(t, executor.endpointInCooldown(endpoint))
+
+	store.mu.Lock()
+	mapLen := len(store.lastFailureByEndpoint)
+	listLen := store.recencyOrder.Len()
+	store.mu.Unlock()
+
+	assert.Equal(t, 0, mapLen)
+	assert.Equal(t, 0, listLen, "deleting an expired cooldown must not leave a stale list element")
+}
+
 func TestStrategyExecuteIgnoresUnhealthyPreferredEndpoint(t *testing.T) {
 	clusterName := "llm-preferred-health"
 	healthyEndpoint := testLLMEndpoint("ep-1", 18086)
@@ -468,7 +549,7 @@ func BenchmarkCooldown_EndpointInCooldown(b *testing.B) {
 		endpoint.LLMMeta.APIKey = fmt.Sprintf("api-key-%d", i)
 		endpoint.LLMMeta.HealthCheckInterval = cooldownTTLMillis
 		endpoints[i] = endpoint
-		store.markFailure(clusterName, endpoint, time.Now())
+		store.markFailure(clusterName, endpoint)
 	}
 
 	b.ReportAllocs()


### PR DESCRIPTION
## Summary

Closes #943.

The LLM proxy cooldown store is bounded by `maxCooldownStoreEntries`. At capacity it evicted the oldest entry by scanning the whole map to find the minimum `lastFailure` — O(N) on the failure path. This PR replaces that scan with a standard-library `container/list` LRU so eviction is O(1), while preserving the existing key and TTL behavior.

## Change

- `cooldownStore` now holds a `recencyOrder *list.List` (oldest at front, newest at back) and the map is keyed to `*list.Element`.
- `cooldownEntry` carries its own `key`, so a front-pop eviction can delete the matching map entry without a reverse lookup.
- `markFailure`: existing key → update entry + `MoveToBack`; new key → `evictOldestIfFullLocked` then `PushBack`.
- `evictOldestIfFullLocked`: pops `recencyOrder.Front()` in O(1) (was a full map scan).
- A shared `removeLocked(key, element)` helper keeps the map and list in sync on every delete / sweep / eviction, so no stale list element survives.

Caller-visible cooldown semantics are unchanged: endpoint identity key (`newCooldownKey` untouched), TTL derivation, idempotent replay, and the lazy expiry sweep all behave exactly as before. The one deliberate difference is the eviction victim: the old scan dropped the entry with the smallest `lastFailure` timestamp, while the LRU drops the recency-list front (insertion / refresh order). On the production failure path these always coincide, because `markFailure` is only ever called with a monotonic `time.Now()`; they can diverge only under out-of-order timestamps supplied directly in tests. No third-party dependency, no background goroutine.

## Tests

Existing cooldown tests pass unchanged (eviction-at-capacity, address/credential isolation, lazy sweep across clusters). New tests cover the LRU-specific invariants the issue calls out:

- `TestCooldownStoreRefreshUpdatesRecency` — re-failing an entry moves it to the newest side; a later eviction drops a genuinely older entry.
- `TestCooldownStoreSweepRemovesMapAndListState` — the TTL sweep clears both the map and the recency list (asserts `recencyOrder.Len() == 0`).
- `TestCooldownStoreDeleteExpiredLeavesNoStaleListElement` — clearing an expired cooldown via the request path leaves no stale list element.

Each new test asserts `len(map) == recencyOrder.Len()` to pin map/list sync.

## Test plan

- [x] `go test -race ./pkg/filter/llm/proxy/...`
- [x] `go vet ./pkg/filter/llm/proxy/` clean
- [x] `go build ./...` clean
- [x] pre-push local-CI (gofmt/vet/tests) passed
