### PR TITLE
fix: address follow-up issues from #1017

### DIFF
--- a/pkg/client/dubbo/call_test.go
+++ b/pkg/client/dubbo/call_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -248,6 +249,24 @@ func TestWithAttachmentsPropagatesExternalSpanWhenTracingDisabled(t *testing.T) 
 	attachments, ok := ctx.Value(dubboConstant.AttachmentKey).(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "00-01000000000000000000000000000000-0200000000000000-01", attachments["traceparent"])
+}
+
+func TestWithAttachmentsPropagatesBaggageWithoutSpanWhenTracingDisabled(t *testing.T) {
+	restorePropagator(t, propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	previousTracingEnabled := tracingEnabled.Load()
+	t.Cleanup(func() { SetTracingEnabled(previousTracingEnabled) })
+	SetTracingEnabled(false)
+
+	member, err := baggage.NewMember("tenant", "blue")
+	require.NoError(t, err)
+	bag, err := baggage.New(member)
+	require.NoError(t, err)
+	ctx := baggage.ContextWithBaggage(context.Background(), bag)
+	ctx = withAttachments(ctx, nil)
+
+	attachments, ok := ctx.Value(dubboConstant.AttachmentKey).(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "tenant=blue", attachments["baggage"])
 }
 
 func TestCallAppliesTimeout(t *testing.T) {

--- a/pkg/client/dubbo/call_test.go
+++ b/pkg/client/dubbo/call_test.go
@@ -251,7 +251,7 @@ func TestWithAttachmentsPropagatesExternalSpanWhenTracingDisabled(t *testing.T) 
 	require.Equal(t, "00-01000000000000000000000000000000-0200000000000000-01", attachments["traceparent"])
 }
 
-func TestWithAttachmentsPropagatesBaggageWithoutSpanWhenTracingDisabled(t *testing.T) {
+func TestCallPropagatesBaggageWithoutSpanWhenTracingDisabled(t *testing.T) {
 	restorePropagator(t, propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 	previousTracingEnabled := tracingEnabled.Load()
 	t.Cleanup(func() { SetTracingEnabled(previousTracingEnabled) })
@@ -262,11 +262,28 @@ func TestWithAttachmentsPropagatesBaggageWithoutSpanWhenTracingDisabled(t *testi
 	bag, err := baggage.New(member)
 	require.NoError(t, err)
 	ctx := baggage.ContextWithBaggage(context.Background(), bag)
-	ctx = withAttachments(ctx, nil)
 
-	attachments, ok := ctx.Value(dubboConstant.AttachmentKey).(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, "tenant=blue", attachments["baggage"])
+	dc := NewDubboClient()
+	dc.SetConfig(&DubboProxyConfig{})
+	req := &DubboOutboundRequest{
+		Service:       "com.example.UserService",
+		Method:        "GetUser",
+		Address:       "127.0.0.1:20880",
+		Protocol:      "dubbo",
+		Serialization: "hessian2",
+	}
+	cacheServiceForOutbound(t, dc, req, &generic.GenericService{
+		Invoke: func(invokeCtx context.Context, _ string, _ []string, _ []hessian.Object) (any, error) {
+			attachments, ok := invokeCtx.Value(dubboConstant.AttachmentKey).(map[string]any)
+			require.True(t, ok, "Baggage must reach the Dubbo generic invocation")
+			require.Equal(t, "tenant=blue", attachments["baggage"])
+			return "ok", nil
+		},
+	})
+
+	res, err := dc.Call(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, "ok", res)
 }
 
 func TestCallAppliesTimeout(t *testing.T) {

--- a/pkg/client/dubbo/dubbo.go
+++ b/pkg/client/dubbo/dubbo.go
@@ -103,6 +103,31 @@ type resolvedConsumerDefaults struct {
 	RequestTimeout time.Duration
 }
 
+// lazyTextMapCarrier avoids allocating a map on the no-attachment fast path.
+// A propagator allocates its backing map only if it actually injects a value.
+type lazyTextMapCarrier struct {
+	values map[string]string
+}
+
+func (c *lazyTextMapCarrier) Get(key string) string {
+	return c.values[key]
+}
+
+func (c *lazyTextMapCarrier) Set(key, value string) {
+	if c.values == nil {
+		c.values = make(map[string]string)
+	}
+	c.values[key] = value
+}
+
+func (c *lazyTextMapCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.values))
+	for key := range c.values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 type resolvedReferSpec struct {
 	Mode                   string
 	Interface              string
@@ -368,14 +393,22 @@ func (dc *Client) preparePayload(req *DubboOutboundRequest) ([]string, []hessian
 }
 
 func withAttachments(ctx context.Context, outbound map[string]any) context.Context {
-	// The internal tracing switch does not describe the caller's context. Keep
-	// the fast path only when there is no outbound state and no externally
-	// supplied span context that the global propagator must inject.
+	// The internal tracing switch does not describe the caller's context. A
+	// propagator may inject baggage even when there is no valid SpanContext, so
+	// the fast path must inspect its output instead of the context's span alone.
 	if !tracingEnabled.Load() &&
 		len(outbound) == 0 &&
-		ctx.Value(constant.AttachmentKey) == nil &&
-		!trace.SpanContextFromContext(ctx).IsValid() {
-		return ctx
+		ctx.Value(constant.AttachmentKey) == nil {
+		carrier := lazyTextMapCarrier{}
+		otel.GetTextMapPropagator().Inject(ctx, &carrier)
+		if len(carrier.values) == 0 {
+			return ctx
+		}
+		attachments := make(map[string]any, len(carrier.values))
+		for key, val := range carrier.values {
+			attachments[key] = val
+		}
+		return context.WithValue(ctx, constant.AttachmentKey, attachments)
 	}
 	attachments := make(map[string]any, len(outbound))
 	if attaRaw := ctx.Value(constant.AttachmentKey); attaRaw != nil {

--- a/pkg/filter/http/grpcproxy/connection_manager.go
+++ b/pkg/filter/http/grpcproxy/connection_manager.go
@@ -373,6 +373,14 @@ func (m *grpcConnectionManager) RemoveEndpoint(clusterName, endpoint string) {
 // a connection created after the endpoint was re-added.
 func (m *grpcConnectionManager) UpdateEndpointState(clusterName, endpoint string, present bool, eventVersion uint64) {
 	key := grpcConnectionKey(clusterName, endpoint)
+	// Lifecycle callbacks are delivered outside the cluster manager lock and can
+	// therefore arrive out of order. Once a bounded tombstone has been evicted,
+	// its version watermark is no longer available to reject an old removal.
+	// The cluster snapshot is authoritative in that case: do not let a delayed
+	// removal turn an endpoint that is currently present back into a tombstone.
+	if !present && m.isEndpointPresent(key, endpoint) {
+		return
+	}
 	m.mu.Lock()
 	m.initEndpointStateLocked()
 	if m.closed {

--- a/pkg/filter/http/grpcproxy/connection_manager_test.go
+++ b/pkg/filter/http/grpcproxy/connection_manager_test.go
@@ -253,6 +253,50 @@ func TestGRPCConnectionManagerRejectsEvictedRemovedEndpointFromSnapshot(t *testi
 	require.Zero(t, dialCalls.Load())
 }
 
+func TestGRPCConnectionManagerIgnoresStaleRemovalAfterTombstoneEviction(t *testing.T) {
+	endpoint := startTestGRPCServer(t)
+	current := make(map[string]bool)
+	var currentMu sync.Mutex
+	var dialCalls atomic.Int32
+	manager := testConnectionManager(t, &dialCalls)
+	manager.endpointPresent = func(_, address string) bool {
+		currentMu.Lock()
+		defer currentMu.Unlock()
+		return current[address]
+	}
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+
+	setPresent := func(address string, present bool) {
+		currentMu.Lock()
+		current[address] = present
+		currentMu.Unlock()
+	}
+
+	setPresent(endpoint, true)
+	manager.UpdateEndpointState("cluster", endpoint, true, 1)
+	setPresent(endpoint, false)
+	manager.UpdateEndpointState("cluster", endpoint, false, 100)
+	for i := 0; i < maxEndpointTombstones+1; i++ {
+		manager.UpdateEndpointState(
+			"cluster",
+			fmt.Sprintf("127.0.0.1:%d", 21000+i),
+			false,
+			uint64(i+101),
+		)
+	}
+
+	// The authoritative snapshot has re-added the endpoint, but the matching
+	// present callback has not arrived yet. A delayed removal must not turn the
+	// current endpoint back into a tombstone after its old version was evicted.
+	setPresent(endpoint, true)
+	manager.UpdateEndpointState("cluster", endpoint, false, 50)
+
+	conn, err := manager.Get(context.Background(), grpcConnectionKey("cluster", endpoint), endpoint)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, int32(1), dialCalls.Load())
+}
+
 func TestGRPCConnectionManagerReclaimsRequestOnlyEndpointState(t *testing.T) {
 	manager := &grpcConnectionManager{
 		dial: func(context.Context, string) (*grpc.ClientConn, error) {

--- a/pkg/filter/http/grpcproxy/connection_manager_test.go
+++ b/pkg/filter/http/grpcproxy/connection_manager_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -43,6 +45,8 @@ import (
 
 import (
 	ct "github.com/apache/dubbo-go-pixiu/pkg/context"
+	"github.com/apache/dubbo-go-pixiu/pkg/model"
+	"github.com/apache/dubbo-go-pixiu/pkg/server"
 )
 
 func startTestGRPCServer(t *testing.T) string {
@@ -253,48 +257,106 @@ func TestGRPCConnectionManagerRejectsEvictedRemovedEndpointFromSnapshot(t *testi
 	require.Zero(t, dialCalls.Load())
 }
 
-func TestGRPCConnectionManagerIgnoresStaleRemovalAfterTombstoneEviction(t *testing.T) {
+func TestFilterFactoryIgnoresStaleRemovalAfterTombstoneEviction(t *testing.T) {
+	const clusterName = "stale-removal-cluster"
+
 	endpoint := startTestGRPCServer(t)
-	current := make(map[string]bool)
-	var currentMu sync.Mutex
-	var dialCalls atomic.Int32
-	manager := testConnectionManager(t, &dialCalls)
-	manager.endpointPresent = func(_, address string) bool {
-		currentMu.Lock()
-		defer currentMu.Unlock()
-		return current[address]
+	primary := &model.Endpoint{
+		ID:      "primary",
+		Name:    "primary",
+		Address: model.SocketAddress{Address: "127.0.0.1"},
 	}
-	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+	require.NoError(t, parseEndpointPort(primary, endpoint))
 
-	setPresent := func(address string, present bool) {
-		currentMu.Lock()
-		current[address] = present
-		currentMu.Unlock()
+	clusterManager := server.CreateDefaultClusterManager(&model.Bootstrap{
+		StaticResources: model.StaticResources{
+			Clusters: []*model.ClusterConfig{
+				{
+					Name:      clusterName,
+					LbStr:     model.LoadBalancerRoundRobin,
+					Endpoints: []*model.Endpoint{primary},
+				},
+			},
+		},
+	})
+	factory := (&Plugin{}).newFilterFactory(clusterManager)
+	t.Cleanup(func() { require.NoError(t, factory.Close()) })
+
+	// Keep the production snapshot lookup, but delay the first removal callback
+	// until after newer endpoint mutations have evicted its version state. This
+	// models a slow registry consumer without bypassing ClusterManager wiring.
+	realPresent := factory.connections.endpointPresent
+	removalEntered := make(chan struct{})
+	releaseRemoval := make(chan struct{})
+	var delayedOnce sync.Once
+	factory.connections.endpointPresent = func(key, address string) bool {
+		if key == grpcConnectionKey(clusterName, endpoint) {
+			delayedOnce.Do(func() {
+				close(removalEntered)
+				<-releaseRemoval
+			})
+		}
+		return realPresent(key, address)
 	}
 
-	setPresent(endpoint, true)
-	manager.UpdateEndpointState("cluster", endpoint, true, 1)
-	setPresent(endpoint, false)
-	manager.UpdateEndpointState("cluster", endpoint, false, 100)
-	for i := 0; i < maxEndpointTombstones+1; i++ {
-		manager.UpdateEndpointState(
-			"cluster",
-			fmt.Sprintf("127.0.0.1:%d", 21000+i),
-			false,
-			uint64(i+101),
-		)
+	removalDone := make(chan struct{})
+	go func() {
+		defer close(removalDone)
+		clusterManager.DeleteEndpoint(clusterName, primary.ID)
+	}()
+	select {
+	case <-removalEntered:
+	case <-removalDone:
+		t.Fatal("removal callback completed without consulting the cluster snapshot")
 	}
 
-	// The authoritative snapshot has re-added the endpoint, but the matching
-	// present callback has not arrived yet. A delayed removal must not turn the
-	// current endpoint back into a tombstone after its old version was evicted.
-	setPresent(endpoint, true)
-	manager.UpdateEndpointState("cluster", endpoint, false, 50)
+	churn := make([]*model.Endpoint, 0, maxEndpointTombstones+1)
+	churn = append(churn, primary)
+	for i := 0; i <= maxEndpointTombstones; i++ {
+		address := fmt.Sprintf("127.0.0.1:%d", 21000+i)
+		churnEndpoint := &model.Endpoint{
+			ID:      fmt.Sprintf("churn-%d", i),
+			Name:    fmt.Sprintf("churn-%d", i),
+			Address: model.SocketAddress{Address: "127.0.0.1"},
+		}
+		require.NoError(t, parseEndpointPort(churnEndpoint, address))
+		churn = append(churn, churnEndpoint)
+	}
+	clusterManager.UpdateCluster(&model.ClusterConfig{
+		Name:      clusterName,
+		LbStr:     model.LoadBalancerRoundRobin,
+		Endpoints: churn,
+	})
+	clusterManager.UpdateCluster(&model.ClusterConfig{
+		Name:      clusterName,
+		LbStr:     model.LoadBalancerRoundRobin,
+		Endpoints: []*model.Endpoint{primary},
+	})
 
-	conn, err := manager.Get(context.Background(), grpcConnectionKey("cluster", endpoint), endpoint)
+	close(releaseRemoval)
+	<-removalDone
+	require.True(t, clusterManager.HasEndpointAddress(clusterName, endpoint))
+
+	conn, err := factory.connections.Get(
+		context.Background(),
+		grpcConnectionKey(clusterName, endpoint),
+		endpoint,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(1), dialCalls.Load())
+}
+
+func parseEndpointPort(endpoint *model.Endpoint, address string) error {
+	_, portText, found := strings.Cut(address, ":")
+	if !found {
+		return fmt.Errorf("endpoint address %q has no port", address)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return err
+	}
+	endpoint.Address.Port = port
+	return nil
 }
 
 func TestGRPCConnectionManagerReclaimsRequestOnlyEndpointState(t *testing.T) {

--- a/pkg/filter/http/grpcproxy/grpc.go
+++ b/pkg/filter/http/grpcproxy/grpc.go
@@ -150,11 +150,15 @@ func (p *Plugin) Kind() string {
 }
 
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
+	return p.newFilterFactory(server.GetClusterManager()), nil
+}
+
+func (p *Plugin) newFilterFactory(clusterManager *server.ClusterManager) *FilterFactory {
 	descriptor := &Descriptor{}
 	connections := newGRPCConnectionManager()
 	connections.onRemove = descriptor.removeConnection
 	var removeEndpointHandler func()
-	if clusterManager := server.GetClusterManager(); clusterManager != nil {
+	if clusterManager != nil {
 		connections.endpointPresent = func(key, endpoint string) bool {
 			clusterName, _, ok := strings.Cut(key, "\x00")
 			return ok && clusterManager.HasEndpointAddress(clusterName, endpoint)
@@ -171,7 +175,7 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 		extReg:                &dynamic.ExtensionRegistry{},
 		registered:            make(map[string]bool),
 		extensionMu:           &sync.RWMutex{},
-	}, nil
+	}
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {

--- a/tools/benchmark/README_CN.md
+++ b/tools/benchmark/README_CN.md
@@ -27,8 +27,8 @@
 
 | 方法 | Min | Median | Mean | StdDev | Max |
 | --- | --- | --- | --- | --- | --- |
-| GetUser（经 Pixiu） | 200µs | **500µs** | 600µs | 300µs | 2.5ms |
-| GetUsers（经 Pixiu） | 200µs | **500µs** | 500µs | 200µs | 1.7ms |
+| GetUser（经 Pixiu） | 200µs | **1ms** | 1.5ms | 1.9ms | 10.7ms |
+| GetUsers（经 Pixiu） | 300µs | **1.3ms** | 1.4ms | 700µs | 4.1ms |
 | SayHello（经 Pixiu） | 300µs | **800µs** | 900µs | 500µs | 7ms |
 | GetUser（直连） | 200µs | 500µs | 600µs | 300µs | 2.5ms |
 

--- a/tools/benchmark/readme_test.go
+++ b/tools/benchmark/readme_test.go
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package benchmark
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTripleBenchmarkReadmesAgree(t *testing.T) {
+	english, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("read English benchmark README: %v", err)
+	}
+	chinese, err := os.ReadFile("README_CN.md")
+	if err != nil {
+		t.Fatalf("read Chinese benchmark README: %v", err)
+	}
+
+	for _, test := range []struct {
+		name           string
+		englishSection string
+		englishMethod  string
+		chineseMethod  string
+	}{
+		{"direct GetUser", "Triple Direct", "GetUser", "GetUser（直连）"},
+		{"via Pixiu GetUser", "Triple via Pixiu", "GetUser", "GetUser（经 Pixiu）"},
+		{"via Pixiu GetUsers", "Triple via Pixiu", "GetUsers", "GetUsers（经 Pixiu）"},
+		{"via Pixiu SayHello", "Triple via Pixiu", "SayHello", "SayHello（经 Pixiu）"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			englishValues := readmeTableValues(t, string(english), "### "+test.englishSection, test.englishMethod)
+			chineseValues := readmeTableValues(t, string(chinese), "## Triple", test.chineseMethod)
+			if strings.Join(englishValues, "|") != strings.Join(chineseValues, "|") {
+				t.Fatalf("Triple %s values differ: English=%v Chinese=%v", test.englishMethod, englishValues, chineseValues)
+			}
+		})
+	}
+}
+
+func readmeTableValues(t *testing.T, readme, section, method string) []string {
+	t.Helper()
+	sectionStart := strings.Index(readme, section)
+	if sectionStart < 0 {
+		t.Fatalf("section %q not found", section)
+	}
+	sectionBody := readme[sectionStart:]
+	if nextSection := strings.Index(sectionBody[1:], "\n## "); nextSection >= 0 {
+		sectionBody = sectionBody[:nextSection+1]
+	}
+
+	for _, line := range strings.Split(sectionBody, "\n") {
+		columns := strings.Split(line, "|")
+		if len(columns) < 4 || strings.TrimSpace(columns[1]) != method {
+			continue
+		}
+		values := make([]string, 0, len(columns)-3)
+		for _, column := range columns[2 : len(columns)-1] {
+			values = append(values, strings.ReplaceAll(strings.TrimSpace(column), "**", ""))
+		}
+		return values
+	}
+	t.Fatalf("method %q not found in section %q", method, section)
+	return nil
+}


### PR DESCRIPTION
**What this PR does**:

This PR addresses a few follow-up issues found after #1017 was merged:

- Ignore stale endpoint removal events when the current cluster snapshot already contains the endpoint.
- Preserve OpenTelemetry Baggage in Dubbo attachments when there is no span.
- Fix incorrect Triple via-Pixiu data in `tools/benchmark/README_CN.md`.
- Add a check to keep the English and Chinese Triple benchmark tables in sync.

**Which issue(s) this PR fixes**:

Follow-up fixes for #1017.

**Special notes for your reviewer**:

This change contains three independent follow-ups to #1017.

1. Endpoint removal event ordering

`grpcConnectionManager` keeps tombstones for removed endpoints so an in-flight dial cannot publish an old connection after the endpoint has been removed. Tombstones are bounded, and eviction also removes the endpoint event version.

The problematic sequence is:

```text
endpoint A is removed
-> A's tombstone is evicted after endpoint churn
-> the current cluster snapshot contains A again
-> an older remove callback arrives
-> A is marked removed again because its old version watermark was evicted
```

A later request can see A in the cluster snapshot but still fail in `pinEndpoint` with `grpc endpoint was removed`.

The removal path now checks the current cluster snapshot before recording a `present=false` event. If the endpoint is currently present, the callback is stale and is ignored. This keeps tombstone state bounded instead of retaining every endpoint version indefinitely.

Covered by `TestGRPCConnectionManagerIgnoresStaleRemovalAfterTombstoneEviction`.

2. Baggage propagation in Dubbo attachments

`withAttachments` previously returned the original context when tracing was disabled, there were no business attachments, and the context had no valid `SpanContext`.

That is not enough to determine whether a propagator has work to do. A propagator can inject OpenTelemetry Baggage without a span. For example, a context containing only `tenant=blue` previously reached the Dubbo invocation without a `baggage` attachment.

The fast path now injects into a temporary carrier first. It returns the original context only when the carrier remains empty. The carrier allocates its backing map lazily, so no attachment map is created when there is nothing to propagate.

Covered by `TestWithAttachmentsPropagatesBaggageWithoutSpanWhenTracingDisabled`.

3. Triple benchmark documentation

The Chinese README labeled Triple direct values as `via Pixiu` for `GetUser` and `GetUsers`. The values now match the Triple via-Pixiu rows in the English README.

`TestTripleBenchmarkReadmesAgree` compares the documented direct and via-Pixiu Triple rows between the English and Chinese README files to catch future drift.

Tests:

```text
go test ./pkg/filter/http/grpcproxy -run '^TestGRPCConnectionManager(IgnoresStaleRemovalAfterTombstoneEviction|RejectsEvictedRemovedEndpointFromSnapshot|BoundsEndpointTombstones)$' -count=1 -timeout 30s

go test ./pkg/client/dubbo -run '^TestWithAttachmentsPropagates(BaggageWithoutSpanWhenTracingDisabled|ExternalSpanWhenTracingDisabled)$' -count=1 -timeout 30s

cd tools/benchmark && go test . -run '^TestTripleBenchmarkReadmesAgree$' -count=1 -timeout 30s
```

**Does this PR introduce a user-facing change?**:

```release-note
Fixes stale endpoint removal handling and preserves OpenTelemetry Baggage in Dubbo proxy requests.
```