### PR TITLE
fix(hotreload): bound reload request body size

### DIFF
--- a/pkg/hotreload/http_handler.go
+++ b/pkg/hotreload/http_handler.go
@@ -19,6 +19,7 @@ package hotreload
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -38,6 +39,8 @@ import (
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
+
+const maxReloadBodyBytes = 1 << 20 // 1 MiB
 
 var (
 	reloadMutex    sync.Mutex
@@ -69,7 +72,7 @@ func checkAuth(r *http.Request) bool {
 	// Check shared secret if configured
 	if reloadSecret != "" {
 		token := r.Header.Get("X-Reload-Token")
-		return token == reloadSecret
+		return subtle.ConstantTimeCompare([]byte(token), []byte(reloadSecret)) == 1
 	}
 
 	// If no secret configured and not localhost, deny
@@ -95,11 +98,17 @@ func (h *ReloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Try to read from body first (handles chunked encoding where ContentLength == -1)
 	// If body is empty, fallback to file reload
 	if r.Body != nil {
-		content, readErr := io.ReadAll(r.Body)
+		content, readErr := io.ReadAll(io.LimitReader(r.Body, maxReloadBodyBytes+1))
 
 		if readErr != nil {
 			logger.Errorf("Failed to read request body: %v", readErr)
 			http.Error(w, fmt.Sprintf("Failed to read request body: %v", readErr), http.StatusBadRequest)
+			return
+		}
+
+		if len(content) > maxReloadBodyBytes {
+			logger.Warnf("Reload request body from %s exceeded %d bytes", r.RemoteAddr, maxReloadBodyBytes)
+			http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
 			return
 		}
 

--- a/pkg/hotreload/http_handler.go
+++ b/pkg/hotreload/http_handler.go
@@ -98,17 +98,17 @@ func (h *ReloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Try to read from body first (handles chunked encoding where ContentLength == -1)
 	// If body is empty, fallback to file reload
 	if r.Body != nil {
-		content, readErr := io.ReadAll(io.LimitReader(r.Body, maxReloadBodyBytes+1))
+		r.Body = http.MaxBytesReader(w, r.Body, maxReloadBodyBytes)
+		content, readErr := io.ReadAll(r.Body)
 
 		if readErr != nil {
+			if _, ok := readErr.(*http.MaxBytesError); ok {
+				logger.Warnf("Reload request body from %s exceeded %d bytes", r.RemoteAddr, maxReloadBodyBytes)
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
 			logger.Errorf("Failed to read request body: %v", readErr)
 			http.Error(w, fmt.Sprintf("Failed to read request body: %v", readErr), http.StatusBadRequest)
-			return
-		}
-
-		if len(content) > maxReloadBodyBytes {
-			logger.Warnf("Reload request body from %s exceeded %d bytes", r.RemoteAddr, maxReloadBodyBytes)
-			http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
 			return
 		}
 

--- a/pkg/hotreload/http_handler_test.go
+++ b/pkg/hotreload/http_handler_test.go
@@ -29,11 +29,7 @@ import (
 )
 
 func TestReloadHandlerRejectsOversizedBody(t *testing.T) {
-	oldSecret := reloadSecret
-	reloadSecret = "test-secret"
-	t.Cleanup(func() {
-		reloadSecret = oldSecret
-	})
+	withReloadSecret(t, "test-secret")
 
 	req := httptest.NewRequest(http.MethodPost, "/-/reload", strings.NewReader(strings.Repeat("a", maxReloadBodyBytes+1)))
 	req.RemoteAddr = "192.0.2.1:12345"
@@ -43,4 +39,47 @@ func TestReloadHandlerRejectsOversizedBody(t *testing.T) {
 	(&ReloadHandler{}).ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+}
+
+func TestReloadHandlerAllowsBodyAtSizeLimit(t *testing.T) {
+	withReloadSecret(t, "test-secret")
+
+	req := httptest.NewRequest(http.MethodPost, "/-/reload", strings.NewReader(strings.Repeat("a", maxReloadBodyBytes)))
+	req.RemoteAddr = "192.0.2.1:12345"
+	req.Header.Set("X-Reload-Token", "test-secret")
+
+	rr := httptest.NewRecorder()
+	(&ReloadHandler{}).ServeHTTP(rr, req)
+
+	assert.NotEqual(t, http.StatusRequestEntityTooLarge, rr.Code)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestReloadHandlerEmptyBodyFallsBackToFileReload(t *testing.T) {
+	withReloadSecret(t, "test-secret")
+	oldConfigPath := configPath
+	configPath = ""
+	t.Cleanup(func() {
+		configPath = oldConfigPath
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/-/reload", strings.NewReader(""))
+	req.RemoteAddr = "192.0.2.1:12345"
+	req.Header.Set("X-Reload-Token", "test-secret")
+
+	rr := httptest.NewRecorder()
+	(&ReloadHandler{}).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "config path not set")
+}
+
+func withReloadSecret(t *testing.T, secret string) {
+	t.Helper()
+
+	oldSecret := reloadSecret
+	reloadSecret = secret
+	t.Cleanup(func() {
+		reloadSecret = oldSecret
+	})
 }

--- a/pkg/hotreload/http_handler_test.go
+++ b/pkg/hotreload/http_handler_test.go
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hotreload
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReloadHandlerRejectsOversizedBody(t *testing.T) {
+	oldSecret := reloadSecret
+	reloadSecret = "test-secret"
+	t.Cleanup(func() {
+		reloadSecret = oldSecret
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/-/reload", strings.NewReader(strings.Repeat("a", maxReloadBodyBytes+1)))
+	req.RemoteAddr = "192.0.2.1:12345"
+	req.Header.Set("X-Reload-Token", "test-secret")
+
+	rr := httptest.NewRecorder()
+	(&ReloadHandler{}).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+}


### PR DESCRIPTION
## What

Limit the HTTP hot reload request body to 1 MiB before parsing reload YAML, and return `413 Request Entity Too Large` when the limit is exceeded. The reload token comparison now uses constant-time comparison.

## Why

The handler previously used `io.ReadAll(r.Body)` without a size limit, which allowed an authenticated caller to force excessive memory use with a large reload body.

## Testing

- `go test ./pkg/hotreload`
- `git diff --check`