### PR TITLE
fix(admin): harden JWT validation

### DIFF
--- a/admin/controller/auth/auth.go
+++ b/admin/controller/auth/auth.go
@@ -19,6 +19,7 @@ package auth
 
 import (
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -99,6 +100,9 @@ func NewJWT() *JWT {
 
 // get signKey
 func GetSignKey() string {
+	if key := os.Getenv("DUBBOGO_PIXIU_JWT_SIGN_KEY"); key != "" {
+		return key
+	}
 	return SignKey
 }
 
@@ -115,6 +119,9 @@ func (j *JWT) ParseToken(tokenString string) (*CustomClaims, error) {
 	// Input: token string, custom Claims structure object, custom function
 	// Parse the token string into jwt's Token structure pointer
 	token, err := jwt.ParseWithClaims(tokenString, &CustomClaims{}, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, TokenInvalid
+		}
 		return j.SigningKey, nil
 	})
 	if err != nil {
@@ -145,6 +152,9 @@ func (j *JWT) RefreshToken(tokenString string) (string, error) {
 		return time.Unix(0, 0)
 	}
 	token, err := jwt.ParseWithClaims(tokenString, &CustomClaims{}, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, TokenInvalid
+		}
 		return j.SigningKey, nil
 	})
 	if err != nil {

--- a/admin/controller/auth/auth.go
+++ b/admin/controller/auth/auth.go
@@ -129,17 +129,9 @@ func (j *JWT) ParseToken(tokenString string) (*CustomClaims, error) {
 	// Parse the token string into jwt's Token structure pointer
 	token, err := jwt.ParseWithClaims(tokenString, &CustomClaims{}, j.keyFunc)
 	if err != nil {
-		if ve, ok := err.(jwt.ValidationError); ok {
-			if ve.Errors&jwt.ValidationErrorMalformed != 0 {
-				return nil, TokenMalformed
-			} else if ve.Errors&jwt.ValidationErrorExpired != 0 {
-				return nil, TokenExpired
-			} else if ve.Errors&jwt.ValidationErrorNotValidYet != 0 {
-				return nil, TokenNotValidYet
-			} else {
-				return nil, TokenInvalid
-			}
-		}
+		// jwt returns *ValidationError; errors.As matches both value and pointer
+		// forms so the expiry/malformed branches below are actually reached.
+		return nil, j.classify(err)
 	}
 	// Parse the claims information in the token and verify the original user data, make the following types of assertions
 	//, and convert token.Claims into a specific user-defined Claims structure
@@ -150,20 +142,50 @@ func (j *JWT) ParseToken(tokenString string) (*CustomClaims, error) {
 }
 
 // Update token
+//
+// RefreshToken reissues a token whose only problem is expiration. It deliberately
+// does not mutate the package-global jwt.TimeFunc (the previous implementation did,
+// which leaked the frozen clock to ParseToken on the parse-failure path and raced
+// with concurrent ParseToken/RefreshToken calls). Instead it parses normally and,
+// when the sole validation failure is expiration, reuses the parsed claims with a
+// fresh expiration time. Any other failure (malformed token, bad signature,
+// non-HMAC algorithm, not-valid-yet, etc.) is rejected just like ParseToken does.
 func (j *JWT) RefreshToken(tokenString string) (string, error) {
-	// Expiration time verification
-	jwt.TimeFunc = func() time.Time {
-		return time.Unix(0, 0)
-	}
 	token, err := jwt.ParseWithClaims(tokenString, &CustomClaims{}, j.keyFunc)
 	if err != nil {
-		return "", err
+		// A token that is otherwise valid but past its ExpiresAt is exactly what
+		// refresh exists to handle. Only the expired bit is tolerated; any other
+		// validation failure is reported with the same semantics as ParseToken.
+		var ve *jwt.ValidationError
+		if !errors.As(err, &ve) || ve.Errors != jwt.ValidationErrorExpired {
+			return "", j.classify(err)
+		}
 	}
-	if claims, ok := token.Claims.(*CustomClaims); ok && token.Valid {
-		jwt.TimeFunc = time.Now
-		// Set token expiration time
-		claims.ExpiresAt = time.Now().Add(1 * time.Hour).Unix()
-		return j.CreateToken(*claims)
+
+	claims, ok := token.Claims.(*CustomClaims)
+	if !ok {
+		return "", TokenInvalid
 	}
-	return "", TokenInvalid
+	// Set token expiration time
+	claims.ExpiresAt = time.Now().Add(1 * time.Hour).Unix()
+	return j.CreateToken(*claims)
+}
+
+// classify maps a raw parse error onto the package sentinel errors, mirroring the
+// mapping ParseToken performs so that both entry points report consistently.
+func (j *JWT) classify(err error) error {
+	var ve *jwt.ValidationError
+	if !errors.As(err, &ve) {
+		return TokenInvalid
+	}
+	switch {
+	case ve.Errors&jwt.ValidationErrorMalformed != 0:
+		return TokenMalformed
+	case ve.Errors&jwt.ValidationErrorExpired != 0:
+		return TokenExpired
+	case ve.Errors&jwt.ValidationErrorNotValidYet != 0:
+		return TokenNotValidYet
+	default:
+		return TokenInvalid
+	}
 }

--- a/admin/controller/auth/auth.go
+++ b/admin/controller/auth/auth.go
@@ -75,6 +75,8 @@ type JWT struct {
 	SigningKey []byte
 }
 
+const jwtSignKeyEnv = "DUBBOGO_PIXIU_JWT_SIGN_KEY"
+
 // Constant
 var (
 	TokenExpired     error  = errors.New("Token is expired")
@@ -100,7 +102,7 @@ func NewJWT() *JWT {
 
 // get signKey
 func GetSignKey() string {
-	if key := os.Getenv("DUBBOGO_PIXIU_JWT_SIGN_KEY"); key != "" {
+	if key := os.Getenv(jwtSignKeyEnv); key != "" {
 		return key
 	}
 	return SignKey
@@ -114,16 +116,18 @@ func (j *JWT) CreateToken(claims CustomClaims) (string, error) {
 	return token.SignedString(j.SigningKey)
 }
 
+func (j *JWT) keyFunc(token *jwt.Token) (any, error) {
+	if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+		return nil, TokenInvalid
+	}
+	return j.SigningKey, nil
+}
+
 // ParseToken
 func (j *JWT) ParseToken(tokenString string) (*CustomClaims, error) {
 	// Input: token string, custom Claims structure object, custom function
 	// Parse the token string into jwt's Token structure pointer
-	token, err := jwt.ParseWithClaims(tokenString, &CustomClaims{}, func(token *jwt.Token) (any, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, TokenInvalid
-		}
-		return j.SigningKey, nil
-	})
+	token, err := jwt.ParseWithClaims(tokenString, &CustomClaims{}, j.keyFunc)
 	if err != nil {
 		if ve, ok := err.(jwt.ValidationError); ok {
 			if ve.Errors&jwt.ValidationErrorMalformed != 0 {
@@ -151,12 +155,7 @@ func (j *JWT) RefreshToken(tokenString string) (string, error) {
 	jwt.TimeFunc = func() time.Time {
 		return time.Unix(0, 0)
 	}
-	token, err := jwt.ParseWithClaims(tokenString, &CustomClaims{}, func(token *jwt.Token) (any, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, TokenInvalid
-		}
-		return j.SigningKey, nil
-	})
+	token, err := jwt.ParseWithClaims(tokenString, &CustomClaims{}, j.keyFunc)
 	if err != nil {
 		return "", err
 	}

--- a/admin/controller/auth/auth_test.go
+++ b/admin/controller/auth/auth_test.go
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTokenRejectsUnexpectedSigningMethod(t *testing.T) {
+	claims := CustomClaims{
+		Username: "admin",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+
+	_, err = NewJWT().ParseToken(tokenString)
+
+	assert.ErrorIs(t, err, TokenInvalid)
+}
+
+func TestGetSignKeyUsesEnvironmentOverride(t *testing.T) {
+	t.Setenv("DUBBOGO_PIXIU_JWT_SIGN_KEY", "from-env")
+
+	assert.Equal(t, "from-env", GetSignKey())
+}

--- a/admin/controller/auth/auth_test.go
+++ b/admin/controller/auth/auth_test.go
@@ -24,6 +24,7 @@ import (
 
 import (
 	"github.com/golang-jwt/jwt/v4"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/admin/controller/auth/auth_test.go
+++ b/admin/controller/auth/auth_test.go
@@ -46,7 +46,7 @@ func TestParseTokenRejectsUnexpectedSigningMethod(t *testing.T) {
 }
 
 func TestGetSignKeyUsesEnvironmentOverride(t *testing.T) {
-	t.Setenv("DUBBOGO_PIXIU_JWT_SIGN_KEY", "from-env")
+	t.Setenv(jwtSignKeyEnv, "from-env")
 
 	assert.Equal(t, "from-env", GetSignKey())
 }

--- a/admin/controller/auth/auth_test.go
+++ b/admin/controller/auth/auth_test.go
@@ -18,6 +18,7 @@
 package auth
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -49,4 +50,149 @@ func TestGetSignKeyUsesEnvironmentOverride(t *testing.T) {
 	t.Setenv(jwtSignKeyEnv, "from-env")
 
 	assert.Equal(t, "from-env", GetSignKey())
+}
+
+// TestRefreshTokenReissuesExpiredToken verifies that an otherwise-valid token
+// past its ExpiresAt is refreshed into a new, usable token.
+func TestRefreshTokenReissuesExpiredToken(t *testing.T) {
+	j := NewJWT()
+	original := CustomClaims{
+		Username: "admin",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+		},
+	}
+	expired, err := j.CreateToken(original)
+	require.NoError(t, err)
+
+	// Sanity: the expired token is rejected by ParseToken.
+	_, err = j.ParseToken(expired)
+	assert.ErrorIs(t, err, TokenExpired)
+
+	refreshed, err := j.RefreshToken(expired)
+	require.NoError(t, err)
+	assert.NotEqual(t, expired, refreshed)
+
+	// The refreshed token must parse cleanly and carry the original identity.
+	claims, err := j.ParseToken(refreshed)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", claims.Username)
+}
+
+// TestRefreshTokenRejectsMalformedToken ensures a malformed refresh request is
+// rejected and — critically — does not corrupt the package-global JWT clock, so
+// a subsequent ParseToken of a valid token still works. This is the regression
+// for the P0 reported in PR #978.
+func TestRefreshTokenRejectsMalformedToken(t *testing.T) {
+	j := NewJWT()
+
+	_, err := j.RefreshToken("not-a-token")
+	assert.ErrorIs(t, err, TokenMalformed)
+
+	// After the failed refresh, a normal ParseToken must still enforce expiration
+	// correctly (i.e. the global clock was not frozen at Unix 0).
+	valid := CustomClaims{
+		Username: "admin",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		},
+	}
+	validString, err := j.CreateToken(valid)
+	require.NoError(t, err)
+	if _, err := j.ParseToken(validString); err != nil {
+		t.Fatalf("ParseToken of a valid token failed after a malformed refresh: %v", err)
+	}
+
+	// And an expired token must still be reported as expired, not accepted.
+	expired := CustomClaims{
+		Username: "admin",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+		},
+	}
+	expiredString, err := j.CreateToken(expired)
+	require.NoError(t, err)
+	if _, err := j.ParseToken(expiredString); err != TokenExpired {
+		t.Fatalf("ParseToken of an expired token = %v, want %v", err, TokenExpired)
+	}
+}
+
+// TestRefreshTokenRejectsBadSignature verifies that a token signed with a
+// different key is not refreshable.
+func TestRefreshTokenRejectsBadSignature(t *testing.T) {
+	j := NewJWT()
+	claims := CustomClaims{
+		Username: "admin",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+		},
+	}
+	forged := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	forgedString, err := forged.SignedString([]byte("wrong-key"))
+	require.NoError(t, err)
+
+	_, err = j.RefreshToken(forgedString)
+	assert.Error(t, err)
+	assert.NotEqual(t, TokenExpired, err)
+}
+
+// TestConcurrentRefreshAndParse stresses RefreshToken and ParseToken running
+// concurrently to confirm there is no data race on a shared global clock and
+// that expiration checks stay correct. Run with -race.
+func TestConcurrentRefreshAndParse(t *testing.T) {
+	j := NewJWT()
+
+	valid := CustomClaims{
+		Username: "admin",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		},
+	}
+	validString, err := j.CreateToken(valid)
+	require.NoError(t, err)
+
+	expired := CustomClaims{
+		Username: "admin",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+		},
+	}
+	expiredString, err := j.CreateToken(expired)
+	require.NoError(t, err)
+
+	const goroutines = 50
+	const iterations = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 3)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for n := 0; n < iterations; n++ {
+				if _, err := j.RefreshToken(expiredString); err != nil {
+					t.Errorf("RefreshToken of an expired token failed: %v", err)
+					return
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for n := 0; n < iterations; n++ {
+				if _, err := j.RefreshToken("not-a-token"); err == nil {
+					t.Error("RefreshToken of a malformed token unexpectedly succeeded")
+					return
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for n := 0; n < iterations; n++ {
+				if _, err := j.ParseToken(validString); err != nil {
+					t.Errorf("ParseToken of a valid token failed concurrently: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## What

Reject admin JWTs that use non-HMAC signing methods and allow deployments to override the default signing key with `DUBBOGO_PIXIU_JWT_SIGN_KEY`.

## Why

JWT parsing previously returned the verification key without first constraining the token signing method, and deployments only had the hardcoded default signing key path.

## Testing

- `go test ./admin/controller/auth`
- `git diff --check`