### PR TITLE
fix(server): remove unbalanced startup wait group

### DIFF
--- a/pkg/server/pixiu_start.go
+++ b/pkg/server/pixiu_start.go
@@ -20,7 +20,6 @@ package server
 import (
 	"net/http"
 	"strconv"
-	"sync"
 )
 
 import (
@@ -35,8 +34,6 @@ var server *Server
 
 // PX is Pixiu start struct
 type Server struct {
-	startWG sync.WaitGroup
-
 	listenerManager *ListenerManager
 	clusterManager  *ClusterManager
 	adapterManager  *AdapterManager
@@ -85,8 +82,6 @@ func (s *Server) GetTraceDriverManager() *tracing.TraceDriverManager {
 func (s *Server) Start() {
 	conf := config.GetBootstrap()
 
-	s.startWG.Add(1)
-
 	defer func() {
 		if re := recover(); re != nil {
 			logger.Error(re)
@@ -118,9 +113,7 @@ func (s *Server) Start() {
 
 // NewServer create server
 func NewServer() *Server {
-	return &Server{
-		startWG: sync.WaitGroup{},
-	}
+	return &Server{}
 }
 
 func Start(bs *model.Bootstrap) {
@@ -129,7 +122,9 @@ func Start(bs *model.Bootstrap) {
 	server = NewServer()
 	server.initialize(bs)
 	server.Start()
-	server.startWG.Wait()
+	// Block forever; the process exits on OS signals (default behavior),
+	// or via ListenerManager.gracefulShutdownInit when graceful shutdown is enabled.
+	select {}
 }
 
 func GetServer() *Server {

--- a/pkg/server/pixiu_start.go
+++ b/pkg/server/pixiu_start.go
@@ -32,6 +32,12 @@ import (
 
 var server *Server
 
+// blockForever blocks the main goroutine until the process exits.
+// Exposed as a variable to allow tests to replace it.
+var blockForever = func() {
+	select {}
+}
+
 // PX is Pixiu start struct
 type Server struct {
 	listenerManager *ListenerManager
@@ -124,7 +130,7 @@ func Start(bs *model.Bootstrap) {
 	server.Start()
 	// Block forever; the process exits on OS signals (default behavior),
 	// or via ListenerManager.gracefulShutdownInit when graceful shutdown is enabled.
-	select {}
+	blockForever()
 }
 
 func GetServer() *Server {

--- a/pkg/server/pixiu_start_test.go
+++ b/pkg/server/pixiu_start_test.go
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/config"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+)
+
+func TestStart_ReachesBlockPoint(t *testing.T) {
+	// Replace blockForever to prevent the test from hanging.
+	original := blockForever
+	blockForever = func() {}
+	defer func() { blockForever = original }()
+
+	bs := &model.Bootstrap{}
+	config.SetBootstrap(bs)
+	defer config.SetBootstrap(nil)
+
+	// Reset global server after test to avoid polluting other tests.
+	defer func() { server = nil }()
+
+	Start(bs)
+
+	s := GetServer()
+	assert.NotNil(t, s)
+	assert.NotNil(t, s.GetListenerManager())
+	assert.NotNil(t, s.GetClusterManager())
+	assert.NotNil(t, s.GetRouterManager())
+	assert.NotNil(t, s.GetApiConfigManager())
+	assert.NotNil(t, s.GetTraceDriverManager())
+}
+
+func TestServerStart_WithMinimalConfig(t *testing.T) {
+	bs := &model.Bootstrap{}
+	config.SetBootstrap(bs)
+	defer config.SetBootstrap(nil)
+
+	s := NewServer()
+	s.initialize(bs)
+	s.Start()
+
+	// Verify Start() returned without panicking.
+	assert.NotNil(t, s.GetListenerManager())
+	assert.NotNil(t, s.GetClusterManager())
+}


### PR DESCRIPTION
## Summary

The `startWG sync.WaitGroup` in `Server` struct had `Add(1)` called in `Start()` but **no matching `Done()` call anywhere** in the codebase. This made `server.startWG.Wait()` block indefinitely by accident — a misleading construct that appeared to coordinate something but was really just an unbalanced WaitGroup.

## Change

- Removed `startWG sync.WaitGroup` field from `Server` struct
- Removed `s.startWG.Add(1)` from `Server.Start()`
- Replaced `server.startWG.Wait()` with `select {}` — the Go idiom for "block forever"
- Removed unused `sync` import

## Why `select {}` is correct

The application shuts down via signal handling in `listener_manager.go:gracefulShutdownInit()`, where **every exit path calls `os.Exit(0)`**:

| Path | Line |
|------|------|
| Timeout during graceful shutdown | L103 |
| Error from listener `ShutDown()` | L112 |
| Normal completion after all listeners shut down | L124 |

There is no channel, context, or callback to notify the main goroutine of shutdown — the process simply exits. `select {}` is functionally equivalent to the old behavior but makes the intent explicit.

No tests are affected; no other code referenced `startWG`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)