### PR TITLE
fix(grpcproxy): load local proto files under the default AUTO strategy

### DIFF
--- a/pkg/filter/http/grpcproxy/descriptor.go
+++ b/pkg/filter/http/grpcproxy/descriptor.go
@@ -111,14 +111,22 @@ func (dr *Descriptor) getDescriptorCompose(ctx context.Context, cfg *Config) (De
 
 	cs := &compositeSource{}
 	cs.reflection, err = dr.getServerDescriptorSourceCtx(ctx, cfg)
-	cs.file = dr.getFileSource()
+	// Never store a nil *fileSource: it would leave cs.file a non-nil interface
+	// holding a nil pointer, so the fallback in compositeSource would dereference
+	// it instead of reporting that the local proto files are unavailable.
+	if fs := dr.getFileSource(); fs != nil {
+		cs.file = fs
+	}
 
 	return cs, err
 }
 
 func (dr *Descriptor) initDescriptorSource(cfg *Config) *Descriptor {
 
-	if cfg.DescriptorSourceStrategy.String() == LOCAL {
+	switch strings.ToLower(cfg.DescriptorSourceStrategy.String()) {
+	case LOCAL, AUTO:
+		// AUTO is `file + reflection`, so the local proto files have to be loaded
+		// as well, otherwise the fallback of the reflection lookup has no source.
 		dr.initFileDescriptorSource(cfg)
 	}
 
@@ -248,7 +256,11 @@ func (dr *Descriptor) getMethodDescriptor(source DescriptorSource, cc *grpc.Clie
 
 func (dr *Descriptor) getFileDescriptorCompose(ctx context.Context, cfg *Config) (DescriptorSource, error) {
 	dr.initFileDescriptorSource(cfg)
-	return dr.getFileSource(), nil
+	fs := dr.getFileSource()
+	if fs == nil {
+		return nil, errors.New("the local proto file descriptor source is not available")
+	}
+	return fs, nil
 }
 
 func (dr *Descriptor) initFileDescriptorSource(cfg *Config) *Descriptor {

--- a/pkg/filter/http/grpcproxy/descriptor_source.go
+++ b/pkg/filter/http/grpcproxy/descriptor_source.go
@@ -160,36 +160,45 @@ func (cs *compositeSource) FindSymbol(fullyQualifiedName string) (desc.Descripto
 		}
 	}
 
+	if cs.file == nil {
+		return nil, fmt.Errorf("could not found symbol %v", fullyQualifiedName)
+	}
 	return cs.file.FindSymbol(fullyQualifiedName)
 }
 
 func (cs *compositeSource) AllExtensionsForType(typeName string) ([]*desc.FieldDescriptor, error) {
 
 	if cs.reflection == nil {
-		fileExts, err := cs.file.AllExtensionsForType(typeName)
-		if err != nil {
-			return fileExts, nil
+		if cs.file == nil {
+			return nil, nil
 		}
-	} else {
-		exts, err := cs.reflection.AllExtensionsForType(typeName)
-		if err != nil {
-			return cs.file.AllExtensionsForType(typeName)
-		}
-		tags := make(map[int32]bool)
-		for _, ext := range exts {
-			tags[ext.GetNumber()] = true
-		}
+		return cs.file.AllExtensionsForType(typeName)
+	}
 
-		fileExts, err := cs.file.AllExtensionsForType(typeName)
-		if err != nil {
-			return exts, nil
+	exts, err := cs.reflection.AllExtensionsForType(typeName)
+	if err != nil {
+		if cs.file == nil {
+			return nil, err
 		}
-		for _, ext := range fileExts {
-			if !tags[ext.GetNumber()] {
-				exts = append(exts, ext)
-			}
-		}
+		return cs.file.AllExtensionsForType(typeName)
+	}
+	if cs.file == nil {
 		return exts, nil
 	}
-	return nil, nil
+
+	tags := make(map[int32]bool)
+	for _, ext := range exts {
+		tags[ext.GetNumber()] = true
+	}
+
+	fileExts, err := cs.file.AllExtensionsForType(typeName)
+	if err != nil {
+		return exts, nil
+	}
+	for _, ext := range fileExts {
+		if !tags[ext.GetNumber()] {
+			exts = append(exts, ext)
+		}
+	}
+	return exts, nil
 }

--- a/pkg/filter/http/grpcproxy/descriptor_test.go
+++ b/pkg/filter/http/grpcproxy/descriptor_test.go
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grpcproxy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/jhump/protoreflect/desc"            //nolint:staticcheck // legacy descriptor API used by grpcproxy.
+	"github.com/jhump/protoreflect/desc/protoparse" //nolint:staticcheck // legacy parser used by grpcproxy.
+
+	"github.com/stretchr/testify/require"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+import (
+	ct "github.com/apache/dubbo-go-pixiu/pkg/context"
+)
+
+const testGreeterProto = `syntax = "proto3";
+package test;
+
+service Greeter {
+  rpc Hello(Request) returns (Response);
+}
+
+message Request {}
+message Response {}
+`
+
+// writeTestProtoDir writes a proto file to a temporary directory usable as Config.Path.
+func writeTestProtoDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.proto"), []byte(testGreeterProto), 0o600))
+	return dir
+}
+
+// TestDescriptorAutoStrategyFallsBackToLocalProtoFiles covers the AUTO strategy, which is
+// the default one, against a backend that does not implement the server reflection API.
+// The documented `file + reflection` fallback has to resolve the method from the local
+// proto files instead of dereferencing an uninitialized file source.
+func TestDescriptorAutoStrategyFallsBackToLocalProtoFiles(t *testing.T) {
+	cfg := &Config{DescriptorSourceStrategy: AUTO, Path: writeTestProtoDir(t)}
+	descriptor := (&Descriptor{}).initDescriptorSource(cfg)
+	require.NotNil(t, descriptor.getFileSource())
+
+	conn, err := grpc.NewClient(startTestGRPCServer(t), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	source, err := descriptor.getDescriptorSource(context.WithValue(ctx, ct.ContextKey(GrpcClientConnKey), conn), cfg)
+	require.NoError(t, err)
+
+	method, err := descriptor.getMethodDescriptor(source, conn, "test.Greeter", "Hello")
+	require.NoError(t, err)
+	require.Equal(t, "Hello", method.GetName())
+}
+
+// TestDescriptorLocalStrategyReportsUnloadableProtoFiles keeps a misconfigured `path` from
+// producing a descriptor source that only fails once it is dereferenced.
+func TestDescriptorLocalStrategyReportsUnloadableProtoFiles(t *testing.T) {
+	cfg := &Config{DescriptorSourceStrategy: LOCAL, Path: filepath.Join(t.TempDir(), "missing")}
+	descriptor := (&Descriptor{}).initDescriptorSource(cfg)
+
+	source, err := descriptor.getDescriptorSource(context.Background(), cfg)
+	require.Error(t, err)
+	require.Nil(t, source)
+}
+
+// TestCompositeSourceFindSymbolWithoutFileSource keeps the fallback safe when the local
+// proto files are unavailable altogether.
+func TestCompositeSourceFindSymbolWithoutFileSource(t *testing.T) {
+	cs := &compositeSource{}
+	_, err := cs.FindSymbol("test.Greeter")
+	require.Error(t, err)
+}
+
+// TestCompositeSourceAllExtensionsForTypeWithoutReflection asserts the extensions found in
+// the local proto files are returned instead of being computed and then discarded.
+func TestCompositeSourceAllExtensionsForTypeWithoutReflection(t *testing.T) {
+	files, err := (protoparse.Parser{
+		Accessor: protoparse.FileContentsFromMap(map[string]string{
+			"extension.proto": `syntax = "proto2";
+package test;
+
+message Request {
+  extensions 100 to 200;
+}
+
+extend Request {
+  optional string note = 100;
+}
+`,
+		}),
+	}).ParseFiles("extension.proto")
+	require.NoError(t, err)
+
+	cs := &compositeSource{file: &fileSource{files: map[string]*desc.FileDescriptor{"extension.proto": files[0]}}}
+	exts, err := cs.AllExtensionsForType("test.Request")
+	require.NoError(t, err)
+	require.Len(t, exts, 1)
+	require.Equal(t, "test.note", exts[0].GetFullyQualifiedName())
+}


### PR DESCRIPTION
**What this PR does**:

`descriptor_source_strategy` defaults to `AUTO` (`grpc.go` — `default:"auto"`), which `getDescriptorSource` documents as `// file + reflection`. But `initDescriptorSource` only loaded the local proto files for `LOCAL`:

```go
func (dr *Descriptor) initDescriptorSource(cfg *Config) *Descriptor {
	if cfg.DescriptorSourceStrategy.String() == LOCAL {
		dr.initFileDescriptorSource(cfg)
	}
	return dr
}
```

and it is the only wiring call (`grpc.go`, in `FilterFactory.Apply`). So under the default strategy `dr.fileSource` stays `nil`, and `getDescriptorCompose` assigns it straight into an interface field:

```go
cs.file = dr.getFileSource()   // nil *fileSource -> non-nil DescriptorSource
```

`cs.file == nil` is therefore **false**, and the fallback in `compositeSource.FindSymbol` dereferences the nil receiver:

```go
return cs.file.FindSymbol(fullyQualifiedName)   // descriptor_source.go:163
```

Two consequences on the out-of-the-box configuration:

1. Any request whose server-reflection lookup fails — a backend that does not implement the reflection API, or an unknown service name — hits a nil-pointer dereference inside the filter chain. `pkg/common/http/manager.go` recovers it, so this is not a process crash, but the caller gets a 500 with a stack trace in the log instead of the intended 405/400.
2. The `file` half of `AUTO` never runs at all, so local `.proto` files are silently ignored under the default strategy.

`getFileDescriptorCompose` returns the same typed-nil, so `LOCAL` with a `path` that cannot be read fails the same way.

The change, confined to `descriptor.go` and `descriptor_source.go`:

- `initDescriptorSource` loads the local proto files for `AUTO` as well as `LOCAL`, once at `Apply()` time. It now uses `strings.ToLower(...)` to match the comparison `getDescriptorSource` already does.
- `getDescriptorCompose` only assigns `cs.file` when the file source is non-nil, so a typed-nil is never boxed into the interface.
- `getFileDescriptorCompose` returns an error instead of a nil source when the local proto files could not be loaded.
- `compositeSource.FindSymbol` and `AllExtensionsForType` guard `cs.file`, so a missing file source surfaces an error rather than a panic.
- `AllExtensionsForType` is restructured flat. Its `cs.reflection == nil` branch used to compute `cs.file.AllExtensionsForType(...)` and then fall through to `return nil, nil`, discarding the successful result; it now returns it. (Collapsing that branch in place would leave the trailing `return nil, nil` unreachable and fail `go vet`, hence the flat rewrite.)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

`pkg/filter/http/grpcproxy` had no test file for `descriptor.go`, so this adds `descriptor_test.go` with four cases that drive the real production path (`initDescriptorSource` → `getDescriptorSource` → `getMethodDescriptor`) against a gRPC server with no reflection service registered.

All four fail on `develop` (`fd9a27e`) and pass with this change. Before, on unmodified sources:

```
--- FAIL: TestDescriptorAutoStrategyFallsBackToLocalProtoFiles
        Error: Expected value not to be nil.          # AUTO never loaded the protos
--- FAIL: TestDescriptorLocalStrategyReportsUnloadableProtoFiles
        Error: An error is expected but got nil.
--- FAIL: TestCompositeSourceFindSymbolWithoutFileSource
panic: runtime error: invalid memory address or nil pointer dereference
--- FAIL: TestCompositeSourceAllExtensionsForTypeWithoutReflection
        Error: "[]" should have 1 item(s), but has 0
```

With the `require.NotNil` guard temporarily removed so the first test reaches the fallback, unmodified sources panic exactly on the live request path:

```
panic: runtime error: invalid memory address or nil pointer dereference
grpcproxy.(*fileSource).FindSymbol
	pkg/filter/http/grpcproxy/descriptor_source.go:123
grpcproxy.(*compositeSource).FindSymbol
	pkg/filter/http/grpcproxy/descriptor_source.go:163
grpcproxy.(*Descriptor).getMethodDescriptor
	pkg/filter/http/grpcproxy/descriptor.go:216
```

After the change (Go 1.25.7):

```
$ go build ./pkg/filter/http/grpcproxy/     # rc=0
$ go vet ./pkg/filter/http/grpcproxy/       # rc=0, silent
$ golangci-lint run ./pkg/filter/http/grpcproxy/...
0 issues.
$ gofmt -s -l <the three changed files>     # no output
$ imports-formatter                          # leaves the three files unchanged
$ go test ./pkg/filter/http/grpcproxy/ -v
--- PASS: TestGRPCConnectionManagerSharesConcurrentConnection (0.01s)
... 14 pre-existing tests, all PASS ...
--- PASS: TestDescriptorAutoStrategyFallsBackToLocalProtoFiles (0.02s)
--- PASS: TestDescriptorLocalStrategyReportsUnloadableProtoFiles (0.00s)
--- PASS: TestCompositeSourceFindSymbolWithoutFileSource (0.00s)
--- PASS: TestCompositeSourceAllExtensionsForTypeWithoutReflection (0.00s)
PASS
ok  	github.com/apache/dubbo-go-pixiu/pkg/filter/http/grpcproxy	0.730s
```

Notes:

- Loading the file source for `AUTO` runs once in `Apply()`, not per request, so a misconfigured `path` logs one error at startup rather than on every request. With `path` unset the loader reads the executable's directory, finds no `.proto` files and yields a valid empty source (INFO only, no error), so reflection-only `AUTO` deployments are unaffected.
- `AllExtensionsForType`'s discarded-result bug is currently latent: `cs.reflection` is nil only when `getDescriptorCompose` also returns a non-nil error, which `Decode` turns into `filter.Stop`. It is fixed here because it is the same function, not because it is separately reachable.
- Scope is kept to `descriptor.go` and `descriptor_source.go` to avoid conflicting with #1023, which is editing `grpc.go` and `connection_manager.go` in this package.
- I verified the touched package only. A full `go build ./...` was not possible on my machine: I am on Windows, where `admin/core` cannot build because `utils.GetWriteSyncer` lives in the Unix-only `admin/utils/rotatelogs_unix.go`, and the build then ran the disk out of space. Neither is related to this change, and `pkg/filter/http/grpcproxy` builds, vets and tests clean.

**Does this PR introduce a user-facing change?**:

```release-note
Fix a nil-pointer dereference in the gRPC proxy filter under the default `AUTO` descriptor source strategy, which returned a 500 whenever a server-reflection lookup failed, and make `AUTO` actually load the local .proto files it documents as its fallback.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
