### PR TITLE
build: migrate github.com/golang/mock to go.uber.org/mock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/go-sql-driver/mysql v1.9.2
 	github.com/goinggo/mapstructure v0.0.0-20140717182941-194205d9b4a9
 	github.com/golang-jwt/jwt/v4 v4.5.2
-	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/jhump/protoreflect v1.17.0
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
@@ -61,6 +60,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/mock v0.5.2
 	go.uber.org/zap v1.21.0
 	go.yaml.in/yaml/v4 v4.0.0-rc.2
 	golang.org/x/crypto v0.49.0
@@ -154,6 +154,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/pkg/config/xds/apiclient/grpc_test.go
+++ b/pkg/config/xds/apiclient/grpc_test.go
@@ -26,9 +26,9 @@ import (
 import (
 	"github.com/agiledragon/gomonkey/v2"
 
-	"go.uber.org/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"

--- a/pkg/config/xds/apiclient/grpc_test.go
+++ b/pkg/config/xds/apiclient/grpc_test.go
@@ -26,7 +26,7 @@ import (
 import (
 	"github.com/agiledragon/gomonkey/v2"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	"github.com/stretchr/testify/require"
 

--- a/pkg/config/xds/cds_test.go
+++ b/pkg/config/xds/cds_test.go
@@ -27,9 +27,9 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
-	"go.uber.org/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"google.golang.org/protobuf/types/known/anypb"
 )

--- a/pkg/config/xds/cds_test.go
+++ b/pkg/config/xds/cds_test.go
@@ -27,7 +27,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	"github.com/stretchr/testify/require"
 

--- a/pkg/config/xds/xds_test.go
+++ b/pkg/config/xds/xds_test.go
@@ -26,9 +26,9 @@ import (
 import (
 	"github.com/agiledragon/gomonkey/v2"
 
-	"go.uber.org/mock/gomock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"

--- a/pkg/config/xds/xds_test.go
+++ b/pkg/config/xds/xds_test.go
@@ -26,7 +26,7 @@ import (
 import (
 	"github.com/agiledragon/gomonkey/v2"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	"github.com/stretchr/testify/require"
 

--- a/pkg/server/controls/mocks/mocks.go
+++ b/pkg/server/controls/mocks/mocks.go
@@ -22,7 +22,7 @@ import (
 )
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 import (

--- a/pkg/server/controls/mocks/mocks.go
+++ b/pkg/server/controls/mocks/mocks.go
@@ -22,10 +22,12 @@ import (
 )
 
 import (
+	gomock "go.uber.org/mock/gomock"
+)
+
+import (
 	model "github.com/apache/dubbo-go-pixiu/pkg/model"
 	controls "github.com/apache/dubbo-go-pixiu/pkg/server/controls"
-
-	gomock "go.uber.org/mock/gomock"
 )
 
 // MockClusterManager is a mock of ClusterManager interface.

--- a/pkg/server/controls/mocks/mocks.go
+++ b/pkg/server/controls/mocks/mocks.go
@@ -22,12 +22,10 @@ import (
 )
 
 import (
-	gomock "go.uber.org/mock/gomock"
-)
-
-import (
 	model "github.com/apache/dubbo-go-pixiu/pkg/model"
 	controls "github.com/apache/dubbo-go-pixiu/pkg/server/controls"
+
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockClusterManager is a mock of ClusterManager interface.


### PR DESCRIPTION
## 动机

`github.com/golang/mock` 已被官方标记为废弃（archived），推荐迁移到官方继任者 `go.uber.org/mock`。

## 改动

- **go.mod**: 直接依赖从 `github.com/golang/mock v1.6.0` → `go.uber.org/mock v0.5.2`
  - 旧包保留为 `// indirect`（被 dubbo-go、nacos-sdk 等上游间接拉入，无法移除）
- **4 个 Go 文件**: `import "github.com/golang/mock/gomock"` → `"go.uber.org/mock/gomock"`
  - `pkg/config/xds/xds_test.go`
  - `pkg/config/xds/apiclient/grpc_test.go`
  - `pkg/config/xds/cds_test.go`
  - `pkg/server/controls/mocks/mocks.go`

## 验证

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./pkg/config/xds/... ./pkg/server/controls/...` ✅

API 完全兼容，无需改任何业务代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)