### PR TITLE
ci: add Docker build validation and update action runtimes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Docker Build
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build Docker image
+        run: docker build -t dubbo-go-pixiu:ci .

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -78,7 +78,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8 # NOSONAR
+        uses: golangci/golangci-lint-action@v9 # NOSONAR
         with:
           version: v2.4.0
           args: ${{ steps.lint_base.outputs.sha != '' && format('--new-from-rev={0}', steps.lint_base.outputs.sha) || '' }}
@@ -100,10 +100,10 @@ jobs:
           go test ./... -gcflags=-l -race -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4 # NOSONAR
+        uses: codecov/codecov-action@v7 # NOSONAR
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.txt
+          files: ./coverage.txt
           flags: unittests
 
   integration-test:
@@ -139,7 +139,7 @@ jobs:
 
       - name: Cache dubbo-go-pixiu-samples
         id: cache_samples
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.SAMPLES_CLONE_DIR }}
           key: ${{ runner.os }}-samples-${{ steps.samples_head.outputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "1.25.0"
+          goversion: "1.25.4"
           project_path: "./cmd/pixiu"
           binary_name: "dubbo-go-pixiu"
           extra_files: LICENSE README.md


### PR DESCRIPTION
## Summary

- add a standalone Docker Build workflow for every push and pull request
- upgrade Cache, golangci-lint, and Codecov actions to the specified Node 24-compatible majors
- align Release Go version with the Docker builder at 1.25.4

## Validation

- `docker build -t dubbo-go-pixiu:ci .`
- workflow YAML parsing and targeted static assertions

The implementation follows the supplied CI Docker Build and Action Runtime Maintenance specification.