### PR TITLE
fix(server): improve listener shutdown error handling

### DIFF
--- a/pkg/server/listener_manager.go
+++ b/pkg/server/listener_manager.go
@@ -46,6 +46,10 @@ type wrapListenerService struct {
 	config *model.Listener
 }
 
+// ShutdownFunc is the signature for a listener shutdown function.
+// It returns an error if shutdown failed.
+type ShutdownFunc func() error
+
 // ListenerManager the listener manager
 type ListenerManager struct {
 	bootstrap *model.Bootstrap
@@ -98,63 +102,18 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 		sig := <-signals
 		logger.Infof("get signal %s, dubbo-go-pixiu will start shutdown.", sig)
 
-		// Create error collection channel with capacity for all listeners
-		errCh := make(chan error, len(lm.activeListenerService))
-		// Create done channel to track completion of each listener goroutine
-		doneCh := make(chan struct{}, len(lm.activeListenerService))
-
-		// Start shutdown for all listeners
+		// Build shutdown functions for all listeners
+		shutdownFuncs := make([]ShutdownFunc, 0, len(lm.activeListenerService))
 		for _, listener := range lm.activeListenerService {
-			lm.shutdownWG.Add(1)
-			go func(listener *wrapListenerService) {
+			shutdownFuncs = append(shutdownFuncs, func() error {
+				lm.shutdownWG.Add(1)
 				// Note: listener.ShutDown() internally calls wg.Done()
-				err := listener.ShutDown(lm.shutdownWG)
-				if err != nil {
-					logger.Errorf("Shutdown Error: %+v", err)
-					errCh <- err
-				}
-				// Signal that this goroutine has completed (after potential error send)
-				doneCh <- struct{}{}
-			}(listener)
+				return listener.ShutDown(lm.shutdownWG)
+			})
 		}
 
-		// Wait for all listener goroutines to complete or timeout
-		// We use doneCh instead of relying solely on WaitGroup because:
-		// - listener.ShutDown() calls wg.Done() before returning
-		// - this ensures we wait until error is sent to errCh
-		allDone := make(chan struct{})
-		go func() {
-			for i := 0; i < len(lm.activeListenerService); i++ {
-				select {
-				case <-doneCh:
-					// listener goroutine completed
-				case <-time.After(5 * time.Second):
-					// Individual listener stuck, continue anyway
-					logger.Warn("Individual listener shutdown stuck")
-				}
-			}
-			close(allDone)
-		}()
-
-		select {
-		case <-allDone:
-			// All listener goroutines completed
-			logger.Info("All listeners shut down gracefully")
-		case <-time.After(timeout):
-			logger.Warn("Shutdown gracefully timeout, some listeners may not have shut down cleanly")
-		}
-
-		// Drain any remaining errors from the channel (non-blocking)
-		var shutdownErrors []error
-	drainErrors:
-		for {
-			select {
-			case err := <-errCh:
-				shutdownErrors = append(shutdownErrors, err)
-			default:
-				break drainErrors
-			}
-		}
+		// Execute shutdown coordination (extracted for testability)
+		shutdownErrors, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 		// those signals' original behavior is exit with dump ths stack, so we try to keep the behavior
 		for _, dumpSignal := range shutdown.DumpHeapShutdownSignals {
@@ -168,8 +127,80 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 			logger.Errorf("Shutdown completed with %d errors", len(shutdownErrors))
 			os.Exit(1)
 		}
+		if timedOut {
+			logger.Warn("Shutdown gracefully timeout, some listeners may not have shut down cleanly")
+		}
 		os.Exit(0)
 	}()
+}
+
+// shutdownListeners coordinates the shutdown of multiple listeners.
+// It returns a slice of errors from failed shutdowns and a boolean indicating
+// whether the shutdown timed out before all listeners completed.
+// This function is extracted from gracefulShutdownInit for testability.
+func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration) ([]error, bool) {
+	if len(shutdownFuncs) == 0 {
+		return nil, false
+	}
+
+	// Create error collection channel with capacity for all listeners
+	errCh := make(chan error, len(shutdownFuncs))
+	// Create done channel to track completion of each listener goroutine
+	doneCh := make(chan struct{}, len(shutdownFuncs))
+
+	// Start shutdown for all listeners
+	for _, shutdownFunc := range shutdownFuncs {
+		go func(fn ShutdownFunc) {
+			err := fn()
+			if err != nil {
+				logger.Errorf("Shutdown Error: %+v", err)
+				errCh <- err
+			}
+			// Signal that this goroutine has completed (after potential error send)
+			doneCh <- struct{}{}
+		}(shutdownFunc)
+	}
+
+	// Wait for all listener goroutines to complete or timeout
+	// We use doneCh instead of relying solely on WaitGroup because:
+	// - listener.ShutDown() calls wg.Done() before returning
+	// - this ensures we wait until error is sent to errCh
+	allDone := make(chan struct{})
+	go func() {
+		for i := 0; i < len(shutdownFuncs); i++ {
+			select {
+			case <-doneCh:
+				// listener goroutine completed
+			case <-time.After(5 * time.Second):
+				// Individual listener stuck, continue anyway
+				logger.Warn("Individual listener shutdown stuck")
+			}
+		}
+		close(allDone)
+	}()
+
+	var timedOut bool
+	select {
+	case <-allDone:
+		// All listener goroutines completed
+		logger.Info("All listeners shut down gracefully")
+	case <-time.After(timeout):
+		timedOut = true
+	}
+
+	// Drain any remaining errors from the channel (non-blocking)
+	var shutdownErrors []error
+drainErrors:
+	for {
+		select {
+		case err := <-errCh:
+			shutdownErrors = append(shutdownErrors, err)
+		default:
+			break drainErrors
+		}
+	}
+
+	return shutdownErrors, timedOut
 }
 
 func resolveListenerName(c *model.Listener) string {

--- a/pkg/server/listener_manager.go
+++ b/pkg/server/listener_manager.go
@@ -23,6 +23,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -132,7 +133,7 @@ func (lm *ListenerManager) handleShutdownSignal(sig os.Signal, timeout time.Dura
 	}
 
 	// Execute shutdown coordination
-	shutdownErrors, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+	shutdownErrors, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 	// those signals' original behavior is exit with dump ths stack, so we try to keep the behavior
 	for _, dumpSignal := range shutdown.DumpHeapShutdownSignals {
@@ -147,19 +148,25 @@ func (lm *ListenerManager) handleShutdownSignal(sig os.Signal, timeout time.Dura
 // shutdownListeners coordinates the shutdown of multiple listeners.
 // It returns a slice of errors from failed shutdowns and a boolean indicating
 // whether the shutdown timed out before all listeners completed.
-// This function is extracted from gracefulShutdownInit for testability.
-// The perListenerTimeout parameter controls how long we wait for each individual
-// listener goroutine before considering it stuck (default 5 seconds in production).
-func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration, perListenerTimeout time.Duration) ([]error, bool) {
+//
+// The overall timeout is the sole bound on how long we wait for listeners: it
+// must honor the user-configured graceful-shutdown budget. We deliberately do
+// NOT impose a shorter per-listener deadline. A fixed per-listener timeout
+// would let a single slow listener be considered "done" early and cause the
+// caller to os.Exit(0) and interrupt the graceful shutdown of listeners that
+// are still within their allowed time (P0 review feedback on PR #993).
+func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration) ([]error, bool) {
 	if len(shutdownFuncs) == 0 {
 		return nil, false
 	}
 
-	// Create error collection channel with capacity for all listeners
+	// Error channel is buffered so a slow send never blocks the worker goroutine.
 	errCh := make(chan error, len(shutdownFuncs))
-	// Create done channel to track completion of each listener goroutine
+	// doneCh is signalled by each worker AFTER its error (if any) has been sent,
+	// so receiving all doneCh signals guarantees every error is already queued.
 	doneCh := make(chan struct{}, len(shutdownFuncs))
 
+	var completed int32
 	// Start shutdown for all listeners
 	for _, shutdownFunc := range shutdownFuncs {
 		go func(fn ShutdownFunc) {
@@ -168,25 +175,19 @@ func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration, perL
 				logger.Errorf("Shutdown Error: %+v", err)
 				errCh <- err
 			}
-			// Signal that this goroutine has completed (after potential error send)
+			atomic.AddInt32(&completed, 1)
+			// Signal that this goroutine has completed (after the error send).
 			doneCh <- struct{}{}
 		}(shutdownFunc)
 	}
 
-	// Wait for all listener goroutines to complete or timeout
-	// We use doneCh instead of relying solely on WaitGroup because:
-	// - listener.ShutDown() calls wg.Done() before returning
-	// - this ensures we wait until error is sent to errCh
+	// Wait for every listener to finish, bounded only by the overall timeout.
+	// There is no per-listener deadline: a listener that is slow but still
+	// within the configured budget must be allowed to run to completion.
 	allDone := make(chan struct{})
 	go func() {
 		for i := 0; i < len(shutdownFuncs); i++ {
-			select {
-			case <-doneCh:
-				// listener goroutine completed
-			case <-time.After(perListenerTimeout):
-				// Individual listener stuck, continue anyway
-				logger.Warn("Individual listener shutdown stuck")
-			}
+			<-doneCh
 		}
 		close(allDone)
 	}()
@@ -198,9 +199,13 @@ func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration, perL
 		logger.Info("All listeners shut down gracefully")
 	case <-time.After(timeout):
 		timedOut = true
+		unfinished := int32(len(shutdownFuncs)) - atomic.LoadInt32(&completed)
+		logger.Warnf("Shutdown timed out after %s; %d of %d listener(s) did not finish gracefully",
+			timeout, unfinished, len(shutdownFuncs))
 	}
 
-	// Drain any remaining errors from the channel (non-blocking)
+	// Drain any queued errors (non-blocking). After allDone this is complete
+	// and safe (all sends are done); after a timeout it is best-effort.
 	var shutdownErrors []error
 drainErrors:
 	for {
@@ -214,11 +219,6 @@ drainErrors:
 
 	return shutdownErrors, timedOut
 }
-
-// defaultPerListenerTimeout is the default timeout for each individual listener
-// during graceful shutdown. If a listener takes longer than this, we continue
-// with other listeners but log a warning.
-const defaultPerListenerTimeout = 5 * time.Second
 
 func resolveListenerName(c *model.Listener) string {
 	return c.Address.SocketAddress.Address + "-" + strconv.Itoa(c.Address.SocketAddress.Port) + "-" + c.ProtocolStr

--- a/pkg/server/listener_manager.go
+++ b/pkg/server/listener_manager.go
@@ -102,25 +102,8 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 		sig := <-signals
 		logger.Infof("get signal %s, dubbo-go-pixiu will start shutdown.", sig)
 
-		// Build shutdown functions for all listeners
-		shutdownFuncs := make([]ShutdownFunc, 0, len(lm.activeListenerService))
-		for _, listener := range lm.activeListenerService {
-			shutdownFuncs = append(shutdownFuncs, func() error {
-				lm.shutdownWG.Add(1)
-				// Note: listener.ShutDown() internally calls wg.Done()
-				return listener.ShutDown(lm.shutdownWG)
-			})
-		}
-
-		// Execute shutdown coordination (extracted for testability)
-		shutdownErrors, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
-
-		// those signals' original behavior is exit with dump ths stack, so we try to keep the behavior
-		for _, dumpSignal := range shutdown.DumpHeapShutdownSignals {
-			if sig == dumpSignal {
-				debug.WriteHeapDump(os.Stdout.Fd())
-			}
-		}
+		// Handle shutdown signal (extracted for testability)
+		shutdownErrors, timedOut := lm.handleShutdownSignal(sig, timeout)
 
 		// Exit with appropriate code based on shutdown errors
 		if len(shutdownErrors) > 0 {
@@ -132,6 +115,33 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 		}
 		os.Exit(0)
 	}()
+}
+
+// handleShutdownSignal processes a shutdown signal by coordinating listener shutdowns.
+// It returns a slice of errors from failed shutdowns and a boolean indicating timeout.
+// This function is extracted from gracefulShutdownInit for testability.
+func (lm *ListenerManager) handleShutdownSignal(sig os.Signal, timeout time.Duration) ([]error, bool) {
+	// Build shutdown functions for all listeners
+	shutdownFuncs := make([]ShutdownFunc, 0, len(lm.activeListenerService))
+	for _, listener := range lm.activeListenerService {
+		shutdownFuncs = append(shutdownFuncs, func() error {
+			lm.shutdownWG.Add(1)
+			// Note: listener.ShutDown() internally calls wg.Done()
+			return listener.ShutDown(lm.shutdownWG)
+		})
+	}
+
+	// Execute shutdown coordination
+	shutdownErrors, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+
+	// those signals' original behavior is exit with dump ths stack, so we try to keep the behavior
+	for _, dumpSignal := range shutdown.DumpHeapShutdownSignals {
+		if sig == dumpSignal {
+			debug.WriteHeapDump(os.Stdout.Fd())
+		}
+	}
+
+	return shutdownErrors, timedOut
 }
 
 // shutdownListeners coordinates the shutdown of multiple listeners.

--- a/pkg/server/listener_manager.go
+++ b/pkg/server/listener_manager.go
@@ -100,6 +100,8 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 
 		// Create error collection channel with capacity for all listeners
 		errCh := make(chan error, len(lm.activeListenerService))
+		// Create done channel to track completion of each listener goroutine
+		doneCh := make(chan struct{}, len(lm.activeListenerService))
 
 		// Start shutdown for all listeners
 		for _, listener := range lm.activeListenerService {
@@ -111,19 +113,32 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 					logger.Errorf("Shutdown Error: %+v", err)
 					errCh <- err
 				}
+				// Signal that this goroutine has completed (after potential error send)
+				doneCh <- struct{}{}
 			}(listener)
 		}
 
-		// Wait for all shutdowns to complete or timeout
-		done := make(chan struct{})
+		// Wait for all listener goroutines to complete or timeout
+		// We use doneCh instead of relying solely on WaitGroup because:
+		// - listener.ShutDown() calls wg.Done() before returning
+		// - this ensures we wait until error is sent to errCh
+		allDone := make(chan struct{})
 		go func() {
-			lm.shutdownWG.Wait()
-			close(done)
+			for i := 0; i < len(lm.activeListenerService); i++ {
+				select {
+				case <-doneCh:
+					// listener goroutine completed
+				case <-time.After(5 * time.Second):
+					// Individual listener stuck, continue anyway
+					logger.Warn("Individual listener shutdown stuck")
+				}
+			}
+			close(allDone)
 		}()
 
 		select {
-		case <-done:
-			// All shutdowns completed
+		case <-allDone:
+			// All listener goroutines completed
 			logger.Info("All listeners shut down gracefully")
 		case <-time.After(timeout):
 			logger.Warn("Shutdown gracefully timeout, some listeners may not have shut down cleanly")
@@ -131,7 +146,7 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 
 		// Drain any remaining errors from the channel (non-blocking)
 		var shutdownErrors []error
-		drainErrors:
+	drainErrors:
 		for {
 			select {
 			case err := <-errCh:

--- a/pkg/server/listener_manager.go
+++ b/pkg/server/listener_manager.go
@@ -98,28 +98,60 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 		sig := <-signals
 		logger.Infof("get signal %s, dubbo-go-pixiu will start shutdown.", sig)
 
-		time.AfterFunc(timeout, func() {
-			logger.Warn("Shutdown gracefully timeout, listeners will shutdown immediately. ")
-			os.Exit(0)
-		})
+		// Create error collection channel with capacity for all listeners
+		errCh := make(chan error, len(lm.activeListenerService))
 
+		// Start shutdown for all listeners
 		for _, listener := range lm.activeListenerService {
 			lm.shutdownWG.Add(1)
 			go func(listener *wrapListenerService) {
+				// Note: listener.ShutDown() internally calls wg.Done()
 				err := listener.ShutDown(lm.shutdownWG)
 				if err != nil {
 					logger.Errorf("Shutdown Error: %+v", err)
-					os.Exit(0)
+					errCh <- err
 				}
 			}(listener)
 		}
-		lm.shutdownWG.Wait()
+
+		// Wait for all shutdowns to complete or timeout
+		done := make(chan struct{})
+		go func() {
+			lm.shutdownWG.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// All shutdowns completed
+			logger.Info("All listeners shut down gracefully")
+		case <-time.After(timeout):
+			logger.Warn("Shutdown gracefully timeout, some listeners may not have shut down cleanly")
+		}
+
+		// Drain any remaining errors from the channel (non-blocking)
+		var shutdownErrors []error
+		drainErrors:
+		for {
+			select {
+			case err := <-errCh:
+				shutdownErrors = append(shutdownErrors, err)
+			default:
+				break drainErrors
+			}
+		}
 
 		// those signals' original behavior is exit with dump ths stack, so we try to keep the behavior
 		for _, dumpSignal := range shutdown.DumpHeapShutdownSignals {
 			if sig == dumpSignal {
 				debug.WriteHeapDump(os.Stdout.Fd())
 			}
+		}
+
+		// Exit with appropriate code based on shutdown errors
+		if len(shutdownErrors) > 0 {
+			logger.Errorf("Shutdown completed with %d errors", len(shutdownErrors))
+			os.Exit(1)
 		}
 		os.Exit(0)
 	}()

--- a/pkg/server/listener_manager.go
+++ b/pkg/server/listener_manager.go
@@ -113,7 +113,7 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 		}
 
 		// Execute shutdown coordination (extracted for testability)
-		shutdownErrors, timedOut := shutdownListeners(shutdownFuncs, timeout)
+		shutdownErrors, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
 
 		// those signals' original behavior is exit with dump ths stack, so we try to keep the behavior
 		for _, dumpSignal := range shutdown.DumpHeapShutdownSignals {
@@ -138,7 +138,9 @@ func (lm *ListenerManager) gracefulShutdownInit() {
 // It returns a slice of errors from failed shutdowns and a boolean indicating
 // whether the shutdown timed out before all listeners completed.
 // This function is extracted from gracefulShutdownInit for testability.
-func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration) ([]error, bool) {
+// The perListenerTimeout parameter controls how long we wait for each individual
+// listener goroutine before considering it stuck (default 5 seconds in production).
+func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration, perListenerTimeout time.Duration) ([]error, bool) {
 	if len(shutdownFuncs) == 0 {
 		return nil, false
 	}
@@ -171,7 +173,7 @@ func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration) ([]e
 			select {
 			case <-doneCh:
 				// listener goroutine completed
-			case <-time.After(5 * time.Second):
+			case <-time.After(perListenerTimeout):
 				// Individual listener stuck, continue anyway
 				logger.Warn("Individual listener shutdown stuck")
 			}
@@ -202,6 +204,11 @@ drainErrors:
 
 	return shutdownErrors, timedOut
 }
+
+// defaultPerListenerTimeout is the default timeout for each individual listener
+// during graceful shutdown. If a listener takes longer than this, we continue
+// with other listeners but log a warning.
+const defaultPerListenerTimeout = 5 * time.Second
 
 func resolveListenerName(c *model.Listener) string {
 	return c.Address.SocketAddress.Address + "-" + strconv.Itoa(c.Address.SocketAddress.Port) + "-" + c.ProtocolStr

--- a/pkg/server/listener_manager.go
+++ b/pkg/server/listener_manager.go
@@ -162,7 +162,7 @@ func shutdownListeners(shutdownFuncs []ShutdownFunc, timeout time.Duration) ([]e
 
 	// Error channel is buffered so a slow send never blocks the worker goroutine.
 	errCh := make(chan error, len(shutdownFuncs))
-	// doneCh is signalled by each worker AFTER its error (if any) has been sent,
+	// doneCh is signaled by each worker AFTER its error (if any) has been sent,
 	// so receiving all doneCh signals guarantees every error is already queued.
 	doneCh := make(chan struct{}, len(shutdownFuncs))
 

--- a/pkg/server/listener_manager_test.go
+++ b/pkg/server/listener_manager_test.go
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestShutdownWaitGroupDoubleDoneWouldPanic demonstrates that calling Done()
+// twice on a WaitGroup with counter 1 would panic (negative counter).
+func TestShutdownWaitGroupDoubleDoneWouldPanic(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	// First Done() - should be fine
+	wg.Done()
+
+	// Second Done() - should panic because counter becomes negative
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic when Done() called twice on WaitGroup with counter 1")
+		}
+	}()
+
+	wg.Done() // This should panic
+}
+
+// TestShutdownErrorCollection verifies that shutdown errors are collected
+// instead of causing immediate exit.
+func TestShutdownErrorCollection(t *testing.T) {
+	numListeners := 3
+	errCh := make(chan error, numListeners)
+
+	results := []struct {
+		hasError bool
+	}{
+		{hasError: false},
+		{hasError: true},
+		{hasError: false},
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(numListeners)
+
+	for i, result := range results {
+		go func(idx int, hasError bool) {
+			defer wg.Done()
+			if hasError {
+				errCh <- &testShutdownError{msg: "listener failed"}
+			}
+		}(i, result.hasError)
+	}
+
+	wg.Wait()
+
+	// Drain errors using labeled break pattern from listener_manager.go
+	var shutdownErrors []error
+	drainErrors:
+	for {
+		select {
+		case err := <-errCh:
+			shutdownErrors = append(shutdownErrors, err)
+		default:
+			break drainErrors
+		}
+	}
+
+	if len(shutdownErrors) != 1 {
+		t.Errorf("Expected 1 shutdown error, got %d", len(shutdownErrors))
+	}
+}
+
+// TestShutdownTimeoutHandling verifies timeout handling pattern
+func TestShutdownTimeoutHandling(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	timeout := 100 * time.Millisecond
+
+	// Listener 1 completes quickly
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		wg.Done()
+	}()
+
+	// Listener 2 takes longer than timeout
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		wg.Done()
+	}()
+
+	// Use the pattern from listener_manager.go
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Log("All shutdowns completed before timeout")
+	case <-time.After(timeout):
+		t.Log("Shutdown timeout reached (expected behavior)")
+	}
+
+	// Wait for remaining listener to complete (cleanup)
+	<-done
+}
+
+// TestLabeledBreakPattern verifies the labeled break pattern for draining channel
+func TestLabeledBreakPattern(t *testing.T) {
+	ch := make(chan int, 3)
+	ch <- 1
+	ch <- 2
+	ch <- 3
+
+	var collected []int
+	drainLoop:
+	for {
+		select {
+		case v := <-ch:
+			collected = append(collected, v)
+		default:
+			break drainLoop // This breaks the for loop, not just the select
+		}
+	}
+
+	if len(collected) != 3 {
+		t.Errorf("Expected to collect 3 values, got %d", len(collected))
+	}
+}
+
+// testShutdownError is a simple error type for testing
+type testShutdownError struct {
+	msg string
+}
+
+func (e *testShutdownError) Error() string {
+	return e.msg
+}

--- a/pkg/server/listener_manager_test.go
+++ b/pkg/server/listener_manager_test.go
@@ -70,7 +70,7 @@ func TestShutdownListenersNoErrors(t *testing.T) {
 	}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 	if len(errs) != 0 {
 		t.Errorf("Expected no errors, got %d: %v", len(errs), errs)
@@ -91,7 +91,7 @@ func TestShutdownListenersWithErrors(t *testing.T) {
 	}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 	if len(errs) != 1 {
 		t.Errorf("Expected 1 error, got %d", len(errs))
@@ -114,7 +114,7 @@ func TestShutdownListenersAllErrors(t *testing.T) {
 	}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 	if len(errs) != 3 {
 		t.Errorf("Expected 3 errors, got %d", len(errs))
@@ -134,7 +134,7 @@ func TestShutdownListenersTimeout(t *testing.T) {
 	}
 
 	timeout := 50 * time.Millisecond
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 	// Should have timed out but still collected errors from fast listeners
 	if !timedOut {
@@ -164,7 +164,7 @@ func TestShutdownListenersRaceCondition(t *testing.T) {
 	}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 	// Both errors should be collected despite the delay
 	if len(errs) != 2 {
@@ -180,7 +180,7 @@ func TestShutdownListenersEmpty(t *testing.T) {
 	shutdownFuncs := []ShutdownFunc{}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 	if len(errs) != 0 {
 		t.Errorf("Expected no errors, got %d", len(errs))
@@ -199,7 +199,7 @@ func TestShutdownListenersTimeoutWithError(t *testing.T) {
 	}
 
 	timeout := 50 * time.Millisecond
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
 	if !timedOut {
 		t.Error("Expected timeout, but did not time out")
@@ -229,30 +229,50 @@ func TestShutdownWaitGroupDoubleDoneWouldPanic(t *testing.T) {
 	wg.Done() // This should panic
 }
 
-// TestShutdownListenersStuckListener tests that shutdownListeners handles
-// individual listeners that get stuck (exceed the per-listener timeout).
-func TestShutdownListenersStuckListener(t *testing.T) {
-	// Use a short per-listener timeout for testing
-	perListenerTimeout := 100 * time.Millisecond
-	// Create a listener that will get stuck
+// TestShutdownListenersSlowListenerWithinBudget verifies the P0 fix from
+// PR #993: a listener that is slow but still within the configured overall
+// timeout must be allowed to run to completion. There is no per-listener
+// deadline that could consider it "done" early and trigger a premature exit.
+func TestShutdownListenersSlowListenerWithinBudget(t *testing.T) {
+	// One slow listener plus a fast one. The slow listener takes a meaningful
+	// amount of time but stays well under the overall budget.
 	shutdownFuncs := []ShutdownFunc{
 		func() error { return nil }, // fast listener
 		func() error {
-			// This listener blocks longer than perListenerTimeout
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(150 * time.Millisecond)
 			return nil
 		},
 	}
 
-	// Use a timeout longer than perListenerTimeout so we can observe the stuck behavior
+	// Overall budget comfortably larger than the slow listener's runtime.
 	timeout := 300 * time.Millisecond
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, perListenerTimeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
 
-	// Should not timeout because overall timeout is longer than listener sleep
+	// Should not timeout because the slow listener finishes within the budget.
 	if timedOut {
-		t.Error("Did not expect overall timeout")
+		t.Error("Did not expect overall timeout for listeners within budget")
 	}
 	// No errors because listeners return nil
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got %d", len(errs))
+	}
+}
+
+// TestShutdownListenersSingleListenerWithinBudget verifies the P0 scenario
+// directly: a single listener whose runtime exceeds what a fixed per-listener
+// timeout would have allowed, but is within the configured overall timeout,
+// must not be cut short.
+func TestShutdownListenersSingleListenerWithinBudget(t *testing.T) {
+	shutdownFuncs := []ShutdownFunc{
+		func() error { time.Sleep(150 * time.Millisecond); return nil },
+	}
+
+	timeout := 300 * time.Millisecond
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+
+	if timedOut {
+		t.Error("Did not expect overall timeout for a listener within budget")
+	}
 	if len(errs) != 0 {
 		t.Errorf("Expected no errors, got %d", len(errs))
 	}

--- a/pkg/server/listener_manager_test.go
+++ b/pkg/server/listener_manager_test.go
@@ -47,6 +47,7 @@ func TestShutdownWaitGroupDoubleDoneWouldPanic(t *testing.T) {
 func TestShutdownErrorCollection(t *testing.T) {
 	numListeners := 3
 	errCh := make(chan error, numListeners)
+	doneCh := make(chan struct{}, numListeners)
 
 	results := []struct {
 		hasError bool
@@ -56,23 +57,24 @@ func TestShutdownErrorCollection(t *testing.T) {
 		{hasError: false},
 	}
 
-	wg := &sync.WaitGroup{}
-	wg.Add(numListeners)
-
 	for i, result := range results {
 		go func(idx int, hasError bool) {
-			defer wg.Done()
 			if hasError {
 				errCh <- &testShutdownError{msg: "listener failed"}
 			}
+			// Signal completion AFTER potential error send (like listener_manager.go)
+			doneCh <- struct{}{}
 		}(i, result.hasError)
 	}
 
-	wg.Wait()
+	// Wait for all goroutines to complete (like listener_manager.go pattern)
+	for i := 0; i < numListeners; i++ {
+		<-doneCh
+	}
 
 	// Drain errors using labeled break pattern from listener_manager.go
 	var shutdownErrors []error
-	drainErrors:
+drainErrors:
 	for {
 		select {
 		case err := <-errCh:
@@ -89,39 +91,116 @@ func TestShutdownErrorCollection(t *testing.T) {
 
 // TestShutdownTimeoutHandling verifies timeout handling pattern
 func TestShutdownTimeoutHandling(t *testing.T) {
-	wg := &sync.WaitGroup{}
-	wg.Add(2)
+	numListeners := 2
+	doneCh := make(chan struct{}, numListeners)
 
 	timeout := 100 * time.Millisecond
 
 	// Listener 1 completes quickly
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		wg.Done()
+		doneCh <- struct{}{}
 	}()
 
 	// Listener 2 takes longer than timeout
 	go func() {
 		time.Sleep(200 * time.Millisecond)
-		wg.Done()
+		doneCh <- struct{}{}
 	}()
 
 	// Use the pattern from listener_manager.go
-	done := make(chan struct{})
+	allDone := make(chan struct{})
 	go func() {
-		wg.Wait()
-		close(done)
+		for i := 0; i < numListeners; i++ {
+			select {
+			case <-doneCh:
+				// listener completed
+			case <-time.After(5 * time.Second):
+				// individual listener stuck (not expected in this test)
+			}
+		}
+		close(allDone)
 	}()
 
 	select {
-	case <-done:
+	case <-allDone:
 		t.Log("All shutdowns completed before timeout")
 	case <-time.After(timeout):
 		t.Log("Shutdown timeout reached (expected behavior)")
 	}
 
 	// Wait for remaining listener to complete (cleanup)
-	<-done
+	<-allDone
+}
+
+// TestShutdownRaceConditionFix verifies that errors are correctly collected
+// even when wg.Done() is called before the error is sent to errCh.
+// This is the race condition that Copilot identified in PR #993.
+func TestShutdownRaceConditionFix(t *testing.T) {
+	numListeners := 2
+	errCh := make(chan error, numListeners)
+	doneCh := make(chan struct{}, numListeners)
+	wg := &sync.WaitGroup{}
+	wg.Add(numListeners)
+
+	// Simulate the pattern from listener.ShutDown() where wg.Done() is called
+	// in a defer before returning (and before listener_manager.go can send error)
+	for i := 0; i < numListeners; i++ {
+		go func(idx int) {
+			// Simulate ShutDown behavior: wg.Done() in defer
+			defer wg.Done()
+
+			// Simulate an error during shutdown
+			time.Sleep(10 * time.Millisecond)
+			// At this point, wg.Done() has been called (WaitGroup reaches 0)
+			// but we haven't yet returned to listener_manager.go's goroutine
+
+			// In the fixed implementation, listener_manager.go waits for doneCh
+			// which is sent AFTER the error is sent
+			if idx == 0 {
+				errCh <- &testShutdownError{msg: "shutdown error 1"}
+			}
+			if idx == 1 {
+				errCh <- &testShutdownError{msg: "shutdown error 2"}
+			}
+			// Signal completion AFTER error send
+			doneCh <- struct{}{}
+		}(i)
+	}
+
+	// Wait for all listener goroutines to complete (the fixed pattern)
+	allDone := make(chan struct{})
+	go func() {
+		for i := 0; i < numListeners; i++ {
+			<-doneCh
+		}
+		close(allDone)
+	}()
+
+	// Wait with timeout
+	select {
+	case <-allDone:
+		t.Log("All listeners completed")
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for listeners")
+	}
+
+	// Drain errors
+	var shutdownErrors []error
+drainLoop:
+	for {
+		select {
+		case err := <-errCh:
+			shutdownErrors = append(shutdownErrors, err)
+		default:
+			break drainLoop
+		}
+	}
+
+	// Both errors should be collected despite the race condition
+	if len(shutdownErrors) != 2 {
+		t.Errorf("Expected 2 shutdown errors, got %d - race condition not fixed", len(shutdownErrors))
+	}
 }
 
 // TestLabeledBreakPattern verifies the labeled break pattern for draining channel
@@ -132,7 +211,7 @@ func TestLabeledBreakPattern(t *testing.T) {
 	ch <- 3
 
 	var collected []int
-	drainLoop:
+drainLoop:
 	for {
 		select {
 		case v := <-ch:

--- a/pkg/server/listener_manager_test.go
+++ b/pkg/server/listener_manager_test.go
@@ -35,7 +35,7 @@ func TestShutdownListenersNoErrors(t *testing.T) {
 	}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
 
 	if len(errs) != 0 {
 		t.Errorf("Expected no errors, got %d: %v", len(errs), errs)
@@ -56,7 +56,7 @@ func TestShutdownListenersWithErrors(t *testing.T) {
 	}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
 
 	if len(errs) != 1 {
 		t.Errorf("Expected 1 error, got %d", len(errs))
@@ -79,7 +79,7 @@ func TestShutdownListenersAllErrors(t *testing.T) {
 	}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
 
 	if len(errs) != 3 {
 		t.Errorf("Expected 3 errors, got %d", len(errs))
@@ -99,7 +99,7 @@ func TestShutdownListenersTimeout(t *testing.T) {
 	}
 
 	timeout := 50 * time.Millisecond
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
 
 	// Should have timed out but still collected errors from fast listeners
 	if !timedOut {
@@ -129,7 +129,7 @@ func TestShutdownListenersRaceCondition(t *testing.T) {
 	}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
 
 	// Both errors should be collected despite the delay
 	if len(errs) != 2 {
@@ -145,7 +145,7 @@ func TestShutdownListenersEmpty(t *testing.T) {
 	shutdownFuncs := []ShutdownFunc{}
 
 	timeout := 1 * time.Second
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
 
 	if len(errs) != 0 {
 		t.Errorf("Expected no errors, got %d", len(errs))
@@ -164,7 +164,7 @@ func TestShutdownListenersTimeoutWithError(t *testing.T) {
 	}
 
 	timeout := 50 * time.Millisecond
-	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, defaultPerListenerTimeout)
 
 	if !timedOut {
 		t.Error("Expected timeout, but did not time out")
@@ -192,4 +192,33 @@ func TestShutdownWaitGroupDoubleDoneWouldPanic(t *testing.T) {
 	}()
 
 	wg.Done() // This should panic
+}
+
+// TestShutdownListenersStuckListener tests that shutdownListeners handles
+// individual listeners that get stuck (exceed the per-listener timeout).
+func TestShutdownListenersStuckListener(t *testing.T) {
+	// Use a short per-listener timeout for testing
+	perListenerTimeout := 100 * time.Millisecond
+	// Create a listener that will get stuck
+	shutdownFuncs := []ShutdownFunc{
+		func() error { return nil }, // fast listener
+		func() error {
+			// This listener blocks longer than perListenerTimeout
+			time.Sleep(200 * time.Millisecond)
+			return nil
+		},
+	}
+
+	// Use a timeout longer than perListenerTimeout so we can observe the stuck behavior
+	timeout := 300 * time.Millisecond
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout, perListenerTimeout)
+
+	// Should not timeout because overall timeout is longer than listener sleep
+	if timedOut {
+		t.Error("Did not expect overall timeout")
+	}
+	// No errors because listeners return nil
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got %d", len(errs))
+	}
 }

--- a/pkg/server/listener_manager_test.go
+++ b/pkg/server/listener_manager_test.go
@@ -369,7 +369,7 @@ type mockSlowListenerService struct {
 }
 
 func (m *mockSlowListenerService) Start() error { return nil }
-func (m *mockSlowListenerService) Close() error  { return nil }
+func (m *mockSlowListenerService) Close() error { return nil }
 func (m *mockSlowListenerService) ShutDown(wg any) error {
 	time.Sleep(m.duration)
 	if w, ok := wg.(*sync.WaitGroup); ok && w != nil {

--- a/pkg/server/listener_manager_test.go
+++ b/pkg/server/listener_manager_test.go
@@ -24,7 +24,9 @@ import (
 	"syscall"
 	"testing"
 	"time"
+)
 
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
 

--- a/pkg/server/listener_manager_test.go
+++ b/pkg/server/listener_manager_test.go
@@ -18,10 +18,162 @@
 package server
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
 )
+
+// TestShutdownListenersNoErrors tests shutdownListeners when all listeners
+// shut down successfully without errors.
+func TestShutdownListenersNoErrors(t *testing.T) {
+	// Create fake listeners that shut down successfully
+	shutdownFuncs := []ShutdownFunc{
+		func() error { return nil },
+		func() error { return nil },
+		func() error { return nil },
+	}
+
+	timeout := 1 * time.Second
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got %d: %v", len(errs), errs)
+	}
+	if timedOut {
+		t.Error("Expected no timeout, but timed out")
+	}
+}
+
+// TestShutdownListenersWithErrors tests shutdownListeners when some listeners
+// return errors during shutdown.
+func TestShutdownListenersWithErrors(t *testing.T) {
+	testErr := errors.New("shutdown failed")
+	shutdownFuncs := []ShutdownFunc{
+		func() error { return nil },
+		func() error { return testErr },
+		func() error { return nil },
+	}
+
+	timeout := 1 * time.Second
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+
+	if len(errs) != 1 {
+		t.Errorf("Expected 1 error, got %d", len(errs))
+	}
+	if timedOut {
+		t.Error("Expected no timeout, but timed out")
+	}
+	if errs[0].Error() != testErr.Error() {
+		t.Errorf("Expected error '%s', got '%s'", testErr.Error(), errs[0].Error())
+	}
+}
+
+// TestShutdownListenersAllErrors tests shutdownListeners when all listeners
+// return errors.
+func TestShutdownListenersAllErrors(t *testing.T) {
+	shutdownFuncs := []ShutdownFunc{
+		func() error { return errors.New("error 1") },
+		func() error { return errors.New("error 2") },
+		func() error { return errors.New("error 3") },
+	}
+
+	timeout := 1 * time.Second
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+
+	if len(errs) != 3 {
+		t.Errorf("Expected 3 errors, got %d", len(errs))
+	}
+	if timedOut {
+		t.Error("Expected no timeout, but timed out")
+	}
+}
+
+// TestShutdownListenersTimeout tests shutdownListeners when listeners take
+// longer than the timeout.
+func TestShutdownListenersTimeout(t *testing.T) {
+	shutdownFuncs := []ShutdownFunc{
+		func() error { time.Sleep(10 * time.Millisecond); return nil },
+		func() error { time.Sleep(200 * time.Millisecond); return nil }, // exceeds timeout
+		func() error { time.Sleep(10 * time.Millisecond); return nil },
+	}
+
+	timeout := 50 * time.Millisecond
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+
+	// Should have timed out but still collected errors from fast listeners
+	if !timedOut {
+		t.Error("Expected timeout, but did not time out")
+	}
+	// No errors in this case (all listeners return nil), but timeout should be set
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors (all returned nil), got %d", len(errs))
+	}
+}
+
+// TestShutdownListenersRaceCondition verifies that errors are correctly collected
+// even when listeners have slow error reporting after completing their work.
+// This addresses the race condition Copilot identified in PR #993.
+func TestShutdownListenersRaceCondition(t *testing.T) {
+	// Simulate slow error send after shutdown completes
+	shutdownFuncs := []ShutdownFunc{
+		func() error {
+			time.Sleep(10 * time.Millisecond)
+			// Simulate slow error channel send
+			return errors.New("delayed error 1")
+		},
+		func() error {
+			time.Sleep(10 * time.Millisecond)
+			return errors.New("delayed error 2")
+		},
+	}
+
+	timeout := 1 * time.Second
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+
+	// Both errors should be collected despite the delay
+	if len(errs) != 2 {
+		t.Errorf("Expected 2 errors, got %d - race condition not fixed", len(errs))
+	}
+	if timedOut {
+		t.Error("Expected no timeout, but timed out")
+	}
+}
+
+// TestShutdownListenersEmpty tests shutdownListeners with no listeners.
+func TestShutdownListenersEmpty(t *testing.T) {
+	shutdownFuncs := []ShutdownFunc{}
+
+	timeout := 1 * time.Second
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got %d", len(errs))
+	}
+	if timedOut {
+		t.Error("Expected no timeout, but timed out")
+	}
+}
+
+// TestShutdownListenersTimeoutWithError tests that errors are collected
+// even when timeout occurs.
+func TestShutdownListenersTimeoutWithError(t *testing.T) {
+	shutdownFuncs := []ShutdownFunc{
+		func() error { return errors.New("fast error") },
+		func() error { time.Sleep(200 * time.Millisecond); return nil }, // exceeds timeout
+	}
+
+	timeout := 50 * time.Millisecond
+	errs, timedOut := shutdownListeners(shutdownFuncs, timeout)
+
+	if !timedOut {
+		t.Error("Expected timeout, but did not time out")
+	}
+	// The fast error should still be collected
+	if len(errs) != 1 {
+		t.Errorf("Expected 1 error from fast listener, got %d", len(errs))
+	}
+}
 
 // TestShutdownWaitGroupDoubleDoneWouldPanic demonstrates that calling Done()
 // twice on a WaitGroup with counter 1 would panic (negative counter).
@@ -40,197 +192,4 @@ func TestShutdownWaitGroupDoubleDoneWouldPanic(t *testing.T) {
 	}()
 
 	wg.Done() // This should panic
-}
-
-// TestShutdownErrorCollection verifies that shutdown errors are collected
-// instead of causing immediate exit.
-func TestShutdownErrorCollection(t *testing.T) {
-	numListeners := 3
-	errCh := make(chan error, numListeners)
-	doneCh := make(chan struct{}, numListeners)
-
-	results := []struct {
-		hasError bool
-	}{
-		{hasError: false},
-		{hasError: true},
-		{hasError: false},
-	}
-
-	for i, result := range results {
-		go func(idx int, hasError bool) {
-			if hasError {
-				errCh <- &testShutdownError{msg: "listener failed"}
-			}
-			// Signal completion AFTER potential error send (like listener_manager.go)
-			doneCh <- struct{}{}
-		}(i, result.hasError)
-	}
-
-	// Wait for all goroutines to complete (like listener_manager.go pattern)
-	for i := 0; i < numListeners; i++ {
-		<-doneCh
-	}
-
-	// Drain errors using labeled break pattern from listener_manager.go
-	var shutdownErrors []error
-drainErrors:
-	for {
-		select {
-		case err := <-errCh:
-			shutdownErrors = append(shutdownErrors, err)
-		default:
-			break drainErrors
-		}
-	}
-
-	if len(shutdownErrors) != 1 {
-		t.Errorf("Expected 1 shutdown error, got %d", len(shutdownErrors))
-	}
-}
-
-// TestShutdownTimeoutHandling verifies timeout handling pattern
-func TestShutdownTimeoutHandling(t *testing.T) {
-	numListeners := 2
-	doneCh := make(chan struct{}, numListeners)
-
-	timeout := 100 * time.Millisecond
-
-	// Listener 1 completes quickly
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		doneCh <- struct{}{}
-	}()
-
-	// Listener 2 takes longer than timeout
-	go func() {
-		time.Sleep(200 * time.Millisecond)
-		doneCh <- struct{}{}
-	}()
-
-	// Use the pattern from listener_manager.go
-	allDone := make(chan struct{})
-	go func() {
-		for i := 0; i < numListeners; i++ {
-			select {
-			case <-doneCh:
-				// listener completed
-			case <-time.After(5 * time.Second):
-				// individual listener stuck (not expected in this test)
-			}
-		}
-		close(allDone)
-	}()
-
-	select {
-	case <-allDone:
-		t.Log("All shutdowns completed before timeout")
-	case <-time.After(timeout):
-		t.Log("Shutdown timeout reached (expected behavior)")
-	}
-
-	// Wait for remaining listener to complete (cleanup)
-	<-allDone
-}
-
-// TestShutdownRaceConditionFix verifies that errors are correctly collected
-// even when wg.Done() is called before the error is sent to errCh.
-// This is the race condition that Copilot identified in PR #993.
-func TestShutdownRaceConditionFix(t *testing.T) {
-	numListeners := 2
-	errCh := make(chan error, numListeners)
-	doneCh := make(chan struct{}, numListeners)
-	wg := &sync.WaitGroup{}
-	wg.Add(numListeners)
-
-	// Simulate the pattern from listener.ShutDown() where wg.Done() is called
-	// in a defer before returning (and before listener_manager.go can send error)
-	for i := 0; i < numListeners; i++ {
-		go func(idx int) {
-			// Simulate ShutDown behavior: wg.Done() in defer
-			defer wg.Done()
-
-			// Simulate an error during shutdown
-			time.Sleep(10 * time.Millisecond)
-			// At this point, wg.Done() has been called (WaitGroup reaches 0)
-			// but we haven't yet returned to listener_manager.go's goroutine
-
-			// In the fixed implementation, listener_manager.go waits for doneCh
-			// which is sent AFTER the error is sent
-			if idx == 0 {
-				errCh <- &testShutdownError{msg: "shutdown error 1"}
-			}
-			if idx == 1 {
-				errCh <- &testShutdownError{msg: "shutdown error 2"}
-			}
-			// Signal completion AFTER error send
-			doneCh <- struct{}{}
-		}(i)
-	}
-
-	// Wait for all listener goroutines to complete (the fixed pattern)
-	allDone := make(chan struct{})
-	go func() {
-		for i := 0; i < numListeners; i++ {
-			<-doneCh
-		}
-		close(allDone)
-	}()
-
-	// Wait with timeout
-	select {
-	case <-allDone:
-		t.Log("All listeners completed")
-	case <-time.After(1 * time.Second):
-		t.Fatal("Timeout waiting for listeners")
-	}
-
-	// Drain errors
-	var shutdownErrors []error
-drainLoop:
-	for {
-		select {
-		case err := <-errCh:
-			shutdownErrors = append(shutdownErrors, err)
-		default:
-			break drainLoop
-		}
-	}
-
-	// Both errors should be collected despite the race condition
-	if len(shutdownErrors) != 2 {
-		t.Errorf("Expected 2 shutdown errors, got %d - race condition not fixed", len(shutdownErrors))
-	}
-}
-
-// TestLabeledBreakPattern verifies the labeled break pattern for draining channel
-func TestLabeledBreakPattern(t *testing.T) {
-	ch := make(chan int, 3)
-	ch <- 1
-	ch <- 2
-	ch <- 3
-
-	var collected []int
-drainLoop:
-	for {
-		select {
-		case v := <-ch:
-			collected = append(collected, v)
-		default:
-			break drainLoop // This breaks the for loop, not just the select
-		}
-	}
-
-	if len(collected) != 3 {
-		t.Errorf("Expected to collect 3 values, got %d", len(collected))
-	}
-}
-
-// testShutdownError is a simple error type for testing
-type testShutdownError struct {
-	msg string
-}
-
-func (e *testShutdownError) Error() string {
-	return e.msg
 }

--- a/pkg/server/listener_manager_test.go
+++ b/pkg/server/listener_manager_test.go
@@ -19,10 +19,43 @@ package server
 
 import (
 	"errors"
+	"os"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
 )
+
+// mockListenerService is a mock implementation of listener.ListenerService for testing.
+type mockListenerService struct {
+	startErr    error
+	closeErr    error
+	shutdownErr error
+	refreshErr  error
+	shutdownWg  *sync.WaitGroup // Will be set when ShutDown is called
+}
+
+func (m *mockListenerService) Start() error {
+	return m.startErr
+}
+
+func (m *mockListenerService) Close() error {
+	return m.closeErr
+}
+
+func (m *mockListenerService) ShutDown(wg any) error {
+	// Cast the WaitGroup and call Done() to simulate real behavior
+	if w, ok := wg.(*sync.WaitGroup); ok && w != nil {
+		w.Done()
+	}
+	return m.shutdownErr
+}
+
+func (m *mockListenerService) Refresh(_ model.Listener) error {
+	return m.refreshErr
+}
 
 // TestShutdownListenersNoErrors tests shutdownListeners when all listeners
 // shut down successfully without errors.
@@ -222,3 +255,126 @@ func TestShutdownListenersStuckListener(t *testing.T) {
 		t.Errorf("Expected no errors, got %d", len(errs))
 	}
 }
+
+// TestHandleShutdownSignalNoErrors tests handleShutdownSignal when all listeners
+// shut down successfully.
+func TestHandleShutdownSignalNoErrors(t *testing.T) {
+	lm := &ListenerManager{
+		activeListenerService: map[string]*wrapListenerService{
+			"listener1": {ListenerService: &mockListenerService{shutdownErr: nil}},
+			"listener2": {ListenerService: &mockListenerService{shutdownErr: nil}},
+		},
+		shutdownWG: &sync.WaitGroup{},
+	}
+
+	errs, timedOut := lm.handleShutdownSignal(os.Interrupt, 1*time.Second)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got %d", len(errs))
+	}
+	if timedOut {
+		t.Error("Expected no timeout")
+	}
+}
+
+// TestHandleShutdownSignalWithErrors tests handleShutdownSignal when some listeners
+// fail to shut down.
+func TestHandleShutdownSignalWithErrors(t *testing.T) {
+	testErr := errors.New("shutdown failed")
+	lm := &ListenerManager{
+		activeListenerService: map[string]*wrapListenerService{
+			"listener1": {ListenerService: &mockListenerService{shutdownErr: nil}},
+			"listener2": {ListenerService: &mockListenerService{shutdownErr: testErr}},
+		},
+		shutdownWG: &sync.WaitGroup{},
+	}
+
+	errs, timedOut := lm.handleShutdownSignal(os.Interrupt, 1*time.Second)
+
+	if len(errs) != 1 {
+		t.Errorf("Expected 1 error, got %d", len(errs))
+	}
+	if timedOut {
+		t.Error("Expected no timeout")
+	}
+	if errs[0].Error() != testErr.Error() {
+		t.Errorf("Expected error '%s', got '%s'", testErr.Error(), errs[0].Error())
+	}
+}
+
+// TestHandleShutdownSignalNoListeners tests handleShutdownSignal with no listeners.
+func TestHandleShutdownSignalNoListeners(t *testing.T) {
+	lm := &ListenerManager{
+		activeListenerService: map[string]*wrapListenerService{},
+		shutdownWG:            &sync.WaitGroup{},
+	}
+
+	errs, timedOut := lm.handleShutdownSignal(os.Interrupt, 1*time.Second)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got %d", len(errs))
+	}
+	if timedOut {
+		t.Error("Expected no timeout")
+	}
+}
+
+// TestHandleShutdownSignalTimeout tests handleShutdownSignal when shutdown times out.
+func TestHandleShutdownSignalTimeout(t *testing.T) {
+	// Create a slow listener that takes longer than the timeout
+	slowListener := &mockSlowListenerService{duration: 100 * time.Millisecond}
+	lm := &ListenerManager{
+		activeListenerService: map[string]*wrapListenerService{
+			"listener1": {ListenerService: slowListener},
+		},
+		shutdownWG: &sync.WaitGroup{},
+	}
+
+	// Very short timeout to trigger timeout condition (less than slowListener duration)
+	errs, timedOut := lm.handleShutdownSignal(os.Interrupt, 10*time.Millisecond)
+
+	// Should timeout because listener takes longer than the timeout
+	if !timedOut {
+		t.Error("Expected timeout")
+	}
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors (listener returns nil), got %d", len(errs))
+	}
+}
+
+// TestHandleShutdownSignalDumpHeap tests handleShutdownSignal with a dump heap signal.
+// Note: We skip actually writing heap dump in tests, but verify the code path is reached.
+func TestHandleShutdownSignalDumpHeap(t *testing.T) {
+	lm := &ListenerManager{
+		activeListenerService: map[string]*wrapListenerService{
+			"listener1": {ListenerService: &mockListenerService{}},
+		},
+		shutdownWG: &sync.WaitGroup{},
+	}
+
+	// SIGQUIT is typically in DumpHeapShutdownSignals
+	errs, timedOut := lm.handleShutdownSignal(os.Signal(syscall.SIGQUIT), 1*time.Second)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got %d", len(errs))
+	}
+	if timedOut {
+		t.Error("Expected no timeout")
+	}
+}
+
+// mockSlowListenerService is a mock that takes time to shutdown for testing timeout scenarios.
+type mockSlowListenerService struct {
+	duration time.Duration
+}
+
+func (m *mockSlowListenerService) Start() error { return nil }
+func (m *mockSlowListenerService) Close() error  { return nil }
+func (m *mockSlowListenerService) ShutDown(wg any) error {
+	time.Sleep(m.duration)
+	if w, ok := wg.(*sync.WaitGroup); ok && w != nil {
+		w.Done()
+	}
+	return nil
+}
+func (m *mockSlowListenerService) Refresh(_ model.Listener) error { return nil }


### PR DESCRIPTION
## Summary

Fixes #989 Issue 3 (listener/shutdown path): The original implementation called `os.Exit(0)` from worker goroutines during shutdown, which is too aggressive.

### Original Problems

- `os.Exit(0)` was called in per-listener worker goroutines on shutdown error
- `os.Exit(0)` was called in timeout handler (`time.AfterFunc`)
- Process always exited with success code (0), even when shutdown errors occurred
- One listener shutdown failure would immediately exit the process while other cleanup was still in progress

### Why this matters

These are operational stability issues:
- Configuration mistakes or transient dependency failures can terminate the whole process
- One listener shutdown failure can immediately exit the process while other cleanup is still in progress
- Metrics/tracing/log flush may not complete
- Makes the system harder to embed, test, and recover

### Changes

- Remove `os.Exit(0)` calls from per-listener worker goroutines
- Remove `os.Exit(0)` from timeout handler (`time.AfterFunc`)
- Collect shutdown errors in a buffered channel instead of immediate exit
- Wait for all shutdowns to complete or timeout before proceeding
- Exit with appropriate code: 0 for success, 1 if errors occurred
- Add unit tests for error collection, timeout handling, and WaitGroup behavior

### Note on WaitGroup

`listener.ShutDown()` methods internally call `wg.Done()`, so we do not add `defer wg.Done()` in the worker goroutine to avoid double `Done()` calls which would panic with negative WaitGroup counter.

## Test Plan

- Added `pkg/server/listener_manager_test.go` with tests covering:
  - WaitGroup double-Done panic behavior
  - Shutdown error collection pattern
  - Shutdown timeout handling pattern
  - Labeled break pattern for draining channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)