### PR TITLE
refactor(admin): remove personal fork dependency v.marlon.life/toolkit

### DIFF
--- a/admin/core/server.go
+++ b/admin/core/server.go
@@ -20,11 +20,11 @@ package core
 import (
 	"fmt"
 	"net/http"
+	"sync"
 )
 
 import (
 	"go.uber.org/zap"
-	"sync"
 )
 
 import (

--- a/admin/core/server.go
+++ b/admin/core/server.go
@@ -24,8 +24,7 @@ import (
 
 import (
 	"go.uber.org/zap"
-
-	"v.marlon.life/toolkit/util"
+	"sync"
 )
 
 import (
@@ -64,23 +63,27 @@ func RunServer() {
 
 	s := initServer(address, router)
 
-	var wg util.WaitGroupWrapper
+	var wg sync.WaitGroup
 
-	wg.AddAndRun(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		global.LOG.Info("server run success on ", zap.String("address", address))
 		fmt.Printf(helperInfo, address)
 
 		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			global.LOG.Error(err.Error())
 		}
-	})
+	}()
 
-	wg.AddAndRun(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		global.LOG.Info("xDS server run success on :18000")
 		if err := StartxDsServer(); err != nil {
 			global.LOG.Error(err.Error())
 		}
-	})
+	}()
 
 	wg.Wait()
 }

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.30.0
 	mosn.io/proxy-wasm-go-host v0.1.0
-	v.marlon.life/toolkit v0.0.0-20211025131614-e4a91730b4ab
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1799,5 +1799,3 @@ sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-v.marlon.life/toolkit v0.0.0-20211025131614-e4a91730b4ab h1:a6cEnTfYq9TiNuFyvtyGsQ/05FfG6W1FkR61o4sWfMk=
-v.marlon.life/toolkit v0.0.0-20211025131614-e4a91730b4ab/go.mod h1:v4RzgEKUNEmIL9GEsV1AbChohLekk/qSK+Ed2Ho0R84=


### PR DESCRIPTION
## Summary

Remove the personal-domain dependency `v.marlon.life/toolkit` and replace it with the standard library `sync.WaitGroup`.

## Problem

`v.marlon.life/toolkit v0.0.0-20211025131614-e4a91730b4ab` is a dependency from a personal domain with no stability guarantees:
- **Domain/repository stability**: personal domains can expire, repos can be deleted
- **Apache compliance**: personal non-versioned dependencies may not satisfy IP clarity requirements
- **Minimal usage**: only `util.WaitGroupWrapper` is used, which is a trivial wrapper around `sync.WaitGroup`

## Changes

| File | Change |
|------|--------|
| `admin/core/server.go` | Replace `util.WaitGroupWrapper` with `sync.WaitGroup`; `AddAndRun(fn)` → `wg.Add(1)` + `go func(){ defer wg.Done(); fn() }()` |
| `go.mod` | Remove `v.marlon.life/toolkit` dependency |
| `go.sum` | Remove `v.marlon.life/toolkit` checksum entries |

## Verification

- `go vet ./admin/core/...` — pass
- `go build ./admin/core/` — pass
- `go mod tidy` — no changes (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)