### PR TITLE
refactor: replace goinggo/mapstructure with mitchellh/mapstructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/go-playground/assert/v2 v2.2.0
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/go-sql-driver/mysql v1.9.2
-	github.com/goinggo/mapstructure v0.0.0-20140717182941-194205d9b4a9
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/goinggo/mapstructure v0.0.0-20140717182941-194205d9b4a9 h1:wqckanyE9qc/XnvnybC6SHOb8Nyd62QXAZOzA8twFig=
-github.com/goinggo/mapstructure v0.0.0-20140717182941-194205d9b4a9/go.mod h1:64ikIrMv84B+raz7akXOqbF7cK3/OQQ/6cClY10oy7A=
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
 github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=

--- a/pkg/config/config_load.go
+++ b/pkg/config/config_load.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/creasty/defaults"
 
-	"github.com/goinggo/mapstructure"
+	"github.com/mitchellh/mapstructure"
 
 	"gopkg.in/yaml.v3"
 )


### PR DESCRIPTION
## Summary

Replace the obsolete `github.com/goinggo/mapstructure` fork (v0.0.0-20140717182941, from 2014) with the standard `github.com/mitchellh/mapstructure` v1.5.0, which is already a dependency in go.mod.

## Changes

- `pkg/config/config_load.go`: Updated import from `github.com/goinggo/mapstructure` → `github.com/mitchellh/mapstructure`
- `go.mod`: Removed `github.com/goinggo/mapstructure` dependency
- `go.sum`: Removed checksum entries for the old fork

## Why

- `goinggo/mapstructure` is a 2014 fork with no updates in 12 years
- It was only used in one place (`config_load.go`) for `mapstructure.Decode()`
- The standard `mitchellh/mapstructure` v1.5.0 is already in go.mod and used by 6 other files in the codebase with the same API
- Removing the fork reduces dependency count and maintenance burden

## Verification

- ✅ `go build ./...` passes
- ✅ `go test ./pkg/config/...` passes
- ✅ `go mod tidy` removes the old dependency cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)