### PR TITLE
fix(dubboproxy): remove direct go-errors/errors dependency, unify to pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/envoyproxy/go-control-plane v0.12.1-0.20240621013728-1eb8caab5155
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gin-gonic/gin v1.10.1
-	github.com/go-errors/errors v1.0.1
 	github.com/go-playground/assert/v2 v2.2.0
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/go-sql-driver/mysql v1.9.2
@@ -134,6 +133,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/pkg/filter/network/dubboproxy/manager.go
+++ b/pkg/filter/network/dubboproxy/manager.go
@@ -32,8 +32,6 @@ import (
 
 	"github.com/dubbogo/grpc-go/metadata"
 
-	"github.com/go-errors/errors"
-
 	perrors "github.com/pkg/errors"
 )
 
@@ -118,7 +116,7 @@ func (dcm *DubboProxyConnectionManager) OnTripleData(ctx context.Context, method
 	ra, err := dcm.routerCoordinator.RouteByPathAndName(interfaceName, methodName)
 
 	if err != nil {
-		return nil, errors.Errorf("Requested dubbo rpc invocation route not found")
+		return nil, perrors.Errorf("Requested dubbo rpc invocation route not found")
 	}
 
 	len := len(arguments)
@@ -163,7 +161,7 @@ func (dcm *DubboProxyConnectionManager) OnData(data any) (any, error) {
 	ra, err := dcm.routerCoordinator.RouteByPathAndName(path, old_invoc.MethodName())
 
 	if err != nil {
-		return nil, errors.Errorf("Requested dubbo rpc invocation route not found")
+		return nil, perrors.Errorf("Requested dubbo rpc invocation route not found")
 	}
 
 	ctx := &dubbo2.RpcContext{}
@@ -182,7 +180,7 @@ func (dcm *DubboProxyConnectionManager) handleRpcInvocation(c *dubbo2.RpcContext
 	defer func() {
 		if err := recover(); err != nil {
 			logger.Warnf("[dubbo-go-pixiu] Occur An Unexpected Err: %+v", err)
-			c.SetError(errors.Errorf("Occur An Unexpected Err: %v", err))
+			c.SetError(perrors.Errorf("Occur An Unexpected Err: %v", err))
 		}
 	}()
 


### PR DESCRIPTION
## Summary

Remove the direct import of `github.com/go-errors/errors` from `pkg/filter/network/dubboproxy/manager.go`, unifying all error handling to `github.com/pkg/errors`.

## Problem

`manager.go` simultaneously imported two overlapping error packages:

```go
"github.com/go-errors/errors"
perrors "github.com/pkg/errors"
```

`go-errors/errors` was only used in this single file (3 call sites), while `pkg/errors` is the project-wide standard (76+ uses). Both provide `Errorf` with stack trace support — the overlap is purely historical.

## Changes

| File | Change |
|------|--------|
| `pkg/filter/network/dubboproxy/manager.go` | Removed `go-errors/errors` import; replaced 3× `errors.Errorf()` → `perrors.Errorf()` |
| `go.mod` | `go-errors/errors` moved from direct dependency to `// indirect` |

## Notes

- `go-errors/errors` remains as an `// indirect` dependency because `nacos-sdk-go/clients/cache` depends on it transitively — outside our control.
- Full project build (`go build ./...`) passes with no errors.

Co-Authored-By: Claude <noreply@anthropic.com>